### PR TITLE
added e2e package test

### DIFF
--- a/.pipelines/templates/e2e-tests.yml
+++ b/.pipelines/templates/e2e-tests.yml
@@ -29,7 +29,7 @@ steps:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest-azurepipelines
-          python -m spacy download en_core_web_sm
+          python -m spacy download en_core_web_lg
       workingDirectory: e2e-tests
       displayName: Install dependencies
 

--- a/.pipelines/templates/e2e-tests.yml
+++ b/.pipelines/templates/e2e-tests.yml
@@ -29,6 +29,7 @@ steps:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest-azurepipelines
+          python -m spacy download en_core_web_sm
       workingDirectory: e2e-tests
       displayName: Install dependencies
 

--- a/.pipelines/templates/e2e-tests.yml
+++ b/.pipelines/templates/e2e-tests.yml
@@ -29,7 +29,7 @@ steps:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest-azurepipelines
-          python -m spacy download en_core_web_lg
+          python -m spacy download en_core_web_sm
       workingDirectory: e2e-tests
       displayName: Install dependencies
 

--- a/e2e-tests/pytest.ini
+++ b/e2e-tests/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     api: tests calling a single service api layer.
     integration: tests calling multiple services.
+    package: tests packages.

--- a/e2e-tests/requirements.txt
+++ b/e2e-tests/requirements.txt
@@ -1,2 +1,4 @@
 requests
 pytest
+file:../presidio-analyzer
+file:../presidio-anonymizer

--- a/e2e-tests/tests/test_e2e_integration_flows.py
+++ b/e2e-tests/tests/test_e2e_integration_flows.py
@@ -264,7 +264,7 @@ def test_given_text_with_pii_using_package_then_analyze_and_anonymize_complete_s
     expected_response.set_text("<PERSON> drivers license is <US_DRIVER_LICENSE>")
     expected_response.add_item(AnonymizedEntity("replace", "US_DRIVER_LICENSE", 28, 47, "<US_DRIVER_LICENSE>"))
     expected_response.add_item(AnonymizedEntity("replace", "PERSON", 0, 8, "<PERSON>"))
-    
+
     anonymizer = AnonymizerEngine()
     anonymizer_results = anonymizer.anonymize(analyzer_request["text"], analyzer_results)
     assert anonymizer_results == expected_response

--- a/e2e-tests/tests/test_e2e_integration_flows.py
+++ b/e2e-tests/tests/test_e2e_integration_flows.py
@@ -6,6 +6,7 @@ import json
 from presidio_analyzer import AnalyzerEngine, RecognizerResult
 from presidio_anonymizer import AnonymizerEngine
 from presidio_anonymizer.entities import AnonymizerResult, AnonymizedEntity
+from presidio_analyzer.nlp_engine import NlpEngineProvider
 
 from common.assertions import equal_json_strings
 from common.methods import analyze, anonymize, analyzer_supported_entities
@@ -246,25 +247,34 @@ def test_demo_website_text_returns_correct_anonymized_version():
 
 @pytest.mark.package
 def test_given_text_with_pii_using_package_then_analyze_and_anonymize_complete_successfully():
-    analyzer_request = {
-        "text": "John Smith drivers license is AC432223",
-        "language": "en",
-    }
+    text_to_test = "John Smith drivers license is AC432223"
 
     expected_response = [RecognizerResult("PERSON", 0, 10, 0.85),
                          RecognizerResult("US_DRIVER_LICENSE", 30, 38, 0.6499999999999999)
                          ]
+    # Create configuration containing engine name and models
+    configuration = {
+        "nlp_engine_name": "spacy",
+        "models": [{"lang_code": "en", "model_name": "en_core_web_sm"}],
+    }
 
-    analyzer = AnalyzerEngine()
-    analyzer_results = analyzer.analyze(analyzer_request["text"], analyzer_request["language"])
+    # Create NLP engine based on configuration
+    provider = NlpEngineProvider(nlp_configuration=configuration)
+    nlp_engine = provider.create_engine()
+
+    # Pass the created NLP engine and supported_languages to the AnalyzerEngine
+    analyzer = AnalyzerEngine(
+        nlp_engine=nlp_engine,
+        supported_languages=["en"]
+    )
+    analyzer_results = analyzer.analyze(text_to_test, "en")
     for i in range(len(analyzer_results)):
         assert analyzer_results[i] == expected_response[i]
 
