### PR TITLE
Stale to 120 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,4 +17,4 @@ jobs:
         stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
-        days-before-stale: 30
+        days-before-stale: 120


### PR DESCRIPTION
Changed the github actions for closing stales issues to 120 days (instead of 30)