### PR TITLE
Don't start cluster on e2e tests

### DIFF
--- a/.pipelines/templates/e2e-tests.yml
+++ b/.pipelines/templates/e2e-tests.yml
@@ -16,7 +16,7 @@ steps:
           dockerComposeFile: docker-compose.yml
           buildImages: false
       # Start cluster when testing against remote cluster, when an external url is not provided.
-      condition: eq('${{ variables.anonymizer_base_url }}', '')
+      condition: eq('${{ parameters.anonymizer_base_url }}', '')
 
     - task: UsePythonVersion@0
       inputs:


### PR DESCRIPTION
Fixing the condition for not starting compose cluster when running e2e against true environments.
Tested [here](https://dev.azure.com/csedevil/Presidio/_build/results?buildId=11332&view=logs&s=0b0143f5-1792-5cb0-42a5-36f61214a5e1&j=7d3b72a5-73cd-5eb7-6c36-be458b806191)