### PR TITLE
analyzer - Spanish language

### DIFF
--- a/docs/tutorial_analyzer.md
+++ b/docs/tutorial_analyzer.md
@@ -100,11 +100,7 @@ NOTE: make sure that you have all your spacy models downloaded with a command li
 python3 -m spacy download es_core_news_md
 ```
 
-Then, we need to serve our models. We can do that very easily with (Takes about 15 seconds to load)
-
-```sh
-./presidio-analyzer serve
-```
+Then, we need to serve our models as showed before in Method 1.
 
 Now that our models is up and running, we can send PII text to it.
 

--- a/docs/tutorial_analyzer.md
+++ b/docs/tutorial_analyzer.md
@@ -77,9 +77,9 @@ print(
 
 ## Using multiple languages
 
-### Multiple Language: Method 1
+### Option 1: Configure which spacy/stanza models to load
 
-First, we need to create a configurarion file to specify what languages to load. Like this:
+First, we need to edit the configuration file (i.e. /presidio-analyzer/conf/spacy_multilingual.yaml) to specify what languages to load. Like this:
 
 ```spacy_multilingual.yaml
 nlp_engine_name: spacy
@@ -113,7 +113,7 @@ _From another shell_
 You can make an English language query like before or use Spanish language query like this:
 
 ```sh
-./presidio-analyzer analyze --text "Mi nombre es Francisco Pérez con DNI 55555555-K, vivo en Madrid y trabajo para la ONU." --fields "ES_NIF" "LOCATION" "ORG" "PERSON" --language "es"
+./presidio-analyzer analyze --text "Mi nombre es Francisco Pérez con DNI 55555555-K, vivo en Madrid y trabajo para la ONU." --fields "ES_NIF" "LOCATION" "PERSON" --language "es"
 ````
 
 The expected result is:
@@ -153,24 +153,13 @@ The expected result is:
         "end": 63,
         "length": 6
       }
-    },
-    {
-      "field": {
-        "name": "ORG"
-      },
-      "score": 0.8500000238418579,
-      "location": {
-        "start": 82,
-        "end": 85,
-        "length": 3
-      }
     }
   ],
   "requestId": "d89ffd66-2adf-486f-a040-4e4f80af7a86"
 }
 ```
 
-### Multiple Language: Method 2
+### Option 2: load models programmatically
 
 Use the analyzer Python code by importing `analyzer_engine.py`, `SpacyNlpEngine` and `RecognizerRegistry`
 

--- a/docs/tutorial_analyzer.md
+++ b/docs/tutorial_analyzer.md
@@ -166,7 +166,7 @@ from presidio_analyzer.recognizer_registry import RecognizerRegistry
 
 registry = RecognizerRegistry()
 nlp = SpacyNlpEngine({"en": "en_core_web_lg", "es": "es_core_news_md"})
-registry.load_predefined_recognizers(["es"], "spacy")
+registry.load_predefined_recognizers(["en", "es"], "spacy")
 analyzer = AnalyzerEngine(registry=registry, nlp_engine=nlp, default_language="es")
 
 # English query with just one entity
@@ -181,7 +181,7 @@ print(
       for res in results])
 
 # Spanish query with all entities and score_threshold
