### PR TITLE
Remove future annotations to support python 3.6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,8 +43,8 @@ jobs:
         vmImage: 'ubuntu-16.04'
       strategy:
         matrix:
-          #Python36: disabled bug2677
-          #  python.version: '3.6'
+          Python36:
+            python.version: '3.6'
           Python37:
             python.version: '3.7'
           Python38:
@@ -91,8 +91,8 @@ jobs:
         vmImage: 'ubuntu-16.04'
       strategy:
         matrix:
-          #Python36: disabled bug2677
-          #  python.version: '3.6'
+          Python36:
+            python.version: '3.6'
           Python37:
             python.version: '3.7'
           Python38:
@@ -127,15 +127,3 @@ jobs:
           parameters:
             SERVICE: 'Anonymizer'
             WORKING_FOLDER: 'presidio-anonymizer'
-
-    - job: FunctionalTests
-      displayName: Functional Tests
-      dependsOn:
-        #- 'validate'
-        - 'inclusivelint'
-        - 'SecurityAnalysis'
-      pool:
-        vmImage: 'ubuntu-16.04'
-
-      steps:
-        - template: .pipelines/templates/functional-tests.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,3 +127,15 @@ jobs:
           parameters:
             SERVICE: 'Anonymizer'
             WORKING_FOLDER: 'presidio-anonymizer'
+
+    - job: FunctionalTests
+      displayName: Functional Tests
+      dependsOn:
+        #- 'validate'
+        - 'inclusivelint'
+        - 'SecurityAnalysis'
+      pool:
+        vmImage: 'ubuntu-16.04'
+
+      steps:
+        - template: .pipelines/templates/functional-tests.yml

--- a/presidio-analyzer/presidio_analyzer/entity_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/entity_recognizer.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import copy
 from abc import abstractmethod
 from typing import List, Dict
@@ -117,7 +116,7 @@ class EntityRecognizer:
         return return_dict
 
     @classmethod
-    def from_dict(cls, entity_recognizer_dict: Dict) -> EntityRecognizer:
+    def from_dict(cls, entity_recognizer_dict: Dict) -> "EntityRecognizer":
         """
         Create EntityRecognizer from a dict input.
 

--- a/presidio-analyzer/presidio_analyzer/pattern.py
+++ b/presidio-analyzer/presidio_analyzer/pattern.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import json
 from typing import Dict
 
@@ -28,7 +27,7 @@ class Pattern:
         return return_dict
 
     @classmethod
-    def from_dict(cls, pattern_dict: Dict) -> Pattern:
+    def from_dict(cls, pattern_dict: Dict) -> "Pattern":
         """
         Load an instance from a dictionary.
 

--- a/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import datetime
 from typing import List, Optional, Dict
 
@@ -236,7 +235,7 @@ class PatternRecognizer(LocalRecognizer):
         return return_dict
 
     @classmethod
-    def from_dict(cls, entity_recognizer_dict: Dict) -> PatternRecognizer:
+    def from_dict(cls, entity_recognizer_dict: Dict) -> "PatternRecognizer":
         """Create instance from a serialized dict."""
         patterns = entity_recognizer_dict.get("patterns")
         if patterns:

--- a/presidio-analyzer/presidio_analyzer/recognizer_result.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_result.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from presidio_analyzer import AnalysisExplanation
 
 
@@ -54,7 +52,7 @@ class RecognizerResult:
         """Return a string representation of the instance."""
         return self.__str__()
 
-    def intersects(self, other: RecognizerResult) -> int:
+    def intersects(self, other: "RecognizerResult") -> int:
         """
         Check if self intersects with a different RecognizerResult.
 
@@ -69,7 +67,7 @@ class RecognizerResult:
         # otherwise the intersection is min(end) - max(start)
         return min(self.end, other.end) - max(self.start, other.start)
 
-    def contained_in(self, other: RecognizerResult) -> bool:
+    def contained_in(self, other: "RecognizerResult") -> bool:
         """
         Check if self is contained in a different RecognizerResult.
 


### PR DESCRIPTION
bug 2677
Replace class hints with strings, removed postponed annotations imports.
Reference: https://discuss.python.org/t/postponed-annotations-in-3-6/1885