### PR TITLE
Release Pipeline - continue on error for GH release

### DIFF
--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -33,6 +33,8 @@ stages:
 
     - job: githubRelease
       displayName: GitHub Release
+      # Don't fail the job and continue to the deployment, if the version already exists
+      continueOnError: true
       dependsOn: version
       variables:
         version: $[ dependencies.Version.outputs['setVer.version'] ]


### PR DESCRIPTION
When running the release pipeline, and when the VERSION is the same, ignore GH release step failure to continue to the deployment