### PR TITLE
Lock mkdocs-material version

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,5 +1,5 @@
 mkdocs
-mkdocs-material
+mkdocs-material==7.0.6
 mkdocs-jupyter
 pymdown-extensions
 markdown


### PR DESCRIPTION
Latest version breaks docs release with:
`jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'toggle'`