### PR TITLE
Fix getting the text before anonymizing

### DIFF
--- a/presidio-anonymizer/presidio_anonymizer/core/text_replace_builder.py
+++ b/presidio-anonymizer/presidio_anonymizer/core/text_replace_builder.py
@@ -11,6 +11,7 @@ class TextReplaceBuilder:
         self.logger = logging.getLogger("presidio-anonymizer")
         self.__validate_text_not_empty(original_text)
         self.output_text = original_text
+        self.original_text = original_text
         self.text_len = len(original_text)
         self.last_replacement_index = self.text_len
 
@@ -28,7 +29,7 @@ class TextReplaceBuilder:
         :return: str - part of the original text
         """
         self.__validate_position_in_text(start, end)
-        return self.output_text[start:end]
+        return self.original_text[start:end]
 
     def replace_text_get_insertion_index(
         self, replacement_text: str, start: int, end: int

--- a/presidio-anonymizer/tests/test_anonymizer_engine.py
+++ b/presidio-anonymizer/tests/test_anonymizer_engine.py
@@ -45,6 +45,16 @@ def test_given_empty_anonymziers_list_then_we_fall_to_default():
     assert result == "please <SSN>."
 
 
+def test_given_custom_anonymizer_then_we_manage_to_anonymize_successfully():
+    engine = AnonymizerEngine()
+    text = "Fake card number 4151 3217 6243 3448.com that overlaps with nonexisting URL."
+    analyzer_result = RecognizerResult("CREDIT_CARD", 17, 36, 0.8)
+    analyzer_result2 = RecognizerResult("URL", 32, 40, 0.8)
+    anonymizer_config = OperatorConfig("custom", {"lambda": lambda x: f"<ENTITY: {x}>"})
+    result = engine.anonymize(text, [analyzer_result, analyzer_result2], {"DEFAULT": anonymizer_config}).text
+    assert result == "Fake card number <ENTITY: 4151 3217 6243 3448><ENTITY: 3448.com> that overlaps with nonexisting URL."
+
+
 def test_given_none_as_anonymziers_list_then_we_fall_to_default():
     engine = AnonymizerEngine()
     text = "please REPLACE ME."

--- a/presidio-anonymizer/tests/test_anonymizer_engine.py
+++ b/presidio-anonymizer/tests/test_anonymizer_engine.py
@@ -47,12 +47,19 @@ def test_given_empty_anonymziers_list_then_we_fall_to_default():
 
 def test_given_custom_anonymizer_then_we_manage_to_anonymize_successfully():
     engine = AnonymizerEngine()
-    text = "Fake card number 4151 3217 6243 3448.com that overlaps with nonexisting URL."
+    text = "Fake card number 4151 3217 6243 3448.com that " \
+           "overlaps with nonexisting URL."
     analyzer_result = RecognizerResult("CREDIT_CARD", 17, 36, 0.8)
     analyzer_result2 = RecognizerResult("URL", 32, 40, 0.8)
-    anonymizer_config = OperatorConfig("custom", {"lambda": lambda x: f"<ENTITY: {x}>"})
-    result = engine.anonymize(text, [analyzer_result, analyzer_result2], {"DEFAULT": anonymizer_config}).text
-    assert result == "Fake card number <ENTITY: 4151 3217 6243 3448><ENTITY: 3448.com> that overlaps with nonexisting URL."
+    anonymizer_config = OperatorConfig(
+        "custom", {"lambda": lambda x: f"<ENTITY: {x}>"}
+    )
+    result = engine.anonymize(
+        text, [analyzer_result, analyzer_result2], {"DEFAULT": anonymizer_config}
+    ).text
+    resp = "Fake card number <ENTITY: 4151 3217 6243 3448>" \
+           "<ENTITY: 3448.com> that overlaps with nonexisting URL."
+    assert result == resp
 
 
 def test_given_none_as_anonymziers_list_then_we_fall_to_default():


### PR DESCRIPTION
## Change Description

Fix the way we get the text for anonymization, get it from the original text and not from the anonymized one to make sure we are not overlapping with wrong text as in issue #888.

## Issue reference
This PR fixes issue #888 

## Checklist

- [ X ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ X ] I have signed the CLA
- [ X ] My code includes unit tests
- [ X ] All unit tests and lint checks pass locally
- [ X ] My PR contains documentation updates / additions if required
