### PR TITLE
Fixed typo in documentation

### DIFF
--- a/docs/tutorial/04_external_services.md
+++ b/docs/tutorial/04_external_services.md
@@ -13,5 +13,5 @@ In a similar way to example 3, we can write logic to call external services for 
 
 ## Calling a model in a different framework
 
-- [This example](../samples/python/flair_recognizer.py) shows a Presidio wraper for a Flair model.
+- [This example](../samples/python/flair_recognizer.py) shows a Presidio wrapper for a Flair model.
 - Using a similar approach, we could create wrappers for HuggingFace models, Conditional Random Fields or any other framework.


### PR DESCRIPTION
Fixed typo in the word 'wrapper'.

## Change Description

In the project documentation under:

`Step by step tutorial/External services/Calling a model in a different framework`

Changed word _wraper_ to _wrapper_.

## Issue reference

This PR does not fix an open issue.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
