### PR TITLE
Use GoTool to install Go + pipenv sync

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,15 +15,16 @@ steps:
       containerregistrytype: "Container Registry"
       dockerRegistryEndpoint: presidio
       command: login
-  - bash: |
-      mkdir -p '$(GOBIN)'
-      mkdir -p '$(GOPATH)/pkg'
-      mkdir -p '$(modulePath)'
-      shopt -s extglob
-      mv !(gopath) '$(modulePath)'
-      echo '##vso[task.prependpath]$(GOBIN)'
-      echo '##vso[task.prependpath]$(GOROOT)/bin'
-    displayName: "Setup Go Env"
+  - task: GoTool@0
+    inputs:
+      version: '1.13.5'
+    displayName: "Setup Go Env - Go Tool"
+  - task: Go@0
+    inputs:
+      command: 'get'
+      arguments: '-d'
+      workingDirectory: '$(System.DefaultWorkingDirectory)'
+    displayName: "Setup Go Env - Get go"
   - bash: |
       curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       dep ensure

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,12 +19,15 @@ steps:
     inputs:
       version: '1.13.5'
     displayName: "Setup Go Env - Go Tool"
-  - task: Go@0
-    inputs:
-      command: 'get'
-      arguments: '-d'
-      workingDirectory: '$(System.DefaultWorkingDirectory)'
-    displayName: "Setup Go Env - Get go"
+  - bash: |
+      mkdir -p '$(GOBIN)'
+      mkdir -p '$(GOPATH)/pkg'
+      mkdir -p '$(modulePath)'
+      shopt -s extglob
+      mv !(gopath) '$(modulePath)'
+      echo '##vso[task.prependpath]$(GOBIN)'
+      echo '##vso[task.prependpath]$(GOROOT)/bin'
+    displayName: "Prepare directories"
   - bash: |
       curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       dep ensure

--- a/pipelines/templates/build-test-publish.yaml
+++ b/pipelines/templates/build-test-publish.yaml
@@ -129,6 +129,7 @@ stages:
       - job: BuildTest
         displayName: Build and Test
         steps:
+          # - template: ./free-agent-disk.yaml
           - task: UsePythonVersion@0
             displayName: 'Use Python $(PYTHON.VERSION)'
             inputs:
@@ -160,7 +161,7 @@ stages:
                 df -h
                 # install dev Pipfile libraries
                 cd presidio-analyzer
-                pipenv install --dev --sequential
+                # pipenv sync --dev --sequential
 
                 # install dependency libraries
                 # re2
@@ -172,6 +173,7 @@ stages:
 
                 # Azure pipelines test publish
                 # regex
+                pipenv sync --dev --sequential
                 pipenv install --dev --skip-lock regex pytest-azurepipelines
           - task: Bash@3  
             displayName: 'Install golang pre requisites'
@@ -229,6 +231,7 @@ stages:
         displayName: Build Containers and Integration Test
         dependsOn: []
         steps:
+          # - template: ./free-agent-disk.yaml
           - task: UsePythonVersion@0
             displayName: 'Use Python $(PYTHON.VERSION)'
             inputs:
@@ -299,6 +302,7 @@ stages:
       - job: SetBuildDep
         displayName: Set base container build
         steps:
+          # - template: ./free-agent-disk.yaml
           - task: Bash@3
             displayName: 'Git diff verify deps build'
             inputs:

--- a/pipelines/templates/build-test-publish.yaml
+++ b/pipelines/templates/build-test-publish.yaml
@@ -161,19 +161,17 @@ stages:
                 df -h
                 # install dev Pipfile libraries
                 cd presidio-analyzer
-                # pipenv sync --dev --sequential
 
-                # install dependency libraries
-                # re2
+                # install re2 dependency
                 re2_version="2018-12-01"
                 wget -O re2.tar.gz https://github.com/google/re2/archive/${re2_version}.tar.gz
                 mkdir re2 
                 tar --extract --file "re2.tar.gz" --directory "re2" --strip-components 1
                 cd re2 && sudo make install
 
-                # Azure pipelines test publish
-                # regex
+                # sync current env python deps 
                 pipenv sync --dev --sequential
+                # install Azure pipelines test publish, regex
                 pipenv install --dev --skip-lock regex pytest-azurepipelines
           - task: Bash@3  
             displayName: 'Install golang pre requisites'