-    expected_response = AnonymizerResult()
-    expected_response.set_text("<PERSON> drivers license is <US_DRIVER_LICENSE>")
+    expected_response = AnonymizerResult(text="<PERSON> drivers license is <US_DRIVER_LICENSE>")
     expected_response.add_item(AnonymizedEntity("replace", "US_DRIVER_LICENSE", 28, 47, "<US_DRIVER_LICENSE>"))
     expected_response.add_item(AnonymizedEntity("replace", "PERSON", 0, 8, "<PERSON>"))
 
     anonymizer = AnonymizerEngine()
-    anonymizer_results = anonymizer.anonymize(analyzer_request["text"], analyzer_results)
+    anonymizer_results = anonymizer.anonymize(text_to_test, analyzer_results)
     assert anonymizer_results == expected_response

--- a/e2e-tests/tests/test_e2e_integration_flows.py
+++ b/e2e-tests/tests/test_e2e_integration_flows.py
@@ -247,7 +247,7 @@ def test_demo_website_text_returns_correct_anonymized_version():
 def test_given_text_with_pii_using_package_then_analyze_and_anonymize_complete_successfully():
     analyzer_request = {
         "text": "John Smith drivers license is AC432223",
-        "language": "en",
+        "language": "en",ƒ
     }
 
     expected_response = [

--- a/e2e-tests/tests/test_e2e_integration_flows.py
+++ b/e2e-tests/tests/test_e2e_integration_flows.py
@@ -247,7 +247,7 @@ def test_demo_website_text_returns_correct_anonymized_version():
 def test_given_text_with_pii_using_package_then_analyze_and_anonymize_complete_successfully():
     analyzer_request = {
         "text": "John Smith drivers license is AC432223",
-        "language": "en",ƒ
+        "language": "en",
     }
 
     expected_response = [

--- a/presidio-analyzer/presidio_analyzer/recognizer_result.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_result.py
@@ -131,7 +131,7 @@ class RecognizerResult:
         :return: bool
         """
         equal_type = self.entity_type == other.entity_type
-        equal_score = self.score is other.score
+        equal_score = self.score == other.score
         return self.equal_indices(other) and equal_type and equal_score
 
     def __hash__(self):

--- a/presidio-analyzer/setup.py
+++ b/presidio-analyzer/setup.py
@@ -14,8 +14,8 @@ with open(path.join(this_directory, 'README.MD'), encoding='utf-8') as f:
 try:
     with open(os.path.join(parent_directory, "VERSION")) as version_file:
         __version__ = version_file.read().strip()
-except: #noqa: E722
-    __version__ = os.environ.get("VERSION","0.0.1-alpha")
+except:  # noqa: E722
+    __version__ = os.environ.get("VERSION", "0.0.1-alpha")
 
 setuptools.setup(
     name="presidio_analyzer",

--- a/presidio-analyzer/setup.py
+++ b/presidio-analyzer/setup.py
@@ -14,8 +14,8 @@ with open(path.join(this_directory, 'README.MD'), encoding='utf-8') as f:
 try:
     with open(os.path.join(parent_directory, "VERSION")) as version_file:
         __version__ = version_file.read().strip()
-except:  # noqa: E722
-    __version__ = os.environ.get("VERSION", "0.0.1-alpha")
+except Exception:
+    __version__ = os.environ.get("PRESIDIO_VERSION", "0.0.1-alpha")
 
 setuptools.setup(
     name="presidio_analyzer",

--- a/presidio-analyzer/setup.py
+++ b/presidio-analyzer/setup.py
@@ -11,8 +11,11 @@ parent_directory = os.path.abspath(os.path.join(this_directory, os.pardir))
 with open(path.join(this_directory, 'README.MD'), encoding='utf-8') as f:
     long_description = f.read()
 
-with open(os.path.join(parent_directory, "VERSION")) as version_file:
-    __version__ = version_file.read().strip()
+try:
+    with open(os.path.join(parent_directory, "VERSION")) as version_file:
+        __version__ = version_file.read().strip()
+except:
+    __version__ = "2.0.0"
 
 setuptools.setup(
     name="presidio_analyzer",

--- a/presidio-analyzer/setup.py
+++ b/presidio-analyzer/setup.py
@@ -14,8 +14,8 @@ with open(path.join(this_directory, 'README.MD'), encoding='utf-8') as f:
 try:
     with open(os.path.join(parent_directory, "VERSION")) as version_file:
         __version__ = version_file.read().strip()
-except:
-    __version__ = "2.0.0"
+except: #noqa: E722
+    __version__ = os.environ.get("VERSION","0.0.1-alpha")
 
 setuptools.setup(
     name="presidio_analyzer",

--- a/presidio-anonymizer/presidio_anonymizer/entities/recognizer_result.py
+++ b/presidio-anonymizer/presidio_anonymizer/entities/recognizer_result.py
@@ -136,7 +136,7 @@ class RecognizerResult:
             self.__validate_field("score")
         if self.start < 0 or self.end < 0:
             raise InvalidParamException(
-                f"Invalid input, analyzer result start and end must be positive"
+                "Invalid input, analyzer result start and end must be positive"
             )
         if self.start >= self.end:
             raise InvalidParamException(

--- a/presidio-anonymizer/setup.py
+++ b/presidio-anonymizer/setup.py
@@ -17,8 +17,8 @@ with open(path.join(this_directory, "README.MD"), encoding="utf-8") as f:
 try:
     with open(os.path.join(parent_directory, "VERSION")) as version_file:
         __version__ = version_file.read().strip()
-except:  # noqa: E722
-    __version__ = os.environ.get("VERSION", "0.0.1-alpha")
+except Exception:
+    __version__ = os.environ.get("PRESIDIO_VERSION", "0.0.1-alpha")
 
 setup(
     name="presidio_anonymizer",

--- a/presidio-anonymizer/setup.py
+++ b/presidio-anonymizer/setup.py
@@ -17,8 +17,8 @@ with open(path.join(this_directory, "README.MD"), encoding="utf-8") as f:
 try:
     with open(os.path.join(parent_directory, "VERSION")) as version_file:
         __version__ = version_file.read().strip()
-except: #noqa: E722
-    __version__ = os.environ.get("VERSION","0.0.1-alpha")
+except:  # noqa: E722
+    __version__ = os.environ.get("VERSION", "0.0.1-alpha")
 
 setup(
     name="presidio_anonymizer",

--- a/presidio-anonymizer/setup.py
+++ b/presidio-anonymizer/setup.py
@@ -14,8 +14,11 @@ parent_directory = os.path.abspath(os.path.join(this_directory, os.pardir))
 with open(path.join(this_directory, "README.MD"), encoding="utf-8") as f:
     long_description = f.read()
 
-with open(os.path.join(parent_directory, "VERSION")) as version_file:
-    __version__ = version_file.read().strip()
+try:
+    with open(os.path.join(parent_directory, "VERSION")) as version_file:
+        __version__ = version_file.read().strip()
+except:
+    __version__ = "2.0.0"
 
 setup(
     name="presidio_anonymizer",

--- a/presidio-anonymizer/setup.py
+++ b/presidio-anonymizer/setup.py
@@ -17,8 +17,8 @@ with open(path.join(this_directory, "README.MD"), encoding="utf-8") as f:
 try:
     with open(os.path.join(parent_directory, "VERSION")) as version_file:
         __version__ = version_file.read().strip()
-except:
-    __version__ = "2.0.0"
+except: #noqa: E722
+    __version__ = os.environ.get("VERSION","0.0.1-alpha")
 
 setup(
     name="presidio_anonymizer",


### PR DESCRIPTION
This PR introduces a simple "good day" scenario for integration of the analyzer and anonymizer packages.

In order to include the packages in the e2e project we had to do a workaround the config.py files, because in the venv context there is no VERSION file. The workaround introduces a fall back in case the VERSION file is not found. In this case we would use an environment variable, and the final fall back is for a default version which is considered pre-release so it wouldn't affect PyPI.
