### PR TITLE
Anonymizer - Integration Tests Infra + Mask scenarios

### DIFF
--- a/presidio-anonymizer/tests/integration/file_utils.py
+++ b/presidio-anonymizer/tests/integration/file_utils.py
@@ -1,0 +1,6 @@
+import os
+
+
+def get_scenario_file_content(scenario_method, scenario_name: str):
+    with open(os.path.join("resources", scenario_method, scenario_name)) as f:
+        return f.read()

--- a/presidio-anonymizer/tests/integration/file_utils.py
+++ b/presidio-anonymizer/tests/integration/file_utils.py
@@ -1,6 +1,8 @@
 import os
+from pathlib import Path
 
 
 def get_scenario_file_content(scenario_method, scenario_name: str):
-    with open(os.path.join("resources", scenario_method, scenario_name)) as f:
+    integration_directory = Path(__file__).parent
+    with open(os.path.join(integration_directory.parent, "resources", scenario_method, scenario_name)) as f:
         return f.read()

--- a/presidio-anonymizer/tests/integration/file_utils.py
+++ b/presidio-anonymizer/tests/integration/file_utils.py
@@ -4,5 +4,6 @@ from pathlib import Path
 
 def get_scenario_file_content(scenario_method, scenario_name: str):
     integration_directory = Path(__file__).parent
-    with open(os.path.join(integration_directory.parent, "resources", scenario_method, scenario_name)) as f:
+    with open(os.path.join(integration_directory.parent,
+                           "resources", scenario_method, scenario_name)) as f:
         return f.read()

--- a/presidio-anonymizer/tests/integration/test_engine.py
+++ b/presidio-anonymizer/tests/integration/test_engine.py
@@ -1,0 +1,33 @@
+import json
+
+import pytest
+
+from presidio_anonymizer import AnonymizerEngine
+from presidio_anonymizer.entities import AnonymizerRequest
+from tests.integration.file_utils import get_scenario_file_content
+
+
+@pytest.mark.parametrize(
+    "anonymize_scenario",
+    [
+        "mask_name_phone_number",
+        "mask_phone_number_with_bad_masking_char",
+    ],
+)
+def test_when_anonymize_called_with_multiple_scenarios_then_expected_results_returned(
+    anonymize_scenario,
+):
+    anonymizer_request_dict = json.loads(
+        get_scenario_file_content("anonymize", f"{anonymize_scenario}.in.json")
+    )
+    expected_anonymize_result = json.loads(
+        get_scenario_file_content("anonymize", f"{anonymize_scenario}.out.json")
+    )
+    anonymizer_request = AnonymizerRequest(anonymizer_request_dict)
+
+    try:
+        actual_anonymize_result = AnonymizerEngine().anonymize(anonymizer_request)
+    except Exception as e:
+        actual_anonymize_result = str(e)
+
+    assert actual_anonymize_result == expected_anonymize_result

--- a/presidio-anonymizer/tests/resources/anonymize/mask_name_phone_number.in.json
+++ b/presidio-anonymizer/tests/resources/anonymize/mask_name_phone_number.in.json
@@ -1,0 +1,31 @@
+{
+  "text": "hello world, my name is Jane Doe. My number is: 03-4453334",
+  "transformations": {
+    "DEFAULT": {
+      "type": "mask",
+      "masking_char": "*",
+        "chars_to_mask": 20,
+      "from_end": false
+    },
+    "PHONE_NUMBER": {
+      "type": "mask",
+      "masking_char": "*",
+      "chars_to_mask": 6,
+      "from_end": true
+    }
+  },
+  "analyzer_results": [
+    {
+      "start": 24,
+      "end": 32,
+      "score": 0.8,
+      "entity_type": "NAME"
+    },
+    {
+      "start": 48,
+      "end": 57,
+      "score": 0.95,
+      "entity_type": "PHONE_NUMBER"
+    }
+  ]
+}

--- a/presidio-anonymizer/tests/resources/anonymize/mask_name_phone_number.out.json
+++ b/presidio-anonymizer/tests/resources/anonymize/mask_name_phone_number.out.json
@@ -1,0 +1,1 @@
+"hello world, my name is ********. My number is: 03-******4"

--- a/presidio-anonymizer/tests/resources/anonymize/mask_phone_number_with_bad_masking_char.in.json
+++ b/presidio-anonymizer/tests/resources/anonymize/mask_phone_number_with_bad_masking_char.in.json
@@ -1,0 +1,19 @@
+{
+  "text": "hello world, my name is Jane Doe. My number is: 03-4453334",
+  "transformations": {
+    "PHONE_NUMBER": {
+      "type": "mask",
+      "masking_char": "non_character",
+      "chars_to_mask": 6,
+      "from_end": true
+    }
+  },
+  "analyzer_results": [
+    {
+      "start": 48,
+      "end": 57,
+      "score": 0.95,
+      "entity_type": "PHONE_NUMBER"
+    }
+  ]
+}

--- a/presidio-anonymizer/tests/resources/anonymize/mask_phone_number_with_bad_masking_char.out.json
+++ b/presidio-anonymizer/tests/resources/anonymize/mask_phone_number_with_bad_masking_char.out.json
@@ -1,0 +1,1 @@
+"Invalid input, masking_char must be a character"


### PR DESCRIPTION
This adds an infrastructure for anonymizer integration tests.
While 'integration' terminology was used before in the functional-tests context (where we test integration **between presidio services** through API), here, the integration is **between anonymizer components** (like engine-anonymizers, with as less mocks as possible).
Why is the functional-tests module not sufficient? Since presidio services can be used as packages, functionality can be extended without exposing new REST APIs.
In return, this additional test layer can reduce the coverage of the functional-tests module, to be mainly on the REST API, with simple and short happy scenarios and negative tests for the different http codes. 

Implementation-wise, each tested entry-point (method) will have a directory under tests/resources. In it, for each method scenario, there's an input and output json files. All the scenarios will asserted in a single parameterized test.
Not sure that files are the best option as the methods receives objects, not jsons (True vs true, None vs null) but currently, and for anonymize method this is an easily extendible option.