--- a/pipelines/templates/free-agent-disk.yaml
+++ b/pipelines/templates/free-agent-disk.yaml
@@ -1,0 +1,28 @@
+# This template removes some of the agents capabilities to free disk space for
+# our build tasks to run successfully.
+steps:
+- task: Bash@3
+  displayName: 'Free Agent Disk Space'
+  inputs:
+    targetType: 'inline'
+    script: |
+      set -x # debug
+      #sudo find / -type d -name "go*"
+      df -h
+      dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+      # sudo apt-get remove 'ghc.*'
+      # sudo apt-get remove 'llvm.*'
+      # sudo apt-get remove 'zulu.*'
+      # sudo apt-get remove 'dotnet.*'
+      sudo apt-get remove 'hhvm'
+      sudo apt-get remove 'google-cloud-sdk'
+      sudo apt-get remove 'firefox'
+      sudo apt-get remove 'google-chrome-stable'
+      sudo apt-get autoremove
+      sudo apt-get clean
+      df -h
+      sudo rm -fr /usr/local/lib/android
+      df -h
+      #sudo du --max-depth=2 --threshold=100M -h /usr /opt /var
+      #sudo find /usr -xdev -type f -size +100M -exec ls -la {} \; | sort -nk 5
+      #sudo du -ahx /usr | sort -rh | head -20

--- a/pipelines/templates/golang-environment.yaml
+++ b/pipelines/templates/golang-environment.yaml
@@ -2,17 +2,13 @@
 # dep ensure. It is required for go <1.11, as noted in ADO golang docs:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/gso?view=azure-devops&tabs=go-older
 steps:
-- task: Bash@3
-  displayName: 'Setup Go Env'
+- task: GoTool@0
   inputs:
-    targetType: 'inline'
-    script: |
-      mkdir -p '$(GOBIN)'
-      mkdir -p '$(GOPATH)/pkg'
-      rm -rf '$(MODULEPATH)'
-      mkdir -p '$(MODULEPATH)'
-      shopt -s extglob
-      shopt -s dotglob
-      mv !(gopath) '$(MODULEPATH)' --force
-      echo '##vso[task.prependpath]$(GOBIN)'
-      echo '##vso[task.prependpath]$(GOROOT)/bin'
+    version: '1.13.5'
+  displayName: "Setup Go Env - Go Tool"
+- task: Go@0
+  inputs:
+    command: 'get'
+    arguments: '-d'
+    workingDirectory: '$(System.DefaultWorkingDirectory)'
+    displayName: "Setup Go Env - Get go"

--- a/pipelines/templates/golang-environment.yaml
+++ b/pipelines/templates/golang-environment.yaml
@@ -6,9 +6,3 @@ steps:
   inputs:
     version: '1.13.5'
   displayName: "Setup Go Env - Go Tool"
-- task: Go@0
-  inputs:
-    command: 'get'
-    arguments: '-d'
-    workingDirectory: '$(System.DefaultWorkingDirectory)'
-  displayName: "Setup Go Env - Get go"

--- a/pipelines/templates/golang-environment.yaml
+++ b/pipelines/templates/golang-environment.yaml
@@ -7,7 +7,7 @@ steps:
     version: '1.13.5'
   displayName: "Setup Go Env - Go Tool"
 - task: Bash@3
-  displayName: 'Create needed Directories'
+  displayName: 'Prepare directories'
   inputs:
     targetType: 'inline'
     script: |

--- a/pipelines/templates/golang-environment.yaml
+++ b/pipelines/templates/golang-environment.yaml
@@ -18,7 +18,5 @@ steps:
       shopt -s extglob
       shopt -s dotglob
       mv !(gopath) '$(MODULEPATH)' --force
-
-
-    # echo '##vso[task.prependpath]$(GOBIN)'
-    # echo '##vso[task.prependpath]$(GOROOT)/bin'
+      echo '##vso[task.prependpath]$(GOBIN)'
+      echo '##vso[task.prependpath]$(GOROOT)/bin'

--- a/pipelines/templates/golang-environment.yaml
+++ b/pipelines/templates/golang-environment.yaml
@@ -11,4 +11,4 @@ steps:
     command: 'get'
     arguments: '-d'
     workingDirectory: '$(System.DefaultWorkingDirectory)'
-    displayName: "Setup Go Env - Get go"
+  displayName: "Setup Go Env - Get go"

--- a/pipelines/templates/golang-environment.yaml
+++ b/pipelines/templates/golang-environment.yaml
@@ -6,3 +6,19 @@ steps:
   inputs:
     version: '1.13.5'
   displayName: "Setup Go Env - Go Tool"
+- task: Bash@3
+  displayName: 'Create needed Directories'
+  inputs:
+    targetType: 'inline'
+    script: |
+      mkdir -p '$(GOBIN)'
+      mkdir -p '$(GOPATH)/pkg'
+      rm -rf '$(MODULEPATH)'
+      mkdir -p '$(MODULEPATH)'
+      shopt -s extglob
+      shopt -s dotglob
+      mv !(gopath) '$(MODULEPATH)' --force
+
+
+    # echo '##vso[task.prependpath]$(GOBIN)'
+    # echo '##vso[task.prependpath]$(GOROOT)/bin'


### PR DESCRIPTION
This PR handles 2 issues:
1. Move to pipenv sync (instead of install) in PR validation stage
1. Install Go using Go Tool as this is the new practice 
https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/go?view=azure-devops&tabs=go-current#set-up-go
1. Add a ci task/template to free disk space in the agent (currently inactive)