### PR TITLE
Run Functional Tests in CI

### DIFF
--- a/.pipelines/templates/functional-tests.yml
+++ b/.pipelines/templates/functional-tests.yml
@@ -1,0 +1,28 @@
+steps:
+    - task: DockerCompose@0
+      displayName: Start Presidio Cluster
+      inputs:
+          action: Run services
+          dockerComposeFile: docker-compose.yml
+          buildImages: true
+
+    - task: UsePythonVersion@0
+      inputs:
+          versionSpec: '3.8'
+
+    - script: |
+          set -eux  # fail on error
+          python -m venv env
+          source env/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest-azurepipelines
+      workingDirectory: functional-tests
+      displayName: Install requirements
+
+    - script: |
+          set -eux  # fail on error
+          source env/bin/activate
+          pytest
+      workingDirectory: functional-tests
+      displayName: Run tests

--- a/.pipelines/templates/functional-tests.yml
+++ b/.pipelines/templates/functional-tests.yml
@@ -18,7 +18,7 @@ steps:
           pip install -r requirements.txt
           pip install pytest-azurepipelines
       workingDirectory: functional-tests
-      displayName: Install requirements
+      displayName: Install dependencies
 
     - script: |
           set -eux  # fail on error

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,11 +1,6 @@
 trigger:
   - V2
 
-pr:
-  branches:
-    include:
-      - V2
-
 jobs:
     #- job: validate
     #  displayName: 'Validate PR pre-requisites'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,3 +105,15 @@ jobs:
 
       steps:
         - template: .pipelines/templates/functional-tests.yml
+
+    - job: DeployToDevEnviroment
+      displayName: Deploy to Development Environment
+      dependsOn:
+        - 'Test'
+        - 'FunctionalTests'
+      pool:
+        vmImage: 'ubuntu-16.04'
+        steps:
+        - script: echo Deploy to Development Environment
+#       - template: .pipelines/templates/dev-deployment.yml
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/V2'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,6 +95,7 @@ jobs:
             WORKING_FOLDER: 'presidio-anonymizer'
 
     - job: FunctionalTests
+      displayName: Functional Tests
       dependsOn:
         #- 'validate'
         - 'inclusivelint'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,6 +115,7 @@ jobs:
             versionSpec: '3.8'
 
         - script: |
+            set -eux  # fail on error
             python -m venv env
             source env/bin/activate
             python -m pip install --upgrade pip
@@ -124,6 +125,7 @@ jobs:
           displayName: Install requirements
 
         - script: |
+            set -eux  # fail on error
             source env/bin/activate
             pytest
           workingDirectory: functional-tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
         - template: .pipelines/templates/security-analysis.yml
        
     - job: 'Test'
-      dependsOn: 
+      dependsOn:
       #- 'validate'
       - 'inclusivelint'
       - 'SecurityAnalysis'
@@ -93,3 +93,34 @@ jobs:
           parameters:
             SERVICE: 'Anonymizer'
             WORKING_FOLDER: 'presidio-anonymizer'
+
+    - job: FunctionalTests
+      pool:
+        vmImage: 'ubuntu-16.04'
+
+      steps:
+        - task: DockerCompose@0
+          displayName: Start Presidio Cluster
+          inputs:
+            action: Run services
+            dockerComposeFile: docker-compose.yml
+            buildImages: true
+
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '3.8'
+
+        - script: |
+            python -m venv env
+            source env/bin/activate
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+            pip install pytest-azurepipelines
+          workingDirectory: functional-tests
+          displayName: Install requirements
+
+        - script: |
+            source env/bin/activate
+            pytest
+          workingDirectory: functional-tests
+          displayName: Run tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,6 +95,10 @@ jobs:
             WORKING_FOLDER: 'presidio-anonymizer'
 
     - job: FunctionalTests
+      dependsOn:
+        #- 'validate'
+        - 'inclusivelint'
+        - 'SecurityAnalysis'
       pool:
         vmImage: 'ubuntu-16.04'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,30 +103,4 @@ jobs:
         vmImage: 'ubuntu-16.04'
 
       steps:
