### PR TITLE
Push Presidio Containers to MCR

### DIFF
--- a/.pipelines/templates/build-containers.yml
+++ b/.pipelines/templates/build-containers.yml
@@ -28,4 +28,3 @@ steps:
         containerregistrytype: Azure Container Registry
         azureSubscriptionEndpoint: ${{ parameters.AZURE_SUBSCRIPTION }}
         azureContainerRegistry: ${{ parameters.REGISTRY_NAME }}
-        projectName: public/$(Build.Repository.Name)

--- a/.pipelines/templates/build-containers.yml
+++ b/.pipelines/templates/build-containers.yml
@@ -7,6 +7,8 @@ parameters:
   default: ''
 - name: AZURE_SUBSCRIPTION
   type: string
+- name: PROJECT_NAME
+  type: string
 steps:
   - task: DockerCompose@0
     displayName: Build Presidio Images
@@ -24,3 +26,4 @@ steps:
         containerregistrytype: Azure Container Registry
         azureSubscriptionEndpoint: ${{ parameters.AZURE_SUBSCRIPTION }}
         azureContainerRegistry: ${{ parameters.REGISTRY_NAME }}
+        projectName: ${{ parameters.PROJECT_NAME }}

--- a/.pipelines/templates/build-containers.yml
+++ b/.pipelines/templates/build-containers.yml
@@ -7,8 +7,9 @@ parameters:
   default: ''
 - name: AZURE_SUBSCRIPTION
   type: string
-- name: PROJECT_NAME
+- name: IMAGE_PREFIX
   type: string
+  default: ''
 steps:
   - task: DockerCompose@0
     displayName: Build Presidio Images
@@ -17,6 +18,7 @@ steps:
         dockerComposeFile: docker-compose.yml
         dockerComposeFileArgs: |
           REGISTRY_NAME=${{ parameters.REGISTRY_NAME }}
+          IMAGE_PREFIX=${{ parameters.IMAGE_PREFIX }}
           TAG=${{ parameters.TAG }}
   - task: DockerCompose@0
     displayName: Push Presidio Images to ACR

--- a/.pipelines/templates/build-containers.yml
+++ b/.pipelines/templates/build-containers.yml
@@ -26,4 +26,4 @@ steps:
         containerregistrytype: Azure Container Registry
         azureSubscriptionEndpoint: ${{ parameters.AZURE_SUBSCRIPTION }}
         azureContainerRegistry: ${{ parameters.REGISTRY_NAME }}
-        projectName: ${{ parameters.PROJECT_NAME }}
+        projectName: public/$(Build.Repository.Name)

--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -36,7 +36,7 @@ jobs:
   variables:
     version: $[ dependencies.Version.outputs['setVer.version'] ]
     REGISTRY_NAME: '$(ACR_REGISTRY_NAME).azurecr.io/'
-    TAG: public/$(version)
+    TAG: :$(version)
   steps:
     - template: ./build-containers.yml
       parameters:

--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -15,17 +15,17 @@ jobs:
         echo "##vso[task.setvariable variable=version;isOutput=true]$ver"
       displayName: Set Version
       name: setVer
-- job: githubRelease
-  displayName: GitHub Release
-  dependsOn: version
-  variables:
-    version: $[ dependencies.Version.outputs['setVer.version'] ]
-  steps:
-    - task: GitHubRelease@0
-      inputs:
-        gitHubConnection: $(GITHUB_CONNECTION)
-        tagSource: manual
-        tag: $(version)
+# - job: githubRelease
+#   displayName: GitHub Release
+#   dependsOn: version
+#   variables:
+#     version: $[ dependencies.Version.outputs['setVer.version'] ]
+#   steps:
+#     - task: GitHubRelease@0
+#       inputs:
+#         gitHubConnection: $(GITHUB_CONNECTION)
+#         tagSource: manual
+#         tag: $(version)
 
 
 - job: BuildAndPushContainers
@@ -36,9 +36,10 @@ jobs:
   variables:
     version: $[ dependencies.Version.outputs['setVer.version'] ]
     REGISTRY_NAME: '$(ACR_REGISTRY_NAME).azurecr.io/'
+    TAG: public/$(version)
   steps:
     - template: ./build-containers.yml
       parameters:
         REGISTRY_NAME: $(REGISTRY_NAME)
-        TAG: public/$(version)
+        TAG: $(TAG)
         AZURE_SUBSCRIPTION: $(ACR_AZURE_SUBSCRIPTION)

--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -43,3 +43,4 @@ jobs:
         REGISTRY_NAME: $(REGISTRY_NAME)
         TAG: $(TAG)
         AZURE_SUBSCRIPTION: $(ACR_AZURE_SUBSCRIPTION)
+        PROJECT_NAME: public/$(Build.Repository.Name)

--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -37,7 +37,7 @@ jobs:
     version: $[ dependencies.Version.outputs['setVer.version'] ]
     REGISTRY_NAME: '$(ACR_REGISTRY_NAME).azurecr.io/'
     IMAGE_PREFIX: 'public/'
-    TAG: $(version)
+    TAG: ':$(version)'
   steps:
     - template: ./build-containers.yml
       parameters:

--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -26,9 +26,7 @@ jobs:
 
 - job: BuildAndPushContainers
   displayName: Build and Push Containers
