### PR TITLE
Italian fiscal code and driver license recognizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+#### Analyzer
+* Added Italian fiscal code recognizer
+* Added Italian driver license recognizer
+
 ## [2.2.29] - 12.07.2022
 ### Added
 

--- a/docs/supported_entities.md
+++ b/docs/supported_entities.md
@@ -47,6 +47,13 @@ For more information, refer to the [adding new recognizers documentation](analyz
 |--- |--- |--- |
 |NIF| A spanish NIF number (Personal tax ID) .|Pattern match, context and checksum|
 
+### Italy
+
+|FieldType|Description|Detection Method|
+|--- |--- |--- |
+|IT_FISCAL_CODE| An Italian personal identification code. <https://en.wikipedia.org/wiki/Italian_fiscal_code>|Pattern match, context and checksum|
+|IT_DRIVER_LICENSE| An Italian driver license number.|Pattern match and context|
+
 ### Singapore
 
 |FieldType|Description|Detection Method|

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
@@ -27,6 +27,8 @@ from .au_abn_recognizer import AuAbnRecognizer
 from .au_acn_recognizer import AuAcnRecognizer
 from .au_tfn_recognizer import AuTfnRecognizer
 from .au_medicare_recognizer import AuMedicareRecognizer
+from .it_driver_license_recognizer import ItDriverLicenseRecognizer
+from .it_fiscal_code_recognizer import ItFiscalCodeRecognizer
 
 NLP_RECOGNIZERS = {
     "spacy": SpacyRecognizer,
@@ -61,4 +63,6 @@ __all__ = [
     "AuTfnRecognizer",
     "AuMedicareRecognizer",
     "TransformersRecognizer",
+    "ItDriverLicenseRecognizer",
+    "ItFiscalCodeRecognizer",
 ]

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/it_driver_license_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/it_driver_license_recognizer.py
@@ -1,0 +1,42 @@
+from typing import List, Optional
+
+from presidio_analyzer import Pattern, PatternRecognizer
+
+
+class ItDriverLicenseRecognizer(PatternRecognizer):
+    """
+    Recognizes IT Driver License using regex.
+
+    :param patterns: List of patterns to be used by this recognizer
+    :param context: List of context words to increase confidence in detection
+    :param supported_language: Language this recognizer supports
+    :param supported_entity: The entity this recognizer can detect
+    """
+
+    PATTERNS = [
+        Pattern(
+            "Driver License",
+            (
+                r"\b(?i)(([A-Z]{2}\d{7}[A-Z])"
+                r"|(^[U]1[BCDEFGHLMNPRSTUWYXZ]\w{6}[A-Z]))\b"
+            ),
+            0.2,
+        ),
+    ]
+    CONTEXT = ["patente", "patente di guida", "licenza", "licenza di guida"]
+
+    def __init__(
+        self,
+        patterns: Optional[List[Pattern]] = None,
+        context: Optional[List[str]] = None,
+        supported_language: str = "it",
+        supported_entity: str = "IT_DRIVER_LICENSE",
+    ):
+        patterns = patterns if patterns else self.PATTERNS
+        context = context if context else self.CONTEXT
+        super().__init__(
+            supported_entity=supported_entity,
+            patterns=patterns,
+            context=context,
+            supported_language=supported_language,
+        )

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/it_fiscal_code_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/it_fiscal_code_recognizer.py
@@ -1,0 +1,187 @@
+from typing import List, Optional
+
+from presidio_analyzer import Pattern, PatternRecognizer
+
+
+class ItFiscalCodeRecognizer(PatternRecognizer):
+    """
+    Recognizes IT Fiscal Code using regex.
+
+    :param patterns: List of patterns to be used by this recognizer
+    :param context: List of context words to increase confidence in detection
+    :param supported_language: Language this recognizer supports
+    :param supported_entity: The entity this recognizer can detect
+    """
+
+    PATTERNS = [
+        Pattern(
+            "Fiscal Code",
+            (
+                r"(?i)((?:[A-Z][AEIOU][AEIOUX]|[AEIOU]X{2}"
+                r"|[B-DF-HJ-NP-TV-Z]{2}[A-Z]){2}"
+                r"(?:[\dLMNP-V]{2}(?:[A-EHLMPR-T](?:[04LQ][1-9MNP-V]|[15MR][\dLMNP-V]"
+                r"|[26NS][0-8LMNP-U])|[DHPS][37PT][0L]|[ACELMRT][37PT][01LM]"
+                r"|[AC-EHLMPR-T][26NS][9V])|(?:[02468LNQSU][048LQU]"
+                r"|[13579MPRTV][26NS])B[26NS][9V])(?:[A-MZ][1-9MNP-V][\dLMNP-V]{2}"
+                r"|[A-M][0L](?:[1-9MNP-V][\dLMNP-V]|[0L][1-9MNP-V]))[A-Z])"
+            ),
+            0.3,
+        ),
+    ]
+    CONTEXT = ["codice fiscale", "cf"]
+
+    def __init__(
+        self,
+        patterns: Optional[List[Pattern]] = None,
+        context: Optional[List[str]] = None,
+        supported_language: str = "it",
+        supported_entity: str = "IT_FISCAL_CODE",
+    ):
+        patterns = patterns if patterns else self.PATTERNS
+        context = context if context else self.CONTEXT
+        super().__init__(
+            supported_entity=supported_entity,
+            patterns=patterns,
+            context=context,
+            supported_language=supported_language,
+        )
+
+    def validate_result(self, pattern_text: str) -> Optional[bool]:
+        """
+        Validate the pattern logic e.g., by running checksum on a detected pattern.
+
+        :param pattern_text: the text to validated.
+        Only the part in text that was detected by the regex engine
+        :return: A bool indicating whether the validation was successful.
+        """
+        pattern_text = pattern_text.upper()
+        control = pattern_text[-1]
+        text_to_validate = pattern_text[:-1]
+        odd_values = text_to_validate[0::2]
+        even_values = text_to_validate[1::2]
+
+        # Odd values
+        map_odd = {
+            "0": 1,
+            "1": 0,
+            "2": 5,
+            "3": 7,
+            "4": 9,
+            "5": 13,
+            "6": 15,
+            "7": 17,
+            "8": 19,
+            "9": 21,
+            "A": 1,
+            "B": 0,
+            "C": 5,
+            "D": 7,
+            "E": 9,
+            "F": 13,
+            "G": 15,
+            "H": 17,
+            "I": 19,
+            "J": 21,
+            "K": 2,
+            "L": 4,
+            "M": 18,
+            "N": 20,
+            "O": 11,
+            "P": 3,
+            "Q": 6,
+            "R": 8,
+            "S": 12,
+            "T": 14,
+            "U": 16,
+            "V": 10,
+            "W": 22,
+            "X": 25,
+            "Y": 24,
+            "Z": 23,
+        }
+
+        odd_sum = 0
+        for char in odd_values:
+            odd_sum += map_odd[char]
+
+        # Even values
+        map_even = {
+            "0": 0,
+            "1": 1,
+            "2": 2,
+            "3": 3,
+            "4": 4,
+            "5": 5,
+            "6": 6,
+            "7": 7,
+            "8": 8,
+            "9": 9,
+            "A": 0,
+            "B": 1,
+            "C": 2,
+            "D": 3,
+            "E": 4,
+            "F": 5,
+            "G": 6,
+            "H": 7,
+            "I": 8,
+            "J": 9,
+            "K": 10,
+            "L": 11,
+            "M": 12,
+            "N": 13,
+            "O": 14,
+            "P": 15,
+            "Q": 16,
+            "R": 17,
+            "S": 18,
+            "T": 19,
+            "U": 20,
+            "V": 21,
+            "W": 22,
+            "X": 23,
+            "Y": 24,
+            "Z": 25,
+        }
+
+        even_sum = 0
+        for char in even_values:
+            even_sum += map_even[char]
+
+        # Mod value
+        map_mod = {
+            0: "A",
+            1: "B",
+            2: "C",
+            3: "D",
+            4: "E",
+            5: "F",
+            6: "G",
+            7: "H",
+            8: "I",
+            9: "J",
+            10: "K",
+            11: "L",
+            12: "M",
+            13: "N",
+            14: "O",
+            15: "P",
+            16: "Q",
+            17: "R",
+            18: "S",
+            19: "T",
+            20: "U",
+            21: "V",
+            22: "W",
+            23: "X",
+            24: "Y",
+            25: "Z",
+        }
+        check_value = map_mod[((odd_sum + even_sum) % 26)]
+
+        if check_value == control:
+            result = True
+        else:
+            result = None
+
+        return result

--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizer_registry.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizer_registry.py
@@ -34,7 +34,9 @@ from presidio_analyzer.predefined_recognizers import (
     AuAcnRecognizer,
     AuTfnRecognizer,
     AuMedicareRecognizer,
-    TransformersRecognizer
+    ItDriverLicenseRecognizer,
+    ItFiscalCodeRecognizer,
+    TransformersRecognizer,
 )
 
 logger = logging.getLogger("presidio-analyzer")
@@ -84,6 +86,7 @@ class RecognizerRegistry:
                 AuMedicareRecognizer,
             ],
             "es": [EsNifRecognizer],
+            "it": [ItDriverLicenseRecognizer, ItFiscalCodeRecognizer],
             "ALL": [
                 CreditCardRecognizer,
                 CryptoRecognizer,
@@ -181,7 +184,8 @@ class RecognizerRegistry:
                     to_return.update(set(subset))
 
         logger.debug(
-            "Returning a total of %s recognizers", str(len(to_return)),
+            "Returning a total of %s recognizers",
+            str(len(to_return)),
         )
 
         if not to_return:

--- a/presidio-analyzer/tests/test_it_driver_license_recognizer.py
+++ b/presidio-analyzer/tests/test_it_driver_license_recognizer.py
@@ -1,0 +1,53 @@
+import pytest
+
+from presidio_analyzer.predefined_recognizers import ItDriverLicenseRecognizer
+from tests import assert_result_within_score_range
+
+
+@pytest.fixture(scope="module")
+def recognizer():
+    return ItDriverLicenseRecognizer()
+
+
+@pytest.fixture(scope="module")
+def entities():
+    return ["IT_DRIVER_LICENSE"]
+
+
+@pytest.mark.parametrize(
+    "text, expected_len, expected_positions, expected_score_ranges",
+    [
+        # fmt: off
+        # Test with one Driver License
+        ("AA0123456B", 1, ((0, 10),), ((0.1, 0.4),),),
+        # Test with two Driver License
+        ("AA0123456B and AA0123456B", 
+        2,
+        ((0, 10), (15, 25),),
+        ((0.1, 0.4), (0.1, 0.4),),),
+        # Test with old Driver License
+        ("U1H00A000B", 1, ((0, 10),), ((0.1, 0.4),),),
+        # Test with invalid Driver License
+        ("990123456B", 0, (), (),),
+        # fmt: on
+    ],
+)
+def test_when_driver_licenses_in_text_then_all_it_driver_licenses_found(
+    text,
+    expected_len,
+    expected_positions,
+    expected_score_ranges,
+    recognizer,
+    entities,
+    max_score,
+):
+    results = recognizer.analyze(text, entities)
+    assert len(results) == expected_len
+    for res, (st_pos, fn_pos), (st_score, fn_score) in zip(
+        results, expected_positions, expected_score_ranges
+    ):
+        if fn_score == "max":
+            fn_score = max_score
+        assert_result_within_score_range(
+            res, entities[0], st_pos, fn_pos, st_score, fn_score
+        )

--- a/presidio-analyzer/tests/test_it_fiscal_code_recognizer.py
+++ b/presidio-analyzer/tests/test_it_fiscal_code_recognizer.py
@@ -1,0 +1,55 @@
+import pytest
+
+from presidio_analyzer.predefined_recognizers import ItFiscalCodeRecognizer
+from tests import assert_result_within_score_range
+
+
+@pytest.fixture(scope="module")
+def recognizer():
+    return ItFiscalCodeRecognizer()
+
+
+@pytest.fixture(scope="module")
+def entities():
+    return ["IT_FISCAL_CODE"]
+
+
+@pytest.mark.parametrize(
+    "text, expected_len, expected_positions, expected_score_ranges",
+    [
+        # fmt: off
+        # Test with valid Fiscal Code and valid last char
+        ("AAAAAA00B11C333Y", 1, ((0, 16),), ((0.3, 1.0),),),
+        # Test with valid Fiscal Code and invalid last char
+        ("AAAAAA00B11C333N", 1, ((0, 16),), ((0.3, 1.0),),),
+        # Test with invalid Fiscal Code
+        ("AAAAAA - 00B11C333N", 0, (), (),),
+        # Test with invalid Fiscal Code
+        ("A55AAA00B11C333N", 0, (), (),),
+        # Test with two Fiscal Code
+        ("AAAAAA00B11C333Y and AAAAAA00B11C333N", 
+        2,
+        ((0, 16), (21, 37),),
+        ((0.3, 1.0), (0.3, 1.0),),),
+        # fmt: on
+    ],
+)
+def test_when_fiscalcode_in_text_then_all_it_fiscalcode_found(
+    text,
+    expected_len,
+    expected_positions,
+    expected_score_ranges,
+    recognizer,
+    entities,
+    max_score,
+):
+    results = recognizer.analyze(text, entities)
+    assert len(results) == expected_len
+    for res, (st_pos, fn_pos), (st_score, fn_score) in zip(
+        results, expected_positions, expected_score_ranges
+    ):
+        if fn_score == "max":
+            fn_score = max_score
+        assert_result_within_score_range(
+            res, entities[0], st_pos, fn_pos, st_score, fn_score
+        )


### PR DESCRIPTION
## Change Description

This contribution adds two recognizers for Italian language:
- Fiscal code: similar to SSN used in United States
- Driver License: number of Italian driver license

For a brief introduction about Italian fiscal code: https://en.wikipedia.org/wiki/Italian_fiscal_code

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
