### PR TITLE
Add Medical License as a Predefined Recognizer

### DIFF
--- a/docs/api-docs/api-docs.yml
+++ b/docs/api-docs/api-docs.yml
@@ -140,7 +140,7 @@ paths:
               example:
                 [ "PHONE_NUMBER", "US_DRIVER_LICENSE", "US_PASSPORT", "LOCATION", "CREDIT_CARD", "CRYPTO",
                   "UK_NHS", "US_SSN", "US_BANK_NUMBER", "EMAIL_ADDRESS", "DATE_TIME", "IP_ADDRESS", "PERSON", "IBAN_CODE",
-                  "NRP", "US_ITIN", "DOMAIN_NAME" ]
+                  "NRP", "US_ITIN", "DOMAIN_NAME", "MEDICAL_LICENSE" ]
 
   /anonymize:
     post:

--- a/docs/supported_entities.md
+++ b/docs/supported_entities.md
@@ -23,6 +23,7 @@ For more information, refer to the [adding new recognizers documentation](analyz
 |LOCATION|Name of politically or geographically defined location (cities, provinces, countries, international regions, bodies of water, mountains|Custom logic and context|
 |PERSON|A full person name, which can include first names, middle names or initials, and last names.|Custom logic and context|
 |PHONE_NUMBER|A telephone number|Custom logic, pattern match and context|
+|MEDICAL_LICENSE|Common medical license numbers.|Pattern match, context and checksum|
 
 ### USA
 

--- a/e2e-tests/tests/test_analyzer.py
+++ b/e2e-tests/tests/test_analyzer.py
@@ -234,7 +234,7 @@ def test_given_a_correct_input_for_supported_entities_then_expect_a_correct_resp
     expected_response = """
         ["PHONE_NUMBER", "US_DRIVER_LICENSE", "US_PASSPORT", "SG_NRIC_FIN", "LOCATION", "CREDIT_CARD", "CRYPTO", 
         "UK_NHS", "US_SSN", "US_BANK_NUMBER", "EMAIL_ADDRESS", "DATE_TIME", "IP_ADDRESS", "PERSON", "IBAN_CODE", 
-        "NRP", "US_ITIN", "DOMAIN_NAME"]
+        "NRP", "US_ITIN", "DOMAIN_NAME", "MEDICAL_LICENSE"]
     """
     assert response_status == 200
     assert equal_json_strings(expected_response, response_content)
@@ -266,7 +266,7 @@ def test_given_an_illegal_input_for_supported_entities_then_igonre_and_proceed()
     expected_response = """ 
         ["PHONE_NUMBER", "US_DRIVER_LICENSE", "US_PASSPORT", "SG_NRIC_FIN", "LOCATION", "CREDIT_CARD", 
          "CRYPTO", "UK_NHS", "US_SSN", "US_BANK_NUMBER", "EMAIL_ADDRESS", "DATE_TIME", "IP_ADDRESS",
-          "PERSON", "IBAN_CODE", "NRP", "US_ITIN", "DOMAIN_NAME"]
+          "PERSON", "IBAN_CODE", "NRP", "US_ITIN", "DOMAIN_NAME", "MEDICAL_LICENSE"]
     """
     assert response_status == 200
     assert equal_json_strings(expected_response, response_content)

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
@@ -2,13 +2,13 @@
 
 from .aba_routing_recognizer import AbaRoutingRecognizer
 from .credit_card_recognizer import CreditCardRecognizer
-from .certificate_number_recognizer import CertificateNumberRecognizer
 from .crypto_recognizer import CryptoRecognizer
 from .date_recognizer import DateRecognizer
 from .domain_recognizer import DomainRecognizer
 from .email_recognizer import EmailRecognizer
 from .iban_recognizer import IbanRecognizer
 from .ip_recognizer import IpRecognizer
+from .medical_license_recognizer import MedicalLicenseRecognizer
 from .sg_fin_recognizer import SgFinRecognizer
 from .spacy_recognizer import SpacyRecognizer
 from .stanza_recognizer import StanzaRecognizer
@@ -26,7 +26,6 @@ NLP_RECOGNIZERS = {"spacy": SpacyRecognizer, "stanza": StanzaRecognizer}
 __all__ = [
     "AbaRoutingRecognizer",
     "CreditCardRecognizer",
-    "CertificateNumberRecognizer",
     "CryptoRecognizer",
     "DateRecognizer",
     "DomainRecognizer",
@@ -34,6 +33,7 @@ __all__ = [
     "IbanRecognizer",
     "IpRecognizer",
     "NhsRecognizer",
+    "MedicalLicenseRecognizer",
     "SgFinRecognizer",
     "SpacyRecognizer",
     "StanzaRecognizer",

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/medical_license_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/medical_license_recognizer.py
@@ -5,7 +5,7 @@ from presidio_analyzer import Pattern, PatternRecognizer
 # https://www.meditec.com/blog/dea-numbers-what-do-they-mean
 
 
-class CertificateNumberRecognizer(PatternRecognizer):
+class MedicalLicenseRecognizer(PatternRecognizer):
     """
     Recognize common Medical license numbers using regex + checksum.
 
@@ -37,7 +37,7 @@ class CertificateNumberRecognizer(PatternRecognizer):
         patterns: Optional[List[Pattern]] = None,
         context: Optional[List[str]] = None,
         supported_language: str = "en",
-        supported_entity: str = "CERTIFICATE_NUMBER",
+        supported_entity: str = "MEDICAL_LICENSE",
         replacement_pairs: Optional[List[Tuple[str, str]]] = None,
     ):
 

--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizer_registry.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizer_registry.py
@@ -12,6 +12,7 @@ from presidio_analyzer.predefined_recognizers import (
     EmailRecognizer,
     IbanRecognizer,
     IpRecognizer,
+    MedicalLicenseRecognizer,
     NhsRecognizer,
     UsBankRecognizer,
     UsLicenseRecognizer,
@@ -77,6 +78,7 @@ class RecognizerRegistry:
                 EmailRecognizer,
                 IbanRecognizer,
                 IpRecognizer,
+                MedicalLicenseRecognizer,
                 nlp_recognizer,
             ],
         }

--- a/presidio-analyzer/tests/test_certificate_number_recognizer.py
+++ b/presidio-analyzer/tests/test_certificate_number_recognizer.py
@@ -1,17 +1,17 @@
 import pytest
 
 from tests import assert_result
-from presidio_analyzer.predefined_recognizers import CertificateNumberRecognizer
+from presidio_analyzer.predefined_recognizers.medical_license_recognizer import MedicalLicenseRecognizer
 
 
 @pytest.fixture(scope="module")
 def cc_recognizer():
-    return CertificateNumberRecognizer()
+    return MedicalLicenseRecognizer()
 
 
 @pytest.fixture(scope="module")
 def entities():
-    return ["CERTIFICATE_NUMBER"]
+    return ["MEDICAL_LICENSE"]
 
 
 @pytest.mark.parametrize(
@@ -25,7 +25,7 @@ def entities():
         # fmt: on
     ],
 )
-def test_when_all_certificate_number_then_succeed(
+def test_when_all_medical_licence_number_then_succeed(
     text,
     expected_len,
     expected_scores,

--- a/presidio-analyzer/tests/test_recognizer_registry.py
+++ b/presidio-analyzer/tests/test_recognizer_registry.py
@@ -52,8 +52,8 @@ def test_when_get_recognizers_then_all_recognizers_returned(mock_recognizer_regi
     registry = mock_recognizer_registry
     registry.load_predefined_recognizers()
     recognizers = registry.get_recognizers(language="en", all_fields=True)
-    # 1 custom recognizer in english + 16 predefined
-    assert len(recognizers) == 1 + 16
+    # 1 custom recognizer in english + 17 predefined
+    assert len(recognizers) == 1 + 17
 
 
 def test_when_get_recognizers_then_return_all_fields(mock_recognizer_registry):


### PR DESCRIPTION
## Change Description

Change the name of 'CertificateNumberRecognizer' to 'MedicalLicenseRecognizer'. 
Add it as a default predefined recognizer.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