-  dependsOn:
-    - 'TestAnonymizer'
-    - 'TestAnalyzer'
+  dependsOn: version
   pool:
     vmImage: 'ubuntu-16.04'
   variables:

--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -1,5 +1,9 @@
 trigger: none
 pr: none
+
+variables:
+  - group: Presidio-V2-CI
+
 jobs:
 - job: version
   displayName: 'Get the version number'

--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -35,7 +35,7 @@ jobs:
     version: $[ dependencies.Version.outputs['setVer.version'] ]
     REGISTRY_NAME: '$(ACR_REGISTRY_NAME).azurecr.io/'
   steps:
-    - template: .pipelines/templates/build-containers.yml
+    - template: ./build-containers.yml
       parameters:
         REGISTRY_NAME: $(REGISTRY_NAME)
         TAG: public/$(version)

--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -15,17 +15,17 @@ jobs:
         echo "##vso[task.setvariable variable=version;isOutput=true]$ver"
       displayName: Set Version
       name: setVer
- - job: githubRelease
-   displayName: GitHub Release
-   dependsOn: version
-   variables:
-     version: $[ dependencies.Version.outputs['setVer.version'] ]
-   steps:
-     - task: GitHubRelease@0
-       inputs:
-         gitHubConnection: $(GITHUB_CONNECTION)
-         tagSource: manual
-         tag: $(version)
+- job: githubRelease
+  displayName: GitHub Release
+  dependsOn: version
+  variables:
+    version: $[ dependencies.Version.outputs['setVer.version'] ]
+  steps:
+    - task: GitHubRelease@0
+      inputs:
+        gitHubConnection: $(GITHUB_CONNECTION)
+        tagSource: manual
+        tag: $(version)
 
 - job: BuildAndPushContainers
   displayName: Build and Push Containers

--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -22,3 +22,5 @@ jobs:
         gitHubConnection: $(GITHUB_CONNECTION)
         tagSource: manual
         tag: $(version)
+
+

--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -15,18 +15,17 @@ jobs:
         echo "##vso[task.setvariable variable=version;isOutput=true]$ver"
       displayName: Set Version
       name: setVer
-# - job: githubRelease
-#   displayName: GitHub Release
-#   dependsOn: version
-#   variables:
-#     version: $[ dependencies.Version.outputs['setVer.version'] ]
-#   steps:
-#     - task: GitHubRelease@0
-#       inputs:
-#         gitHubConnection: $(GITHUB_CONNECTION)
-#         tagSource: manual
-#         tag: $(version)
-
+ - job: githubRelease
+   displayName: GitHub Release
+   dependsOn: version
+   variables:
+     version: $[ dependencies.Version.outputs['setVer.version'] ]
+   steps:
+     - task: GitHubRelease@0
+       inputs:
+         gitHubConnection: $(GITHUB_CONNECTION)
+         tagSource: manual
+         tag: $(version)
 
 - job: BuildAndPushContainers
   displayName: Build and Push Containers

--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -36,11 +36,12 @@ jobs:
   variables:
     version: $[ dependencies.Version.outputs['setVer.version'] ]
     REGISTRY_NAME: '$(ACR_REGISTRY_NAME).azurecr.io/'
-    TAG: :$(version)
+    IMAGE_PREFIX: 'public/'
+    TAG: $(version)
   steps:
     - template: ./build-containers.yml
       parameters:
         REGISTRY_NAME: $(REGISTRY_NAME)
+        IMAGE_PREFIX: $(IMAGE_PREFIX)
         TAG: $(TAG)
         AZURE_SUBSCRIPTION: $(ACR_AZURE_SUBSCRIPTION)
-        PROJECT_NAME: public/$(Build.Repository.Name)

--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -24,3 +24,19 @@ jobs:
         tag: $(version)
 
 
+- job: BuildAndPushContainers
+  displayName: Build and Push Containers
+  dependsOn:
+    - 'TestAnonymizer'
+    - 'TestAnalyzer'
+  pool:
+    vmImage: 'ubuntu-16.04'
+  variables:
+    version: $[ dependencies.Version.outputs['setVer.version'] ]
+    REGISTRY_NAME: '$(ACR_REGISTRY_NAME).azurecr.io/'
+  steps:
+    - template: .pipelines/templates/build-containers.yml
+      parameters:
+        REGISTRY_NAME: $(REGISTRY_NAME)
+        TAG: public/$(version)
+        AZURE_SUBSCRIPTION: $(ACR_AZURE_SUBSCRIPTION)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   presidio-anonymizer:
-    image: ${REGISTRY_NAME}presidio-anonymizer${TAG}
+    image: ${REGISTRY_NAME}${IMAGE_PREFIX}presidio-anonymizer${TAG}
     build:
       context: ./presidio-anonymizer
       args:
@@ -11,7 +11,7 @@ services:
     ports:
       - "5001:5001"
   presidio-analyzer:
-    image: ${REGISTRY_NAME}presidio-analyzer${TAG}
+    image: ${REGISTRY_NAME}${IMAGE_PREFIX}presidio-analyzer${TAG}
     build:
       context: ./presidio-analyzer
       args:


### PR DESCRIPTION
Add build and push step to release pipeline, with 'public/' as a prefix to the image name.
This will automatically push the container to MCR with a web-hook defined in our acr

*pushing 'latest' tag will be added in a different PR