### PR TITLE
Allow more customisation of ingress resource with annotations and host

### DIFF
--- a/charts/presidio/templates/api-deployment.yaml
+++ b/charts/presidio/templates/api-deployment.yaml
@@ -15,8 +15,9 @@ spec:
       app: {{ $fullname }}
   template:
     metadata:
-      {{- with .Values.api.ingress.annotations }}
-{{ toYaml . | indent 6 }}
+      {{- with .Values.api.annotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
       {{- end }}
       labels:
         app: {{ $fullname }}

--- a/charts/presidio/templates/api-deployment.yaml
+++ b/charts/presidio/templates/api-deployment.yaml
@@ -15,6 +15,9 @@ spec:
       app: {{ $fullname }}
   template:
     metadata:
+      {{- with .Values.api.ingress.annotations }}
+{{ toYaml . | indent 6 }}
+      {{- end }}
       labels:
         app: {{ $fullname }}
     spec:

--- a/charts/presidio/templates/api-ingress.yaml
+++ b/charts/presidio/templates/api-ingress.yaml
@@ -12,7 +12,9 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.api.ingress.class }}
-    nginx.ingress.kubernetes.io/rewrite-target: /
+    {{- with .Values.api.ingress.additional_annotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
 spec:
   rules:
   - http:
@@ -21,4 +23,7 @@ spec:
         backend:
           serviceName: {{ $serviceName }}
           servicePort: {{ $servicePort }}
+    {{- with .Values.api.ingress.host }}
+    host: {{ . }}
+    {{- end }}
 {{- end -}}

--- a/charts/presidio/templates/api-ingress.yaml
+++ b/charts/presidio/templates/api-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.api.ingress.enabled) (or (eq .Values.api.ingress.class "nginx") (eq .Values.api.ingress.class "traefik")) -}}
+{{- if and (.Values.api.ingress.enabled) (or (eq .Values.api.ingress.class "nginx") (eq .Values.api.ingress.class "traefik") (eq .Values.api.ingress.class "alb")) -}}
 {{- $serviceName := include "presidio.api.fullname" . -}}
 {{- $servicePort := .Values.api.service.externalPort -}}
 apiVersion: extensions/v1beta1

--- a/charts/presidio/values.yaml
+++ b/charts/presidio/values.yaml
@@ -19,12 +19,12 @@ api:
   name: presidio-api
   replicas: 1
   imagePullPolicy: Always
+  # annotations:
   service:
     type: ClusterIP
     externalPort: 8080
     internalPort: 8080
     name: http
-    # annotations:
   # Configure liveness probes except `httpGet` and the belongings
   #livenessProbe:
   #  initialDelaySeconds: 20

--- a/charts/presidio/values.yaml
+++ b/charts/presidio/values.yaml
@@ -1,5 +1,5 @@
 registry: mcr.microsoft.com
- 
+
 # Image pull secret
 #privateRegistry: acr-auth
 tag: latest
@@ -24,6 +24,7 @@ api:
     externalPort: 8080
     internalPort: 8080
     name: http
+    # annotations:
   # Configure liveness probes except `httpGet` and the belongings
   #livenessProbe:
   #  initialDelaySeconds: 20
@@ -35,6 +36,9 @@ api:
   ingress:
     enabled: false
     class: nginx
+    additional_annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /
+    # host:
 
 # For any of the services below, a service mesh like Linkerd or Istio
 # is needed to properly balance traffic to more than 1 replica.
@@ -97,7 +101,7 @@ scheduler:
     externalPort: 3001
     internalPort: 3001
     name: grpc
-  
+
 recognizersstore:
   name: presidio-recognizers-store
   imagePullPolicy: Always


### PR DESCRIPTION
Allows use of more complex ingress configuration including external-dns integration, and further annotations for classes such as ALB. Also allows custom annotations on the API deployment for use with tools like datadog.