### PR TITLE
Add catch for ValueError exception.

### DIFF
--- a/presidio-analyzer/analyzer/predefined_recognizers/uk_nhs_recognizer.py
+++ b/presidio-analyzer/analyzer/predefined_recognizers/uk_nhs_recognizer.py
@@ -23,7 +23,10 @@ class NhsRecognizer(PatternRecognizer):
         multiplier = 10
         total = 0
         for c in text:
-            val = int(c)
+            try:
+                val = int(c)
+            except ValueError:
+                return False
             total = total + val * multiplier
             multiplier = multiplier - 1
 


### PR DESCRIPTION
Got an exception when processing data while using re2. 

```
 File "\site-packages\analyzer\predefined_recognizers\uk_nhs_recognizer.py", line 26, in validate_result
    val = int(c)
ValueError: invalid literal for int() with base 10: 'U'
```

This catches that error as obviously this is not expected, and hence not valid. 