### PR TITLE
Relaxing regex dependency requirement

### DIFF
--- a/presidio-analyzer/setup.py
+++ b/presidio-analyzer/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     tests_require=["pytest", "flake8==3.7.9"],
     install_requires=[
         "spacy==3.0.6",
-        "regex==2020.11.13",
+        "regex>=2020.11.13",
         "tldextract==3.1.0",
         "pyyaml==5.4.1",
         "pydantic==1.7.4",


### PR DESCRIPTION
## Change Description

Changing regex dependency requirement to more relax one ie `regex>=2020.11.13`

## Issue reference

This PR fixes issue #780

## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [X] I have signed the CLA
- [ ] My code includes unit tests: NA
- [X] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required: NA
