### PR TITLE
Add Text Analytics Recognizer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
         - NAME=presidio-analyzer
     environment:
       - PORT=5001
+      - TEXT_ANALYTICS_KEY=${TEXT_ANALYTICS_KEY}
+      - TEXT_ANALYTICS_ENDPOINT=${TEXT_ANALYTICS_ENDPOINT}
     ports:
       - "5002:5001"
   presidio-image-redactor:

--- a/presidio-analyzer/Pipfile
+++ b/presidio-analyzer/Pipfile
@@ -10,9 +10,13 @@ tldextract = "*"
 numpy = "==1.19.3"
 flask = "==1.1.2"
 pyyaml = "*"
+azure-ai-textanalytics = "==5.1.0b3"
 
 [dev-packages]
 pytest = "*"
 flake8= {version = "==3.7.9"}
 pep8-naming = "*"
 flake8-docstrings = "*"
+
+[pipenv]
+allow_prereleases = true

--- a/presidio-analyzer/Pipfile.lock
+++ b/presidio-analyzer/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ac76d269f83d5991331e8a444f7b23a17330915301e4cd733ddb24d50cf9646d"
+            "sha256": "7e25e1e1d241c8a2cea9d2d231b99114ec3ac8e02134e35feaeeb8a633755a01"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,6 +14,28 @@
         ]
     },
     "default": {
+        "azure-ai-textanalytics": {
+            "hashes": [
+                "sha256:87d57156b9831398d269066b9dcf6c4ca13434e619992669edb33588406b1a1e",
+                "sha256:fe2617f2d6d0f10ae40eaadadd52cea17d644b47d6441281122e94292b99adb0"
+            ],
+            "index": "pypi",
+            "version": "==5.1.0b3"
+        },
+        "azure-common": {
+            "hashes": [
+                "sha256:426673962740dbe9aab052a4b52df39c07767decd3f25fdc87c9d4c566a04934",
+                "sha256:9f3f5d991023acbd93050cf53c4e863c6973ded7e236c69e99c8ff5c7bad41ef"
+            ],
+            "version": "==1.1.27"
+        },
+        "azure-core": {
+            "hashes": [
+                "sha256:3c886a5c6e0698360826c08b2685965d8c23e1292c32be9028ce2fa691005849",
+                "sha256:624b46db407dbed9e03134ab65214efab5b5315949a1fbd6cd592c46fb272588"
+            ],
+            "version": "==1.13.0"
+        },
         "blis": {
             "hashes": [
                 "sha256:168fd7bd763ebe529aa25a066d3a6b89f4c3f492f6297f881df6942741b95787",
@@ -34,11 +56,11 @@
         },
         "catalogue": {
             "hashes": [
-                "sha256:0d01077dbfca7aa53f3ef4adecccce636bce4f82e5b52237703ab2f56478e56e",
-                "sha256:8919341b5ed6ac922f4512925e4eadf36b7ece22f94d56691de658ec0dc61e52"
+                "sha256:887d8a579f7e9e7a6ec424212931ad367a5e6c09e01dfa3eb398ac3b3a2765ba",
+                "sha256:ea9626fe3dffe2c17c2e8dad9edf689acb08b980babfa96f698687305cc0a194"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.0.1"
+            "version": "==2.0.3"
         },
         "certifi": {
             "hashes": [
@@ -93,7 +115,7 @@
                 "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf",
                 "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"
             ],
-            "markers": "python_version < '3.7' and python_version < '3.7'",
+            "markers": "python_version < '3.7'",
             "version": "==0.8"
         },
         "filelock": {
@@ -142,11 +164,18 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:c9db46394197244adf2f0b08ec5bc3cf16757e9590b02af1fca085c16c0d600a",
-                "sha256:d2d46ef77ffc85cbf7dac7e81dd663fde71c45326131bea8033b9bad42268ebe"
+                "sha256:19192b88d959336bfa6bdaaaef99aeafec179eca19c47c804e555703ee5f07ef",
+                "sha256:2e881981c9748d7282b374b68e759c87745c25427b67ecf0cc67fb6637a1bff9"
             ],
-            "markers": "python_version < '3.8' and python_version < '3.8'",
-            "version": "==3.10.0"
+            "markers": "python_version < '3.8'",
+            "version": "==4.0.0"
+        },
+        "isodate": {
+            "hashes": [
+                "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8",
+                "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"
+            ],
+            "version": "==0.6.0"
         },
         "itsdangerous": {
             "hashes": [
@@ -222,6 +251,13 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
+        "msrest": {
+            "hashes": [
+                "sha256:72661bc7bedc2dc2040e8f170b6e9ef226ee6d3892e01affd4d26b06474d68d8",
+                "sha256:c840511c845330e96886011a236440fafc2c9aff7b2df9c0a92041ee2dee3782"
+            ],
+            "version": "==0.6.21"
+        },
         "murmurhash": {
             "hashes": [
                 "sha256:023391cfefe584ac544c1ea0936976c0119b17dd27bb8280652cef1704f76428",
@@ -283,6 +319,14 @@
             ],
             "index": "pypi",
             "version": "==1.19.3"
+        },
+        "oauthlib": {
+            "hashes": [
+                "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889",
+                "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==3.1.0"
         },
         "packaging": {
             "hashes": [
@@ -355,7 +399,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pyyaml": {
@@ -455,12 +499,20 @@
             ],
             "version": "==1.5.1"
         },
+        "requests-oauthlib": {
+            "hashes": [
+                "sha256:7f71572defaecd16372f9006f33c2ec8c077c3cfa6f5911a9a90202beb513f3d",
+                "sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a",
+                "sha256:fa6c47b933f01060936d87ae9327fead68768b69c6c9ea2109c48be30f2d4dbc"
+            ],
+            "version": "==1.3.0"
+        },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "smart-open": {
@@ -499,41 +551,41 @@
         },
         "srsly": {
             "hashes": [
-                "sha256:0d8ac57ee64bbb2f04af9680eea577e1f31c9804c334f25fab8bd074e51e5ae4",
-                "sha256:3fdaa7bbbfd930da28bbbfdddd31bf40e712bcd217f4534c8e56c47141bc8536",
-                "sha256:4ec1f3ada5873fd99c71ecaf6daf5bf9c5c9fb30bac90f1658d3f8a017cff98a",
-                "sha256:5951ff0da7f20b5898fd788e9eaf0aa52a5fbf8f4208e3372bcde984a129335b",
-                "sha256:6f8c8f72d2877a20ffe20baf587d21d9ed6e9fae5531ecc513e2411369d534a1",
-                "sha256:81aa16f3cf7c7766a5b13e5daf25d729348067bc70c44c41f6a2bcf0b150dff5",
-                "sha256:9e55364151efaeb2811fc8dd222ece154cb74ababa57e878487b001c3ff2f8f6",
-                "sha256:b5c087dcf9f9113d588ee5f24f00581ef7f561353eb5784a431dbb0ee9bfe3bd",
-                "sha256:c851d0644083a9607fbe343372d355a4ab6093348b119f5c870050911ffd7f41",
-                "sha256:d49461cd7f4a6461fe850cf9cae24e1f415d64c73fdcbe8f45a1d9c53caf7d5d",
-                "sha256:e29730be53015970e4a59050e8e9f9be44d762108a617df56c9dfc981b515ab7",
-                "sha256:e9da4e425e754ce3eafbc5aea73af4c60e5a700f454be720ee2349cf4f59a8dd",
-                "sha256:efa6977dc98069d5731e929d7c121bbe9764bcd39b44a232f600a81bcae0983e"
+                "sha256:129c85db752b5945c6398a1952294e03b7d20fa111eb7fd1083c4a6b1d02f7c7",
+                "sha256:178aa6d350c9cfedb8adadb5e1f96b7aadde203d088917063415fcd689eb6e42",
+                "sha256:20f11d5d6ae29e3cc97e93c862d7bf8b75023668daf1ac5892598c512302e5d3",
+                "sha256:76b11e0ec0056bda4ad009b6e0db37f3ad0005a0501d587080023d4312ad2ada",
+                "sha256:867d1154ff7b60043584fe048de9b6d9a7d5a7fc61437850922ae4bd46d3be16",
+                "sha256:869fdcf664edf20cd374cf1add869d67960061276478025a5887e080d8f99e1c",
+                "sha256:9625a584b26e522b6afb7c24be8783228ff44d7ac624e500020b0b888e09c6b6",
+                "sha256:b0f2aec0a329e6e7e742a0a60e99a74968ca29be71f35c5c4de221e328176926",
+                "sha256:b1bd4a55bafbb8cf86be15bf18aa2ba2c953161ad71ce7d2dae0c141201a7d89",
+                "sha256:cefe06912f3944b5729d555ee110f434a0787843c6676b90f4987ff7a0a69500",
+                "sha256:e896d516ca2e2e89cc01df8c9c8b1528701d6f49e9c814332582cc701af64a91",
+                "sha256:f7c3374184bfb1aa852bcb8e45747b02f2dde0ebe62b4ddf4b0141affeab32e1",
+                "sha256:ff36dc01df8890a239e5d15cffa3ae3b272c19e5ae279840f2d30085d361c20a"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.4.0"
+            "version": "==2.4.1"
         },
         "thinc": {
             "hashes": [
-                "sha256:0db31c19f98465c1c5dce67ed383a561d51e09f575cd4f8046dc29df02e97dc0",
-                "sha256:20f033b3d9fbd02389d8f828cebcd3a42aee3e17ed4c2d56c6d5163af83a9cee",
-                "sha256:23aed2233366f49ac248147bade29d414551768ed7b56f65f20867558694c346",
-                "sha256:3044bcbf81f5590866bb4cbfd209a58ff3a4eb291f61630e80108bfbe7b9ca5f",
-                "sha256:3be782345d41f3ceb06b53151e29e7499709d21cc9c19413ac4a1971a8d2d8d6",
-                "sha256:3dd32d67193ab8cc0a24737070fd63c7cc061d3066c30dbb392ffcbd0b0dbd61",
-                "sha256:4eba56f8f6b029e971469b76ea397175f7c4643258a58af9715640a44a5e78e0",
-                "sha256:4f136f417b805fb862062dcdad8a10cf00ff73932a2357763af206deb3e0ba8a",
-                "sha256:53bb0ebc1203ccb3ede90470f9bf41aea6e20568671e5f1a3f1a5345d46a3a28",
-                "sha256:a79dc4f5a5c35952619d3ccbe146564c2d6e01dec8e324f5716d8c4c39073153",
-                "sha256:ada393f7d2a4e888083f404f33a441b0e4bbed82493fc101691448495641c3c0",
-                "sha256:b69a15f103afae7c7176bcc750ebfced50225ee499362f2fc37ec4add967f1b3",
-                "sha256:cdb4defa3085f939805b3b3edead79d66f318a58bd86eb6ea647e7154f5b5f6e"
+                "sha256:0a08043a664448a3768f68221ce2a60f331b730aa32d15372e07f3d90bf49765",
+                "sha256:2e20d73a800afa5c9b7d41d589f086fc4c776dc9d7024f5ca9c67332bb50b6c8",
+                "sha256:40db2225cd7994372b7748d2be542e206f85d82d950e54fc42dac460795af124",
+                "sha256:72d04d1c0791ad067f9b215d7c0eccda9376079b8b7170a1d834f68b3a0b1cd5",
+                "sha256:739b5e454d5670d228ad62721d0037b0e6cab53adc8b499dcaf6167213690d2a",
+                "sha256:7c30ec3a30125bbffb877ab94792b14807fce1d94a15c8affc0ddfdb7e849ab0",
+                "sha256:a625900fdb978e8834eabf68be099cdb487bf637c98c8fe8161a1b6e41def5b7",
+                "sha256:aa5f64c45067a762d624dfeff5f6a9e7f2cb0d484fe5f0054b77deb7089a9cfb",
+                "sha256:bd87496ceab914fb0fd646b7ef8542f4c379e76e9dc5271768d089acc7b70d54",
+                "sha256:c370a7a46d01b588d8d5f99d8d5e36b3cbac4512638356fa430f7f52bb3a8897",
+                "sha256:c842d9432018564f8289ac19fb71ed9311a13b9a002ef88f92373158329f45a4",
+                "sha256:ddf994fac571e657091c78d4fa5b99c18950d683250226b8be72a212f16f8e0a",
+                "sha256:e9a07b1f1ddca26b5594234cbe9015b055d95b2e10796c66182030282e2f485b"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.0.2"
+            "version": "==8.0.3"
         },
         "tldextract": {
             "hashes": [
@@ -565,7 +617,7 @@
                 "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
                 "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
-            "markers": "python_version < '3.8' and python_version < '3.8'",
+            "markers": "python_version < '3.8'",
             "version": "==3.7.4.3"
         },
         "urllib3": {
@@ -596,7 +648,7 @@
                 "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
                 "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_version < '3.8'",
             "version": "==3.4.1"
         }
     },
@@ -642,11 +694,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:c9db46394197244adf2f0b08ec5bc3cf16757e9590b02af1fca085c16c0d600a",
-                "sha256:d2d46ef77ffc85cbf7dac7e81dd663fde71c45326131bea8033b9bad42268ebe"
+                "sha256:19192b88d959336bfa6bdaaaef99aeafec179eca19c47c804e555703ee5f07ef",
+                "sha256:2e881981c9748d7282b374b68e759c87745c25427b67ecf0cc67fb6637a1bff9"
             ],
-            "markers": "python_version < '3.8' and python_version < '3.8'",
-            "version": "==3.10.0"
+            "markers": "python_version < '3.8'",
+            "version": "==4.0.0"
         },
         "iniconfig": {
             "hashes": [
@@ -723,7 +775,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
@@ -746,7 +798,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "typing-extensions": {
@@ -755,7 +807,7 @@
                 "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
                 "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
-            "markers": "python_version < '3.8' and python_version < '3.8'",
+            "markers": "python_version < '3.8'",
             "version": "==3.7.4.3"
         },
         "zipp": {
@@ -763,7 +815,7 @@
                 "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
                 "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_version < '3.8'",
             "version": "==3.4.1"
         }
     }

--- a/presidio-analyzer/conf/text_analytics_entity_categories.yaml
+++ b/presidio-analyzer/conf/text_analytics_entity_categories.yaml
@@ -1,0 +1,11 @@
+- name: DateTime
+  entity_type: DATE_TIME
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+- name: Email
+  entity_type: EMAIL_ADDRESS
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+- name: Quantity
+  subcategory: Age
+  entity_type: AGE
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+

--- a/presidio-analyzer/conf/text_analytics_entity_categories.yaml
+++ b/presidio-analyzer/conf/text_analytics_entity_categories.yaml
@@ -11,5 +11,70 @@
 - name: EU Passport Number
   entity_type: PASSPORT_NUMBER
   languages: [en, es, fr, de, it, pt-pt]
-
-
+- name: Person
+  entity_type: PERSON
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+- name: Address
+  entity_type: LOCATION
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+- name: DateTime
+  entity_type: DATE
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+- name: DateTime
+  subcategory: Time
+  entity_type: DATE_TIME
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+- name: DateTime
+  subcategory: Date
+  entity_type: DATE_TIME
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+- name: DateTime
+  subcategory: DateRange
+  entity_type: DATE_TIME
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+- name: Date
+  entity_type: DATE_TIME
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+- name: Phone Number
+  entity_type: PHONE_NUMBER
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt pt-br]
+- name: Organization
+  entity_type: ORGANIZATION
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+- name: PersonType
+  entity_type: PROFESSION
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+- name: Credit Card Number
+  entity_type: CREDIT_CARD
+  languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+# Identification numbers
+- name: EU Tax Identification Number (TIN)
+  entity_type: IDNUM
+  languages: [en, es, fr, de, it, pt-pt]
+- name: EU Social Security Number (SSN)
+  entity_type: IDNUM
+  languages: [en, es, fr, de, it, pt-pt]
+- name: EU passport number
+  entity_type: IDNUM
+  languages: [en, es, fr, de, it, pt-pt]
+- name: EU national identification number
+  entity_type: IDNUM
+  languages: [en, es, fr, de, it, pt-pt]
+- name: EU GPU coordinates
+  entity_type: IDNUM
+  languages: [en, es, fr, de, it, pt-pt]
+- name: U.S. Social Security Number (SSN)
+  entity_type: IDNUM
+  languages: [en]
+- name: U.S. or U.K. Passport Number
+  entity_type: IDNUM
+  languages: [en]
+- name: U.S. Individual Taxpayer Identification Number (ITIN)
+  entity_type: IDNUM
+  languages: [en]
+- name: U.S. Drug Enforcement Agency (DEA) Number
+  entity_type: IDNUM
+  languages: [en]
+- name: U.S. Bank Account Number
+  entity_type: IDNUM
+  languages: [en]

--- a/presidio-analyzer/conf/text_analytics_entity_categories.yaml
+++ b/presidio-analyzer/conf/text_analytics_entity_categories.yaml
@@ -8,4 +8,8 @@
   subcategory: Age
   entity_type: AGE
   languages: [en, es, fr, de, it, zh-hans, ja, ko, pt-pt, pt-br]
+- name: EU Passport Number
+  entity_type: PASSPORT_NUMBER
+  languages: [en, es, fr, de, it, pt-pt]
+
 

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
@@ -10,6 +10,7 @@ from .ip_recognizer import IpRecognizer
 from .sg_fin_recognizer import SgFinRecognizer
 from .spacy_recognizer import SpacyRecognizer
 from .stanza_recognizer import StanzaRecognizer
+from .text_analytics_recognizer import TextAnalyticsRecognizer
 from .uk_nhs_recognizer import NhsRecognizer
 from .us_bank_recognizer import UsBankRecognizer
 from .us_driver_license_recognizer import UsLicenseRecognizer
@@ -43,4 +44,5 @@ __all__ = [
     "SpacyRecognizer",
     "StanzaRecognizer",
     "NLP_RECOGNIZERS",
+    "TextAnalyticsRecognizer",
 ]

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/text_analytics_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/text_analytics_recognizer.py
@@ -1,0 +1,173 @@
+import logging
+import os
+from pathlib import Path
+from typing import List
+
+import yaml
+
+from presidio_analyzer import (
+    RecognizerResult,
+    RemoteRecognizer,
+    AnalysisExplanation,
+)
+from presidio_analyzer.nlp_engine import NlpArtifacts
+from presidio_analyzer.text_analytics_entity_category import TextAnalyticsEntityCategory
+from azure.core.credentials import AzureKeyCredential
+from azure.ai.textanalytics import TextAnalyticsClient
+
+logger = logging.getLogger("presidio-analyzer")
+
+
+class TextAnalyticsRecognizer(RemoteRecognizer):
+    """
+    Recognize PII entities using a remote Text Analytics Server.
+
+    Using an existing instance of Text Analytics, this recognizer recognizes multiple
+     PIIs from a fixed list,
+    https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/named-entity-types?tabs=personal
+    and replaces their types to align with Presidio's.
+
+    :param supported_language: Language this recognizer supports
+    :param text_analytics_key: The key used to authenticate to Text Analytics Azure
+        Instance. If not passed will be evaluated from the TEXT_ANALYTICS_KEY
+        environment variable, where its existence will determine the if this
+        recognizer is enabled.
+    :param text_analytics_endpoint: Supported Cognitive Services or Text Analytics
+        resource endpoints (protocol and hostname). If not passed will be evaluated
+        from the TEXT_ANALYTICS_ENDPOINT environment variable, where its existence
+        will determine if this recognizer is enabled.
+    :param text_analytics_categories: The categories supported by this recognizers,
+        their languages and their corresponding Presidio entity type. If not passed,
+        will be loaded with the default list in 'text_analytics_entity_categories.yaml'
+        file.
+    """
+
+    def __init__(
+        self,
+        supported_language: str = "en",
+        text_analytics_key: str = os.environ.get("TEXT_ANALYTICS_KEY"),
+        text_analytics_endpoint: str = os.environ.get("TEXT_ANALYTICS_ENDPOINT"),
+        text_analytics_categories: List[TextAnalyticsEntityCategory] = None,
+    ):
+        self.supported_language = supported_language
+        self.text_analytics_key = text_analytics_key
+        self.text_analytics_endpoint = text_analytics_endpoint
+        self.text_analytics_categories = text_analytics_categories
+        self.text_analytics_client = None
+        self.enabled = (
+            self.text_analytics_key and self.text_analytics_endpoint
+        ) is not None
+        if self.enabled and not self.text_analytics_categories:
+            self.text_analytics_categories = self._get_default_categories()
+
+        super().__init__(
+            supported_entities=self.get_supported_entities(),
+            supported_language=supported_language,
+            name="Text Analytics",
+            version="3.1",
+        )
+
+    def load(self):
+        """
+        Initialize the recognizer's Text Analytics Client.
+
+        If the recognizer is enabled (passed with Text Analytics key and endpoint).
+
+        """
+        if self.enabled:
+            logger.info("Loading Text Analytics Recognizer")
+            credential = AzureKeyCredential(self.text_analytics_key)
+            self.text_analytics_client = TextAnalyticsClient(
+                endpoint=self.text_analytics_endpoint, credential=credential
+            )
+
+    def get_supported_entities(self) -> List[str]:
+        """
+        Text Analytics Supported Entities.
+
+        :return: List of the supported entities matching the Text Analytics categories'
+         languages.
+        """
+        return (
+            [
+                category.entity_type
+                for category in self.text_analytics_categories
+                if self.supported_language in category.languages
+            ]
+            if self.enabled
+            else []
+        )
+
+    def analyze(
+        self, text: str, entities: List[str], nlp_artifacts: NlpArtifacts = None
+    ) -> List[RecognizerResult]:
+        """
+        Analyze text using Text Analytics.
+
+        :param text: The text for analysis.
+        :param entities: Not used by this recognizer.
+        :param nlp_artifacts: Not used by this recognizer.
+        :return: The list of Presidio RecognizerResult constructed from the recognized
+            Text Analytics detections.
+        """
+        if self.enabled:
+            result = self.text_analytics_client.recognize_pii_entities(
+                [text], language="en"
+            )
+            category_names = [
+                category.name for category in self.text_analytics_categories
+            ]
+            return [
+                self._convert_to_recognizer_result(categorized_entity)
+                for categorized_entity in result[0].entities
+                if categorized_entity.category in category_names
+            ]
+
+    def _convert_to_recognizer_result(self, categorized_entity):
+        if categorized_entity.subcategory:
+            entity_type = next(
+                filter(
+                    lambda x: categorized_entity.subcategory == x.subcategory
+                    and categorized_entity.category == x.name,
+                    self.text_analytics_categories,
+                )
+            ).entity_type
+        else:
+            entity_type = next(
+                filter(
+                    lambda x: categorized_entity.category == x.name,
+                    self.text_analytics_categories,
+                )
+            ).entity_type
+
+        return RecognizerResult(
+            entity_type=entity_type,
+            start=categorized_entity.offset,
+            end=categorized_entity.offset + len(categorized_entity.text),
+            score=categorized_entity.confidence_score,
+            analysis_explanation=TextAnalyticsRecognizer._build_explanation(
+                original_score=categorized_entity.confidence_score,
+                entity_type=entity_type,
+            ),
+        )
+
+    @staticmethod
+    def _build_explanation(
+        original_score: float, entity_type: str
+    ) -> AnalysisExplanation:
+        explanation = AnalysisExplanation(
+            recognizer=TextAnalyticsRecognizer.__class__.__name__,
+            original_score=original_score,
+            textual_explanation=f"Identified as {entity_type} by Text Analytics",
+        )
+        return explanation
+
+    @staticmethod
+    def _get_default_categories():
+        file_location = Path(
+            Path(__file__).parent.parent.parent,
+            "conf",
+            "text_analytics_entity_categories.yaml",
+        )
+        categories_file = yaml.safe_load(open(file_location))
+        return [TextAnalyticsEntityCategory(**category) for category in categories_file]

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/text_analytics_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/text_analytics_recognizer.py
@@ -111,24 +111,22 @@ class TextAnalyticsRecognizer(RemoteRecognizer):
             Text Analytics detections.
         """
         if self.enabled:
-            result = self.text_analytics_client.recognize_pii_entities(
+            text_analytics_results = self.text_analytics_client.recognize_pii_entities(
                 [text], language="en"
             )
             category_names = [
-                category.name for category in self.text_analytics_categories
+                category.name.lower() for category in self.text_analytics_categories
             ]
-            return [
-                self._convert_to_recognizer_result(categorized_entity)
-                for categorized_entity in result[0].entities
-                if categorized_entity.category in category_names
-            ]
+            converted_results = [self._convert_to_recognizer_result(categorized_entity) for categorized_entity in
+                    text_analytics_results[0].entities if categorized_entity.category.lower() in category_names]
+            return converted_results
 
     def _convert_to_recognizer_result(self, categorized_entity):
         if categorized_entity.subcategory:
             entity_type = next(
                 filter(
                     lambda x: categorized_entity.subcategory == x.subcategory
-                    and categorized_entity.category == x.name,
+                    and categorized_entity.category.lower() == x.name.lower(),
                     self.text_analytics_categories,
                 )
             ).entity_type

--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizer_registry.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizer_registry.py
@@ -21,6 +21,7 @@ from presidio_analyzer.predefined_recognizers import (
     SpacyRecognizer,
     EsNifRecognizer,
     StanzaRecognizer,
+    TextAnalyticsRecognizer,
 )
 
 logger = logging.getLogger("presidio-analyzer")
@@ -75,6 +76,7 @@ class RecognizerRegistry:
                 IbanRecognizer,
                 IpRecognizer,
                 nlp_recognizer,
+                TextAnalyticsRecognizer,
             ],
         }
         for lang in languages:

--- a/presidio-analyzer/presidio_analyzer/text_analytics_entity_category.py
+++ b/presidio-analyzer/presidio_analyzer/text_analytics_entity_category.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class TextAnalyticsEntityCategory:
+    """
+    A Category recognized by Text Analytics 'Named entity recognition and PII'.
+
+    The full list can be found here:
+    https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/named-entity-types?tabs=personal#category-datetime
+    """
+
+    name: str
+    entity_type: str
+    languages: List[str]
+    subcategory: str = None

--- a/presidio-analyzer/setup.py
+++ b/presidio-analyzer/setup.py
@@ -35,6 +35,7 @@ setuptools.setup(
         "regex==2020.11.13",
         "tldextract==3.1.0",
         "pyyaml==5.4.1",
+        "azure-ai-textanalytics==5.1.0b3",
     ],
     include_package_data=True,
     license="MIT",

--- a/presidio-analyzer/tests/test_recognizer_registry.py
+++ b/presidio-analyzer/tests/test_recognizer_registry.py
@@ -52,7 +52,7 @@ def test_when_get_recognizers_then_all_recognizers_returned(mock_recognizer_regi
     registry = mock_recognizer_registry
     registry.load_predefined_recognizers()
     recognizers = registry.get_recognizers(language="en", all_fields=True)
-    # 1 custom recognizer in english + 15 predefined
+    # 1 custom recognizer in english + 16 predefined
     assert len(recognizers) == 1 + 16
 
 

--- a/presidio-analyzer/tests/test_recognizer_registry.py
+++ b/presidio-analyzer/tests/test_recognizer_registry.py
@@ -53,7 +53,7 @@ def test_when_get_recognizers_then_all_recognizers_returned(mock_recognizer_regi
     registry.load_predefined_recognizers()
     recognizers = registry.get_recognizers(language="en", all_fields=True)
     # 1 custom recognizer in english + 15 predefined
-    assert len(recognizers) == 1 + 15
+    assert len(recognizers) == 1 + 16
 
 
 def test_when_get_recognizers_then_return_all_fields(mock_recognizer_registry):


### PR DESCRIPTION
Adds a recognizer integrating with Azure Text Analytics.
It uses a python package serving as a client to a predefined Text Analytics instance. 
If the Text Analytics attributes 'key' and 'endpoints' are set as env. vars., then the recognizer is enabled.
It reads from a predefined categories yaml file, defining the categories supported by presidio and their corresponding Presidio entity types.
The file will be fully populated along with tests for each entity in later PRs.

*Missing tests