### PR TITLE
Entities list for all fields true

### DIFF
--- a/presidio-analyzer/analyzer/analyzer_engine.py
+++ b/presidio-analyzer/analyzer/analyzer_engine.py
@@ -94,9 +94,10 @@ class AnalyzerEngine(analyze_pb2_grpc.AnalyzeServiceServicer):
                 raise ValueError("Cannot have both all_fields=True "
                                  "and a populated list of entities. "
                                  "Either have all_fields set to True "
-                                 "and entities are empty, or all_fields is False"
-                                 "and entities is populated")
-            # Since all_fields=True, list all entities by going over all recognizers
+                                 "and entities are empty, or all_fields "
+                                 "is False and entities is populated")
+            # Since all_fields=True, list all entities by going
+            # over all recognizers
             entities = self.__list_entities(recognizers)
 
         results = []
@@ -116,7 +117,8 @@ class AnalyzerEngine(analyze_pb2_grpc.AnalyzeServiceServicer):
     def __list_entities(recognizers):
         entities = []
         for recognizer in recognizers:
-            entities.extend([entity for entity in recognizer.supported_entities])
+            ents = [entity for entity in recognizer.supported_entities]
+            entities.extend(ents)
 
         return list(set(entities))
 

--- a/presidio-analyzer/analyzer/analyzer_engine.py
+++ b/presidio-analyzer/analyzer/analyzer_engine.py
@@ -5,7 +5,6 @@ import analyze_pb2
 import analyze_pb2_grpc
 import common_pb2
 
-
 from analyzer import RecognizerRegistry  # noqa: F401
 
 loglevel = os.environ.get("LOG_LEVEL", "INFO")
@@ -40,7 +39,7 @@ class AnalyzerEngine(analyze_pb2_grpc.AnalyzeServiceServicer):
                     # If result is equal to or substring of
                     # one of the other results
                     if result.start >= filtered.start \
-                            and result.end <= filtered.end:
+                        and result.end <= filtered.end:
                         valid_result = False
                         break
 
@@ -85,11 +84,22 @@ class AnalyzerEngine(analyze_pb2_grpc.AnalyzeServiceServicer):
         of the requested language
         :return: an array of the found entities in the text
         """
+
         recognizers = self.registry.get_recognizers(language=language,
                                                     entities=entities,
                                                     all_fields=all_fields)
-        results = []
 
+        if all_fields:
+            if entities:
+                raise ValueError("Cannot have both all_fields=True "
+                                 "and a populated list of entities. "
+                                 "Either have all_fields set to True "
+                                 "and entities are empty, or all_fields is False"
+                                 "and entities is populated")
+            # Since all_fields=True, list all entities by going over all recognizers
+            entities = self.__list_entities(recognizers)
+
+        results = []
         for recognizer in recognizers:
             # Lazy loading of the relevant recognizers
             if not recognizer.is_loaded:
@@ -101,6 +111,14 @@ class AnalyzerEngine(analyze_pb2_grpc.AnalyzeServiceServicer):
                 results.extend(r)
 
         return AnalyzerEngine.__remove_duplicates(results)
+
+    @staticmethod
+    def __list_entities(recognizers):
+        entities = []
+        for recognizer in recognizers:
+            entities.extend([entity for entity in recognizer.supported_entities])
+
+        return list(set(entities))
 
     @staticmethod
     def __convert_fields_to_entities(fields):

--- a/presidio-analyzer/analyzer/analyzer_engine.py
+++ b/presidio-analyzer/analyzer/analyzer_engine.py
@@ -39,7 +39,7 @@ class AnalyzerEngine(analyze_pb2_grpc.AnalyzeServiceServicer):
                     # If result is equal to or substring of
                     # one of the other results
                     if result.start >= filtered.start \
-                        and result.end <= filtered.end:
+                            and result.end <= filtered.end:
                         valid_result = False
                         break
 

--- a/presidio-analyzer/tests/test_analyzer_engine.py
+++ b/presidio-analyzer/tests/test_analyzer_engine.py
@@ -253,3 +253,15 @@ class TestAnalyzerEngine(TestCase):
         assert "PERSON" in returned_entities
         assert "LOCATION" in returned_entities
         assert "DOMAIN_NAME" in returned_entities
+
+    def test_when_allFields_is_true_and_entities_not_empty_exception(self):
+        analyze_engine = AnalyzerEngine(RecognizerRegistry())
+        request = AnalyzeRequest()
+        request.text = "My name is David and I live in Seattle." \
+                       "Domain: microsoft.com "
+        request.analyzeTemplate.allFields = True
+        new_field = request.analyzeTemplate.fields.add()
+        new_field.name = 'CREDIT_CARD'
+        new_field.minScore = '0.5'
+        with pytest.raises(ValueError):
+            analyze_engine.Apply(request, None)

--- a/presidio-analyzer/tests/test_analyzer_engine.py
+++ b/presidio-analyzer/tests/test_analyzer_engine.py
@@ -235,4 +235,14 @@ class TestAnalyzerEngine(TestCase):
             "Domain: microsoft.com"
         response = analyze_engine.Apply(request, None)
         assert response.analyzeResults is not None
-        assert len(response.analyzeResults) is 3
+        assert len(response.analyzeResults) == 3
+
+    def test_when_allFields_is_true_full_recognizers_list_return_all_fields(self):
+        analyze_engine = AnalyzerEngine(RecognizerRegistry())
+        request = AnalyzeRequest()
+        request.analyzeTemplate.allFields = True
+        request.text = "My name is David, Credit card: 4095-2609-9393-4932" \
+            "Domain: microsoft.com and I live in Seattle"
+        response = analyze_engine.Apply(request, None)
+        assert response.analyzeResults is not None
+        assert len(response.analyzeResults) == 4

--- a/presidio-analyzer/tests/test_analyzer_engine.py
+++ b/presidio-analyzer/tests/test_analyzer_engine.py
@@ -234,15 +234,22 @@ class TestAnalyzerEngine(TestCase):
         request.text = " Credit card: 4095-2609-9393-4932,  my phone is 425 8829090 " \
             "Domain: microsoft.com"
         response = analyze_engine.Apply(request, None)
+        returned_entities = [field.field.name for field in response.analyzeResults]
+
         assert response.analyzeResults is not None
-        assert len(response.analyzeResults) == 3
+        assert "CREDIT_CARD" in returned_entities
+        assert "PHONE_NUMBER" in returned_entities
+        assert "DOMAIN_NAME" in returned_entities
 
     def test_when_allFields_is_true_full_recognizers_list_return_all_fields(self):
         analyze_engine = AnalyzerEngine(RecognizerRegistry())
         request = AnalyzeRequest()
         request.analyzeTemplate.allFields = True
-        request.text = "My name is David, Credit card: 4095-2609-9393-4932" \
-            "Domain: microsoft.com and I live in Seattle"
+        request.text = "My name is David and I live in Seattle." \
+            "Domain: microsoft.com "
         response = analyze_engine.Apply(request, None)
+        returned_entities = [field.field.name for field in response.analyzeResults]
         assert response.analyzeResults is not None
-        assert len(response.analyzeResults) == 4
+        assert "PERSON" in returned_entities
+        assert "LOCATION" in returned_entities
+        assert "DOMAIN_NAME" in returned_entities


### PR DESCRIPTION
Bug fix for all_fields=True.
Currently: Calling presidio's API with all_fields=True and a Spacy entity (person, location) does not return an answer. SpacyRecognizer expects entities in order to filter the ones needs to be evaluated. 
New logic gathers entities from all recognizers, in case of all_fields=True and sends it to recognizers, in order not to change recognizer internal logic.