### PR TITLE
Reduce docs build time

### DIFF
--- a/.pipelines/templates/release-docs.yml
+++ b/.pipelines/templates/release-docs.yml
@@ -16,4 +16,9 @@ stages:
                 - script: |
                       set -eux  # fail on error                                            
                       pip install -r docs/requirements-docs.txt
+
+                      # Install Presidio modules for generating API references
+                      pip install presidio-analyzer --no-dependencies
+                      pip install presidio-anonymizer --no-dependencies
+                      pip install presidio-image-redactor --no-dependencies
                       mkdocs gh-deploy

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -3,6 +3,7 @@ mkdocs-material
 pymdown-extensions
 markdown
 mkdocstrings
-presidio_analyzer
-presidio_anonymizer
-presidio_image_redactor
+
+# presidio_analyzer 
+# presidio_anonymizer 
+# presidio_image_redactor 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ nav:
       - Home: samples/index.md
       - Python: samples/python/index.md
       - Docker: samples/docker/index.md
-      - Sample Deployments: samples/deployments/index.md
+      - Sample Deployments:
         - Azure App Service: samples/deployments/app-service/index.md
         - Kubernetes: samples/deployments/k8s/index.md
     - Supported entities: supported_entities.md


### PR DESCRIPTION
Docs take a lot of time to build because it installs Presidio's modules for automated API reference generation.
This PR proposes:
1. Run `pip install` on presidio-analyzer, presidio-anonymizer and presidio-image-redactor with `--no-dependencies`
2. Split between the requirements-docs.txt which have mkdocs + plugins, and the installation of Presidio