### PR TITLE
Remove flask from presidio python packages

### DIFF
--- a/presidio-analyzer/setup.py
+++ b/presidio-analyzer/setup.py
@@ -27,8 +27,7 @@ setuptools.setup(
     install_requires=[
         "spacy==2.3",
         "regex==2020.11.13",
-        "tldextract==3.1.0",
-        "flask==1.1.2",
+        "tldextract==3.1.0"
     ],
     include_package_data=True,
     license="MIT",

--- a/presidio-anonymizer/setup.py
+++ b/presidio-anonymizer/setup.py
@@ -5,8 +5,6 @@ from os import path
 
 from setuptools import setup, find_packages
 
-requirements = ["flask==1.1.2"]
-
 test_requirements = ["pytest>=3", "flake8==3.7.9", "flask==1.1.2"]
 
 __version__ = ""
@@ -29,7 +27,6 @@ setup(
     ],
     description="Persidio Anonymizer package - replaces analyzed text with desired "
                 "values.",
-    install_requires=requirements,
     license="MIT license",
     include_package_data=True,
     keywords="presidio_anonymizer",


### PR DESCRIPTION
setup.py's should not install_require flask as this is the non applicative way of using presidio