### PR TITLE
Sanitize IBAN match before validation

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/iban_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/iban_recognizer.py
@@ -65,7 +65,7 @@ class IbanRecognizer(PatternRecognizer):
         )
 
     def validate_result(self, pattern_text):
-        try: 
+        try:
             pattern_text = self.__sanitize_value(pattern_text, self.replacement_pairs)
             is_valid_checksum = (
                 self.__generate_iban_check_digits(pattern_text, self.LETTERS)

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/iban_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/iban_recognizer.py
@@ -49,7 +49,9 @@ class IbanRecognizer(PatternRecognizer):
         exact_match=False,
         BOSEOS=(BOS, EOS),
         regex_flags=re.DOTALL | re.MULTILINE,
+        replacement_pairs=None,
     ):
+        self.replacement_pairs = replacement_pairs or [("-", ""), ("/", ""), (" ", "")]
         self.exact_match = exact_match
         self.BOSEOS = BOSEOS if exact_match else ()
         self.flags = regex_flags
@@ -63,7 +65,7 @@ class IbanRecognizer(PatternRecognizer):
         )
 
     def validate_result(self, pattern_text):
-        pattern_text = pattern_text.replace(" ", "")
+        pattern_text = self.__sanitize_value(pattern_text, self.replacement_pairs)
         is_valid_checksum = (
             self.__generate_iban_check_digits(pattern_text, self.LETTERS)
             == pattern_text[2:4]
@@ -170,3 +172,9 @@ class IbanRecognizer(PatternRecognizer):
             return country_regex and re.match(country_regex, iban, flags=flags)
 
         return False
+
+    @staticmethod
+    def __sanitize_value(text, replacement_pairs):
+        for search_string, replacement_string in replacement_pairs:
+            text = text.replace(search_string, replacement_string)
+        return text

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/iban_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/iban_recognizer.py
@@ -51,7 +51,7 @@ class IbanRecognizer(PatternRecognizer):
         regex_flags=re.DOTALL | re.MULTILINE,
         replacement_pairs=None,
     ):
-        self.replacement_pairs = replacement_pairs or [("-", ""), ("/", ""), (" ", "")]
+        self.replacement_pairs = replacement_pairs or [("-", ""), (" ", "")]
         self.exact_match = exact_match
         self.BOSEOS = BOSEOS if exact_match else ()
         self.flags = regex_flags

--- a/presidio-analyzer/tests/test_iban_recognizer.py
+++ b/presidio-analyzer/tests/test_iban_recognizer.py
@@ -354,11 +354,7 @@ def update_iban_checksum(iban):
             1,
             ((24, 58),),
         ),
-        (
-            "Slash as iban separator: AL47/2121/1009/0000/0002/3569/8741",
-            1,
-            ((25, 59),),
-        ),
+        ("Slash as iban separator: AL47/2121/1009/0000/0002/3569/8741", 0, (),),
     ],
 )
 def test_all_ibans(iban, expected_len, expected_res, recognizer, entities, max_score):

--- a/presidio-analyzer/tests/test_iban_recognizer.py
+++ b/presidio-analyzer/tests/test_iban_recognizer.py
@@ -349,6 +349,16 @@ def update_iban_checksum(iban):
             2,
             ((15, 43), (45, 73),),
         ),
+        (
+            "Dash as iban separator: AL47-2121-1009-0000-0002-3569-8741",
+            1,
+            ((24, 58),),
+        ),
+        (
+            "Slash as iban separator: AL47/2121/1009/0000/0002/3569/8741",
+            1,
+            ((25, 59),),
+        ),
     ],
 )
 def test_all_ibans(iban, expected_len, expected_res, recognizer, entities, max_score):


### PR DESCRIPTION
The [IBAN pattern](https://github.com/microsoft/presidio/blob/master/presidio-analyzer/presidio_analyzer/predefined_recognizers/iban_recognizer.py#L32) detect possible IBAN codes with ` ` and `-` separators.

Sanitize theses characters from the matched text before validation to avoid #363 
