### PR TITLE
Update phone_recognizer.py

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/phone_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/phone_recognizer.py
@@ -21,7 +21,7 @@ class PhoneRecognizer(LocalRecognizer):
 
     SCORE = 0.6
     CONTEXT = ["phone", "number", "telephone", "cell", "cellphone", "mobile", "call"]
-    DEFAULT_SUPPORTED_COUNTRY_CODES = ("US", "UK", "DE", "FE", "IL")
+    DEFAULT_SUPPORTED_COUNTRY_CODES = ["US", "UK", "DE", "FE", "IL"]
 
     def __init__(
         self,


### PR DESCRIPTION
## Change Description

When only one country code is used, such as CN, supported_entities will be parsed as "C" and "N", so DEFAULT_SUPPORTED_ COUNTRY_ CODE  should be array

## Issue reference

This PR fixes issue #XX

## Checklist

- [ ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
