### PR TITLE
Changed pipenv install to pipenv sync

### DIFF
--- a/pipelines/templates/build-python-template.yaml
+++ b/pipelines/templates/build-python-template.yaml
@@ -34,7 +34,6 @@ steps:
     script: |
       python -m pip install --upgrade pip
       python -m pip install pipenv
-      pipenv --python 3
     workingDirectory: ${{ parameters.folder_name }}
 - task: PipAuthenticate@0
   displayName: 'Authenticate PIP with Azure Artifacts'
@@ -47,7 +46,7 @@ steps:
     script: |
       export PRESIDIO_PYPI_FEED=$PIP_EXTRA_INDEX_URL
       export PIPENV_VENV_IN_PROJECT=1
-      pipenv sync
+      pipenv sync --dev
       # Print venv information
       pipenv --venv
     workingDirectory: ${{ parameters.folder_name }}
@@ -57,7 +56,6 @@ steps:
     targetType: 'inline'
     script: |
       export PIPENV_VENV_IN_PROJECT=1
-      pipenv install pylint==2.3.1 flake8==3.7.9 --skip-lock
       pipenv run pylint $PACKAGE_NAME && \
       pipenv run flake8 $PACKAGE_NAME --exclude "*pb2*.py"
     workingDirectory: ${{ parameters.folder_name }}
@@ -70,7 +68,7 @@ steps:
     script: |
       export PIPENV_VENV_IN_PROJECT=1
       export PRESIDIO_PYPI_FEED=$PIP_EXTRA_INDEX_URL
-      pipenv install pytest pytest-azurepipelines --skip-lock
+      #pipenv install pytest-azurepipelines --skip-lock
       pipenv run pytest --log-cli-level=0
     workingDirectory: ${{ parameters.folder_name }}
 - task: Bash@3

--- a/pipelines/templates/build-python-template.yaml
+++ b/pipelines/templates/build-python-template.yaml
@@ -46,7 +46,8 @@ steps:
     targetType: 'inline'
     script: |
       export PRESIDIO_PYPI_FEED=$PIP_EXTRA_INDEX_URL
-      pipenv install --dev --sequential
+      export PIPENV_VENV_IN_PROJECT=1
+      pipenv sync
       # Print venv information
       pipenv --venv
     workingDirectory: ${{ parameters.folder_name }}
@@ -55,6 +56,8 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
+      export PIPENV_VENV_IN_PROJECT=1
+      pipenv install pylint==2.3.1 flake8==3.7.9 pytest --skip-lock
       pipenv run pylint $PACKAGE_NAME && \
       pipenv run flake8 $PACKAGE_NAME --exclude "*pb2*.py"
     workingDirectory: ${{ parameters.folder_name }}
@@ -65,8 +68,9 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
+      export PIPENV_VENV_IN_PROJECT=1
       export PRESIDIO_PYPI_FEED=$PIP_EXTRA_INDEX_URL
-      pipenv install --skip-lock pytest-azurepipelines
+      pipenv install pytest pytest-azurepipelines --skip-lock
       pipenv run pytest --log-cli-level=0
     workingDirectory: ${{ parameters.folder_name }}
 - task: Bash@3

--- a/pipelines/templates/build-python-template.yaml
+++ b/pipelines/templates/build-python-template.yaml
@@ -57,7 +57,7 @@ steps:
     targetType: 'inline'
     script: |
       export PIPENV_VENV_IN_PROJECT=1
-      pipenv install pylint==2.3.1 flake8==3.7.9 pytest --skip-lock
+      pipenv install pylint==2.3.1 flake8==3.7.9 --skip-lock
       pipenv run pylint $PACKAGE_NAME && \
       pipenv run flake8 $PACKAGE_NAME --exclude "*pb2*.py"
     workingDirectory: ${{ parameters.folder_name }}

--- a/pipelines/templates/build-python-template.yaml
+++ b/pipelines/templates/build-python-template.yaml
@@ -46,6 +46,7 @@ steps:
     script: |
       export PRESIDIO_PYPI_FEED=$PIP_EXTRA_INDEX_URL
       export PIPENV_VENV_IN_PROJECT=1
+      export PIPENV_SKIP_LOCK=1
       pipenv sync --dev
       # Print venv information
       pipenv --venv
@@ -67,6 +68,7 @@ steps:
     targetType: 'inline'
     script: |
       export PIPENV_VENV_IN_PROJECT=1
+      export PIPENV_SKIP_LOCK=1
       export PRESIDIO_PYPI_FEED=$PIP_EXTRA_INDEX_URL
       #pipenv install pytest-azurepipelines --skip-lock
       pipenv run pytest --log-cli-level=0


### PR DESCRIPTION
1. Attempt to fix failing build on Azure Pipelines due to timeouts on Pipfile lock. 
`pipenv sync` does not re-lock the Pipfile.
2. Make the pipeline script identical to the Presidio Python base Dockerfile