### PR TITLE
Document build failure due to lack of memory

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -15,6 +15,10 @@ For convenience the script `build.sh` at the root of this repo will run the `mak
 **NOTE: Error message** You may see error messages like this:
 `Error response from daemon: pull access denied for presidio/presidio-golang-deps, repository does not exist or may require 'docker login': denied: requested access to the resource is denied` when running the `make` commands. These can be ignored.
 
+**NOTE: Memory requirements** if you get an error message like this
+ `tests/test_analyzer_engine.py ...............The command '/bin/sh -c pipenv run pytest' returned a non-zero code: 137`
+ while building you may need to increase the docker memory limit for your machine
+ 
 If you prefer to run each step by hand instead of using the `build.sh` script these are as follows:
 
 ```sh


### PR DESCRIPTION
Building the base images will fail with a non-specific error message if docker is configured with a low memory limit, e.g. 4GB.  This adds a note so that it is more obvious to end users what to do when getting that message. 