### PR TITLE
fix: Replace sys.path.append in app.py

### DIFF
--- a/presidio-analyzer/presidio_analyzer/app.py
+++ b/presidio-analyzer/presidio_analyzer/app.py
@@ -12,6 +12,8 @@ from knack.commands import CLICommandsLoader, CommandGroup
 from knack.help import CLIHelp
 from knack.help_files import helps
 
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from analyzer_engine import AnalyzerEngine  # noqa
 from recognizer_registry.recognizer_registry import RecognizerRegistry  # noqa
 from nlp_engine import NLP_ENGINES  # noqa


### PR DESCRIPTION
This PR addresses #355 .

I am by no means a python expert, but this line to register the module's parent directory with `sys.path` seems to address the issue that was preventing the `presidio-analyzer` from running in it's docker container.

This line originally was in `__main__.py` but was not carried over with the migration to `app.py` from these changes: https://github.com/microsoft/presidio/commit/e5fe414fd6108095e9fade11280d8143a9948f88#diff-7667e7401c6e0dc1f5576509d1c53249