-        - task: DockerCompose@0
-          displayName: Start Presidio Cluster
-          inputs:
-            action: Run services
-            dockerComposeFile: docker-compose.yml
-            buildImages: true
-
-        - task: UsePythonVersion@0
-          inputs:
-            versionSpec: '3.8'
-
-        - script: |
-            set -eux  # fail on error
-            python -m venv env
-            source env/bin/activate
-            python -m pip install --upgrade pip
-            pip install -r requirements.txt
-            pip install pytest-azurepipelines
-          workingDirectory: functional-tests
-          displayName: Install requirements
-
-        - script: |
-            set -eux  # fail on error
-            source env/bin/activate
-            pytest
-          workingDirectory: functional-tests
-          displayName: Run tests
+        - template: .pipelines/templates/functional-tests.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,15 +100,3 @@ jobs:
 
       steps:
         - template: .pipelines/templates/functional-tests.yml
-
-    - job: DeployToDevEnviroment
-      displayName: Deploy to Development Environment
-      dependsOn:
-        - 'Test'
-        - 'FunctionalTests'
-      pool:
-        vmImage: 'ubuntu-16.04'
-        steps:
-        - script: echo Deploy to Development Environment
-#       - template: .pipelines/templates/dev-deployment.yml
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/V2'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,11 @@
 trigger:
   - V2
 
+pr:
+  branches:
+    include:
+      - V2
+
 jobs:
     #- job: validate
     #  displayName: 'Validate PR pre-requisites'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
       args:
         - NAME=presidio-anonymizer
     environment:
-      - FLASK_RUN_PORT=5001
+      - PORT=5001
     ports:
       - "5001:5001"

--- a/functional-tests/common/methods.py
+++ b/functional-tests/common/methods.py
@@ -9,10 +9,11 @@ def anonymize(data):
     response = requests.post(
         f"{ANONYMIZER_BASE_URL}/anonymize", json=data, headers=DEFAULT_HEADERS
     )
-    return response.status_code, json.loads(response.content)
+    return response.status_code, response.content.decode()
 
 
 def analyze(data):
-    return requests.post(
+    response = requests.post(
         f"{ANALYZER_BASE_URL}/analyze", json=data, headers=DEFAULT_HEADERS
     )
+    return response.status_code, json.loads(response.content)

--- a/functional-tests/tests/test_anonymizer.py
+++ b/functional-tests/tests/test_anonymizer.py
@@ -4,9 +4,15 @@ from common.methods import anonymize
 
 @pytest.mark.api
 def test_anonymize():
-    request_body = {"key": "value"}
+    request_body = {
+        "text": "hello world, my name is Jane Doe. My number is: 034453334",
+        "transformations": {"DEFAULT": {"type": "replace", "new_value": "ANONYMIZED"}},
+        "analyzer_results": [
+            {"start": 24, "end": 32, "score": 0.8, "entity_type": "NAME"}
+        ],
+    }
 
     response_status, response_content = anonymize(request_body)
 
     assert response_status == 200
-    assert response_content == {"key": "value"}
+    assert response_content == "hello world, my name is <NAME>. My number is: 034453334"

--- a/presidio-anonymizer/Dockerfile
+++ b/presidio-anonymizer/Dockerfile
@@ -10,5 +10,5 @@ RUN pipenv sync
 
 COPY . /usr/bin/${NAME}/
 
-EXPOSE ${FLASK_RUN_PORT}
-CMD pipenv run flask run --host 0.0.0.0
+EXPOSE ${PORT}
+CMD pipenv run python app.py --host 0.0.0.0

--- a/presidio-anonymizer/Dockerfile
+++ b/presidio-anonymizer/Dockerfile
@@ -10,5 +10,6 @@ RUN pipenv sync
 
 COPY . /usr/bin/${NAME}/
 
+# [ADO-2680] Use FLASK_RUN_PORT and flask run --host 0.0.0.0
 EXPOSE ${PORT}
-CMD pipenv run python app.py --host 0.0.0.0
+CMD pipenv run python app.py

--- a/presidio-anonymizer/Dockerfile
+++ b/presidio-anonymizer/Dockerfile
@@ -10,6 +10,6 @@ RUN pipenv sync
 
 COPY . /usr/bin/${NAME}/
 
-# [ADO-2680] Use FLASK_RUN_PORT and flask run --host 0.0.0.0
+# TODO: [ADO-2680] Use FLASK_RUN_PORT and flask run --host 0.0.0.0
 EXPOSE ${PORT}
 CMD pipenv run python app.py

--- a/presidio-anonymizer/app.py
+++ b/presidio-anonymizer/app.py
@@ -35,4 +35,4 @@ class Server:
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", DEFAULT_PORT))
     server = Server()
-    server.app.run(port=port)
+    server.app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
Add additional job to CI pipeline for factional tests validation that:
1. Starts presidio cluster with docker-compose
2. Bootstraps the functional tests venv  
3. Runs the tests with pytest