### PR TITLE
Add operators dynamically

### DIFF
--- a/presidio-anonymizer/presidio_anonymizer/anonymizer_engine.py
+++ b/presidio-anonymizer/presidio_anonymizer/anonymizer_engine.py
@@ -6,7 +6,7 @@ from presidio_anonymizer.core.engine_base import EngineBase
 from presidio_anonymizer.entities.engine import OperatorConfig
 from presidio_anonymizer.entities.engine import RecognizerResult
 from presidio_anonymizer.entities.engine.result import EngineResult
-from presidio_anonymizer.operators import OperatorType
+from presidio_anonymizer.operators import OperatorType, Operator, OperatorsFactory
 
 DEFAULT = "replace"
 
@@ -49,7 +49,7 @@ class AnonymizerEngine(EngineBase):
         return self._operate(text, analyzer_results, operators, OperatorType.Anonymize)
 
     def _remove_conflicts_and_get_text_manipulation_data(self, analyzer_results: List[
-            RecognizerResult]) -> List[RecognizerResult]:
+        RecognizerResult]) -> List[RecognizerResult]:
         """
         Iterate the list and create a sorted unique results list from it.
 
@@ -80,6 +80,12 @@ class AnonymizerEngine(EngineBase):
         """Return a list of supported anonymizers."""
         names = [p for p in self.operators_factory.get_anonymizers().keys()]
         return names
+
+    def add_anonymizer(self, operator: Operator) -> None:
+        self.operators_factory.add_operator(operator, OperatorType.Anonymize)
+
+    def remove_anonymizer(self, operator_name: str) -> None:
+        self.operators_factory.remove_operator(operator_name, OperatorType.Anonymize)
 
     @staticmethod
     def __is_result_conflicted_with_other_elements(other_elements, result):

--- a/presidio-anonymizer/presidio_anonymizer/deanonymize_engine.py
+++ b/presidio-anonymizer/presidio_anonymizer/deanonymize_engine.py
@@ -6,7 +6,7 @@ from presidio_anonymizer.core.engine_base import EngineBase
 from presidio_anonymizer.entities.engine import OperatorConfig
 from presidio_anonymizer.entities.engine.anonymizer_result import AnonymizerResult
 from presidio_anonymizer.entities.engine.result.engine_result import EngineResult
-from presidio_anonymizer.operators import OperatorType
+from presidio_anonymizer.operators import OperatorType, Operator
 
 
 class DeanonymizeEngine(EngineBase):
@@ -35,3 +35,9 @@ class DeanonymizeEngine(EngineBase):
         """Return a list of supported deanonymizers."""
         names = [p for p in self.operators_factory.get_deanonymizers().keys()]
         return names
+
+    def add_deanonymizer(self, operator: Operator) -> None:
+        self.operators_factory.add_operator(operator, OperatorType.Deanonymize)
+
+    def remove_deanonymizer(self, operator_name: str) -> None:
+        self.operators_factory.remove_operator(operator_name, OperatorType.Deanonymize)

--- a/presidio-anonymizer/presidio_anonymizer/operators/__init__.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/__init__.py
@@ -1,19 +1,7 @@
 """Initializing all the existing anonymizers."""
 from .operator import OperatorType, Operator
-from .hash import Hash
-from .mask import Mask
-from .redact import Redact
-from .replace import Replace
-from .encrypt import Encrypt
-from .decrypt import Decrypt
 from .operators_factory import OperatorsFactory
 
 __all__ = ["OperatorType",
            "Operator",
-           "Hash",
-           "Mask",
-           "Redact",
-           "Replace",
-           "Encrypt",
-           "Decrypt",
            "OperatorsFactory"]


### PR DESCRIPTION
THIS IS A PREVIEW FOR THE MEETING ON MONDAY, NO CODE REVIEW IS NEEDED.
Remove operators from the __init__ file and make sure they are loaded when setting up the anonymizers and deanonymizers dictionaries.
Add dynamic add of operators, so when someone is using the python package, he can access the anonymizer/deanonymizer engine and add_anonymizer/deanonymizer and remove_anonymizer/deanonymizer