### PR TITLE
fixed analysis explanation having the wrong score after validation

### DIFF
--- a/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
@@ -217,6 +217,9 @@ class PatternRecognizer(LocalRecognizer):
                 if pattern_result.score > EntityRecognizer.MIN_SCORE:
                     results.append(pattern_result)
 
+                # Update analysis explanation score following validation or invalidation
+                description.score = pattern_result.score
+
         results = EntityRecognizer.remove_duplicates(results)
         return results
 

--- a/presidio-analyzer/tests/test_pattern_recognizer.py
+++ b/presidio-analyzer/tests/test_pattern_recognizer.py
@@ -1,10 +1,13 @@
+from typing import List
+
 import pytest
+
+from presidio_analyzer import Pattern, RecognizerResult
+from presidio_analyzer import PatternRecognizer
 
 # https://www.datatrans.ch/showcase/test-cc-numbers
 # https://www.freeformatter.com/credit-card-number-generator-validator.html
 from tests import assert_result
-from presidio_analyzer import Pattern
-from presidio_analyzer import PatternRecognizer
 
 
 class MockRecognizer(PatternRecognizer):
@@ -105,3 +108,22 @@ def test_when_taken_from_dict_then_returns_instance():
     assert pattern_recognizer.patterns[1].name == "p2"
     assert pattern_recognizer.patterns[1].score == 0.8
     assert pattern_recognizer.patterns[1].regex == "([0-9]{1,9})"
+
+
+def test_when_validation_occurs_then_analysis_explanation_is_updated():
+
+    patterns = [Pattern(name="test_pattern", regex="([0-9]{1,9})", score=0.5)]
+    mock_recognizer = MockRecognizer(
+        entity="TEST",
+        patterns=patterns,
+        deny_list=None,
+        name="MockRecognizer",
+        context=None,
+    )
+
+    results: List[RecognizerResult] = mock_recognizer.analyze(
+        text="Testing 1 2 3", entities=["TEST"]
+    )
+
+    assert results[0].analysis_explanation.original_score == 0.5
+    assert results[0].analysis_explanation.score == 1


### PR DESCRIPTION
## Change Description

When detecting pattern based recognizer using the `PatternRecognizer` class, the `AnalysisExplanation` object now holds the updated score after validation/invalidation

## Issue reference

This PR fixes issue #847 

## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [X] I have signed the CLA
- [X] My code includes unit tests
- [X] All unit tests and lint checks pass locally
- [X] My PR contains documentation updates / additions if required
