### PR TITLE
Document dependencies for spark sample 

### DIFF
--- a/docs/samples/deployments/spark/index.md
+++ b/docs/samples/deployments/spark/index.md
@@ -3,6 +3,8 @@
 You can leverages presidio to perform data anonymization as part of spark notebooks.
 The following sample uses [Azure Databricks](https://docs.microsoft.com/en-us/azure/databricks/) and simple text files hosted on [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/). However, it can easily change to fit any other scenario which requires PII analysis or anonymization as part of spark jobs.
 
+**Note** that this code works for Databricks runtime 8.1 (spark 3.1.1) and the libraries described [here](https://docs.microsoft.com/en-us/azure/databricks/release-notes/runtime/8.1).
+
 ## Pre-requisites
 
 Provision and setup the required infrastrucutre

--- a/docs/samples/deployments/spark/presidio_anonymize_blobs.py
+++ b/docs/samples/deployments/spark/presidio_anonymize_blobs.py
@@ -82,17 +82,20 @@ display(input_df)
 # This is due to spacy limitation of loading models in multiple threads as
 # described here: https://github.com/explosion/spaCy/issues/4349
 def anonymize_text(text: str) -> str:
-    analyzer = AnalyzerEngine()
-    anonymizer = AnonymizerEngine()
-    analyzer_results = analyzer.analyze(text=text, language="en")
-    anonymized_results = anonymizer.anonymize(
-        text=text,
-        analyzer_results=analyzer_results,
-        operators={
-            "DEFAULT": AnonymizerConfig("replace", {"new_value": "<ANONYMIZED>"})
-        },
-    )
-    return anonymized_results
+    try:
+        analyzer = AnalyzerEngine()
+        anonymizer = AnonymizerEngine()
+        analyzer_results = analyzer.analyze(text=text, language="en")
+        anonymized_results = anonymizer.anonymize(
+            text=text,
+            analyzer_results=analyzer_results,
+            operators={
+                "DEFAULT": AnonymizerConfig("replace", {"new_value": "<ANONYMIZED>"})
+            },
+        )
+        return anonymized_results.text
+    except Exception as e:
+        print(f"An exception occurred. {e}")
 
 
 def anonymize_series(s: pd.Series) -> pd.Series:


### PR DESCRIPTION
This PR:

* Fixes the script to the API changes of anonymizer where the result text is at anonymized_results.text property.
* Adds a try-except clause for the udf function.
* Adds a note to the sample doc on the spark dependency version.

close #655 
