### PR TITLE
bug fixes to mkdocs, added download button capability

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -3,7 +3,7 @@ mkdocs-material
 mkdocs-jupyter
 pymdown-extensions<9.4
 markdown
-mkdocstrings
+mkdocstrings[python-legacy]
 presidio_analyzer
 presidio_anonymizer
 presidio_image_redactor

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
     - Simple anonymization: tutorial/10_simple_anonymization.md
     - Custom anonymization: tutorial/11_custom_anonymization.md
     - Encryption/Decryption: tutorial/12_encryption.md
+    - Allow-lists: tutorial/13_allow_list.md
   - Docs:
     - Installation: installation.md
     - Handling text:
@@ -75,8 +76,9 @@ theme:
 plugins:
 - search
 - mkdocstrings
-- mkdocs-jupyter
-
+- mkdocs-jupyter:
+    include_source: True
+    include: ["*.ipynb"]
 
 extra:
   social:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -9,3 +9,14 @@
     })(window, document, "clarity", "script", "5pd40fk720");
 </script>
 {% endblock %}
+
+{% block content %}
+{% if page.nb_url %}
+
+    <a href="{{ page.nb_url }}" title="Download Notebook" class="md-content__button md-icon">
+       {% include ".icons/material/download.svg" %}Download
+    </a><br>
+{% endif %}
+
+{{ super() }}
+{% endblock content %}


### PR DESCRIPTION
## Change Description

Updates to the docs site:
1. Fixed missing reference to the new allow list tutorial on mkdocs.yml
2. Added a download button as jupyter notebooks are rendered as HTML
3. Updated requirements-docs.txt to use mkdoctsrings[python-legacy] as the mkdocstrings package no longer supports restructured-text ( https://github.com/mkdocstrings/python/issues/31 )

Example screenshot:
![image](https://user-images.githubusercontent.com/3776619/178700400-942193cb-5873-4258-8233-856c2aab6860.png)