-results = engine.analyze(text = "Mi nombre es Francisco Pérez con DNI 55555555-K, \
+results = analyzer.analyze(text = "Mi nombre es Francisco Pérez con DNI 55555555-K, \
                          vivo en Madrid y trabajo para la ONU.",
                          entities=[],
                          language='es',

--- a/presidio-analyzer/conf/spacy_multilingual.yaml
+++ b/presidio-analyzer/conf/spacy_multilingual.yaml
@@ -2,7 +2,10 @@ nlp_engine_name: spacy
 models:
   -
     lang_code: en
-    model_name: en
+    model_name: en_core_web_lg
   -
     lang_code: de
-    model_name: de
+    model_name: de_core_news_md
+  -
+    lang_code: es
+    model_name: es_core_news_md

--- a/presidio-analyzer/presidio_analyzer/app.py
+++ b/presidio-analyzer/presidio_analyzer/app.py
@@ -138,7 +138,8 @@ def serve_command_handler(
         server.stop(0)
 
 
-def analyze_command_handler(text, fields, language, env_grpc_port=False, grpc_port=3001):
+def analyze_command_handler(text, fields, language="en", env_grpc_port=False,
+                            grpc_port=3001):
 
     if env_grpc_port:
         port = os.environ.get("GRPC_PORT")

--- a/presidio-analyzer/presidio_analyzer/app.py
+++ b/presidio-analyzer/presidio_analyzer/app.py
@@ -156,7 +156,7 @@ def analyze_command_handler(text, fields, language, env_grpc_port=False, grpc_po
         field_type.name = field_name
 
     request.analyzeTemplate.language = language
-    
+
     results = stub.Apply(request)
     print(MessageToJson(results))
 

--- a/presidio-analyzer/presidio_analyzer/app.py
+++ b/presidio-analyzer/presidio_analyzer/app.py
@@ -138,7 +138,7 @@ def serve_command_handler(
         server.stop(0)
 
 
-def analyze_command_handler(text, fields, env_grpc_port=False, grpc_port=3001):
+def analyze_command_handler(text, fields, language, env_grpc_port=False, grpc_port=3001):
 
     if env_grpc_port:
         port = os.environ.get("GRPC_PORT")
@@ -154,6 +154,9 @@ def analyze_command_handler(text, fields, env_grpc_port=False, grpc_port=3001):
     for field_name in fields:
         field_type = request.analyzeTemplate.fields.add()
         field_type.name = field_name
+
+    request.analyzeTemplate.language = language
+    
     results = stub.Apply(request)
     print(MessageToJson(results))
 
@@ -183,6 +186,7 @@ class CommandsLoader(CLICommandsLoader):
             ac.argument("grpc_port", default=3001, type=int, required=False)
             ac.argument("text", required=True)
             ac.argument("fields", nargs="*", required=True)
+            ac.argument("language", default="en", required=False)
         logger.info(f"cli commands: {command}")
         super(CommandsLoader, self).load_arguments(command)
 

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
@@ -15,6 +15,7 @@ from .us_itin_recognizer import UsItinRecognizer
 from .us_passport_recognizer import UsPassportRecognizer
 from .us_phone_recognizer import UsPhoneRecognizer
 from .us_ssn_recognizer import UsSsnRecognizer
+from .es_nif_recognizer import EsNifRecognizer
 
 NLP_RECOGNIZERS = {"spacy": SpacyRecognizer, "stanza": StanzaRecognizer}
 
@@ -37,4 +38,5 @@ __all__ = [
     "UsPhoneRecognizer",
     "UsSsnRecognizer",
     "NLP_RECOGNIZERS",
+    "EsNifRecognizer",
 ]

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/es_nif_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/es_nif_recognizer.py
@@ -42,7 +42,7 @@ class EsNifRecognizer(PatternRecognizer):
         letter = pattern_text[-1]
         number = int(''.join(filter(str.isdigit, pattern_text)))
         letters = 'TRWAGMYFPDXBNJZSQVHLCKE'
-        return letter == letters[number%23]
+        return letter == letters[number % 23]
 
     @staticmethod
     def __sanitize_value(text):

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/es_nif_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/es_nif_recognizer.py
@@ -1,0 +1,49 @@
+from presidio_analyzer import Pattern, PatternRecognizer
+
+
+class EsNifRecognizer(PatternRecognizer):
+    """
+    Recognizes NIF number using regex and checksum
+    """
+
+    PATTERNS = [
+        Pattern("NIF", r'\b[0-9]?[0-9]{7}[-]?[A-Z]\b', 0.5,),
+    ]
+
+    CONTEXT = [
+        "documento nacional de identidad",
+        "DNI",
+        "NIF",
+        "identificación"
+    ]
+
+    def __init__(
+        self,
+        patterns=None,
+        context=None,
+        supported_language="es",
+        supported_entity="ES_NIF",
+        replacement_pairs=None,
+    ):
+        self.replacement_pairs = replacement_pairs \
+            if replacement_pairs \
+            else [("-", ""), (" ", "")]
+        context = context if context else self.CONTEXT
+        patterns = patterns if patterns else self.PATTERNS
+        super().__init__(
+            supported_entity=supported_entity,
+            patterns=patterns,
+            context=context,
+            supported_language=supported_language,
+        )
+
+    def validate_result(self, pattern_text):
+        pattern_text = EsNifRecognizer.__sanitize_value(pattern_text)
+        letter = pattern_text[-1]
+        number = int(''.join(filter(str.isdigit, pattern_text)))
+        letters = 'TRWAGMYFPDXBNJZSQVHLCKE'
+        return letter == letters[number%23]
+
+    @staticmethod
+    def __sanitize_value(text):
+        return text.replace('-', '').replace(' ', '')

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/spacy_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/spacy_recognizer.py
@@ -3,7 +3,7 @@ from presidio_analyzer import RecognizerResult, LocalRecognizer, AnalysisExplana
 
 class SpacyRecognizer(LocalRecognizer):
 
-    ENTITIES = ["DATE_TIME", "NRP", "LOCATION", "PERSON"]
+    ENTITIES = ["DATE_TIME", "NRP", "LOCATION", "PERSON", "ORG"]
 
     DEFAULT_EXPLANATION = "Identified as {} by Spacy's Named Entity Recognition"
 
@@ -12,6 +12,7 @@ class SpacyRecognizer(LocalRecognizer):
         ({"PERSON", "PER"}, {"PERSON", "PER"}),
         ({"DATE_TIME"}, {"DATE", "TIME"}),
         ({"NRP"}, {"NORP"}),
+        ({"ORG"}, {"ORG"})
     ]
 
     def __init__(

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/spacy_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/spacy_recognizer.py
@@ -3,7 +3,7 @@ from presidio_analyzer import RecognizerResult, LocalRecognizer, AnalysisExplana
 
 class SpacyRecognizer(LocalRecognizer):
 
-    ENTITIES = ["DATE_TIME", "NRP", "LOCATION", "PERSON", "ORG"]
+    ENTITIES = ["DATE_TIME", "NRP", "LOCATION", "PERSON"]
 
     DEFAULT_EXPLANATION = "Identified as {} by Spacy's Named Entity Recognition"
 
@@ -11,8 +11,7 @@ class SpacyRecognizer(LocalRecognizer):
         ({"LOCATION"}, {"GPE", "LOC"}),
         ({"PERSON", "PER"}, {"PERSON", "PER"}),
         ({"DATE_TIME"}, {"DATE", "TIME"}),
-        ({"NRP"}, {"NORP"}),
-        ({"ORG"}, {"ORG"})
+        ({"NRP"}, {"NORP"})
     ]
 
     def __init__(

--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizer_registry.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizer_registry.py
@@ -19,6 +19,7 @@ from presidio_analyzer.predefined_recognizers import (
     UsSsnRecognizer,
     SgFinRecognizer,
     SpacyRecognizer,
+    EsNifRecognizer,
 )
 
 
@@ -74,6 +75,9 @@ class RecognizerRegistry:
                 UsSsnRecognizer,
                 NhsRecognizer,
                 SgFinRecognizer,
+            ],
+            "es": [
+                EsNifRecognizer,
             ],
             "ALL": [
                 CreditCardRecognizer,

--- a/presidio-analyzer/tests/test_analyzer_engine.py
+++ b/presidio-analyzer/tests/test_analyzer_engine.py
@@ -658,8 +658,9 @@ def test_demo_text(unit_test_guid, nlp_engine):
     )
     assert len([entity for entity in detected_entities if entity == "US_PASSPORT"]) == 1
     assert len([entity for entity in detected_entities if entity == "US_SSN"]) == 1
+    assert len([entity for entity in detected_entities if entity == "ORG"]) == 7
 
-    assert len(results) == 19
+    assert len(results) == 26
 
 
 def test_get_recognizers_returns_predefined(nlp_engine):

--- a/presidio-analyzer/tests/test_analyzer_engine.py
+++ b/presidio-analyzer/tests/test_analyzer_engine.py
@@ -658,9 +658,8 @@ def test_demo_text(unit_test_guid, nlp_engine):
     )
     assert len([entity for entity in detected_entities if entity == "US_PASSPORT"]) == 1
     assert len([entity for entity in detected_entities if entity == "US_SSN"]) == 1
-    assert len([entity for entity in detected_entities if entity == "ORG"]) == 7
 
-    assert len(results) == 26
+    assert len(results) == 19
 
 
 def test_get_recognizers_returns_predefined(nlp_engine):

--- a/presidio-analyzer/tests/test_es_nif_recognizer.py
+++ b/presidio-analyzer/tests/test_es_nif_recognizer.py
@@ -1,0 +1,36 @@
+import pytest
+
+from tests import assert_result
+from presidio_analyzer.predefined_recognizers import EsNifRecognizer
+
+
+@pytest.fixture(scope="module")
+def recognizer():
+    return EsNifRecognizer()
+
+
+@pytest.fixture(scope="module")
+def entities():
+    return ["ES_NIF"]
+
+
+@pytest.mark.parametrize(
+    "text, expected_len, expected_positions",
+    [
+        # valid NIF scores
+        ("55555555K", 1, ((0, 9),),),
+        ("55555555-K", 1, ((0, 10),),),
+        ("1111111-G", 1, ((0, 9),),),
+        ("1111111G", 1, ((0, 8),),),
+        ("01111111G", 1, ((0, 9),),),
+        # invalid NIF scores
+        ("401-023-2138", 0, ()),
+    ],
+)
+def test_all_es_nifes(
+    text, expected_len, expected_positions, recognizer, entities, max_score
+):
+    results = recognizer.analyze(text, entities)
+    assert len(results) == expected_len
+    for res, (st_pos, fn_pos) in zip(results, expected_positions):
+        assert_result(res, entities[0], st_pos, fn_pos, max_score)


### PR DESCRIPTION
Using the recently added multi language support, this PR provides:

- Spanish national identification number recognizer
- Support for language parameter using GRPC script
- Examples using multilingual capabilities:
    - Loading 2 different languages
    - Querying with specific language
    - Using python library or GRPC script with multiple languages

NOTE: In the future I expect to add more generic and Spanish recognizers
 