### PR TITLE
Pass `nlp_engine` down to `NlpArtifacts`

### DIFF
--- a/presidio-analyzer/presidio_analyzer/nlp_engine/nlp_artifacts.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/nlp_artifacts.py
@@ -26,6 +26,7 @@ class NlpArtifacts:
         self.lemmas = lemmas
         self.tokens_indices = tokens_indices
         self.keywords = self.set_keywords(nlp_engine, lemmas, language)
+        self.nlp_engine = nlp_engine
 
     @staticmethod
     def set_keywords(

--- a/presidio-analyzer/presidio_analyzer/nlp_engine/nlp_artifacts.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/nlp_artifacts.py
@@ -62,6 +62,9 @@ class NlpArtifacts:
 
         return_dict = self.__dict__.copy()
 
+        # Ignore NLP engine as it's not serializable currently
+        del return_dict['nlp_engine']
+
         # Converting spaCy tokens and spans to string as they are not serializable
         if "tokens" in return_dict:
             return_dict["tokens"] = [token.text for token in self.tokens]


### PR DESCRIPTION
## Change Description

Adding the `nlp_engine` object to `NlpArtifacts`.

This is helpful when we need access to the original `nlp_engine` object.

One use case is we add a custom recognizer to use [`PhraseMatcher` from spaCy](https://spacy.io/api/phrasematcher). We can initialize the recognizer with the `PhraseMatcher` object, and use the `nlp` object to run the spaCy pipeline (with the matcher).

## Issue reference

n/a

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
