### PR TITLE
Optimize the Dockerfiles

### DIFF
--- a/presidio-analyzer/Dockerfile
+++ b/presidio-analyzer/Dockerfile
@@ -3,11 +3,12 @@ FROM python:3.9-slim
 ARG NAME
 ARG NLP_CONF_FILE=conf/default.yaml
 ENV PIPENV_VENV_IN_PROJECT=1
+ENV PIP_NO_CACHE_DIR=1
 WORKDIR /usr/bin/${NAME}
 
 COPY ./Pipfile* /usr/bin/${NAME}/
-RUN pip install pipenv
-RUN pipenv sync
+RUN pip install pipenv \
+  && pipenv sync
 # install nlp models specified in conf/default.yaml
 COPY ./install_nlp_models.py /usr/bin/${NAME}/
 COPY ${NLP_CONF_FILE} /usr/bin/${NAME}/${NLP_CONF_FILE}

--- a/presidio-anonymizer/Dockerfile
+++ b/presidio-anonymizer/Dockerfile
@@ -2,11 +2,12 @@ FROM python:3.9-slim
 
 ARG NAME
 ENV PIPENV_VENV_IN_PROJECT=1
+ENV PIP_NO_CACHE_DIR=1
 WORKDIR /usr/bin/${NAME}
 
 COPY ./Pipfile* /usr/bin/${NAME}/
-RUN pip install pipenv
-RUN pipenv sync
+RUN pip install pipenv \
+  && pipenv sync
 
 COPY . /usr/bin/${NAME}/
 

--- a/presidio-image-redactor/Dockerfile
+++ b/presidio-image-redactor/Dockerfile
@@ -2,17 +2,18 @@ FROM python:3.8-slim
 
 ARG NAME
 ENV PIPENV_VENV_IN_PROJECT=1
+ENV PIP_NO_CACHE_DIR=1
 WORKDIR /usr/bin/${NAME}
 
-RUN apt-get update 
-RUN apt-get install tesseract-ocr -y 
-RUN tesseract -v
+RUN apt-get update \
+  && apt-get install tesseract-ocr -y \
+  && rm -rf /var/lib/apt/lists/* \
+  && tesseract -v
 
 COPY ./Pipfile* /usr/bin/${NAME}/
-RUN pip install pipenv
-RUN pipenv sync
-
-RUN pipenv run python -m spacy download en_core_web_lg
+RUN pip install pipenv \
+  && pipenv sync \
+  && pipenv run python -m spacy download en_core_web_lg
 
 COPY . /usr/bin/${NAME}/
 EXPOSE ${PORT}


### PR DESCRIPTION
## Change Description

This PR optimizes the Dockerfiles so that the final build image size is reduced. The big size is mostly caused by the `en_core_web_lg` package is being cached on `/root/.cache`. So by adding `ENV PIP_NO_CACHE_DIR=1`, the pip will not cache it anymore, reducing the image size.

I also merge some RUN commands into one RUN, so that it results to 1 layer instead of many layers.

```
                         BEFORE   AFTER
presidio-analyzer        2.1GB    1.26GB
presidio-anonymizer      212MB    196MB
presidio-image-redactor  2.34GB   1.46GB
```

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
