### PR TITLE
fix(helm):  Remove duplicate resources property

### DIFF
--- a/charts/presidio/values.yaml
+++ b/charts/presidio/values.yaml
@@ -49,7 +49,6 @@ analyzer:
       requests:
         memory: "1500Mi"
         cpu: "1500m"
-    resources:
       limits:
         memory: "3000Mi"
         cpu: "2000m"


### PR DESCRIPTION
The current `values.yaml` file has a duplicate `resources:` property that causes the helm deployment to fail.

 ```
==> Linting .
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/: template: presidio/templates/analyzer-deployment.yaml:29:30: executing "presidio/templates/analyzer-deployment.yaml" at <.Values.analyzer.container.resources.requests.memory>: nil pointer evaluating interface {}.memory

Error: 1 chart(s) linted, 1 chart(s) failed
```