### PR TITLE
Fix typo to recognize a key context word

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/us_bank_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/us_bank_recognizer.py
@@ -6,7 +6,7 @@ from presidio_analyzer import PatternRecognizer
 REGEX = r'\b[0-9]{8,17}\b'
 
 CONTEXT = [
-    "bank"
+    "bank",
     # Task #603: Support keyphrases: change to "checking account"
     # as part of keyphrase change
     "check",


### PR DESCRIPTION
otherwise bank and check get concatenated

#309 