### PR TITLE
Added unique identifier to each recognizer name

### DIFF
--- a/presidio-analyzer/presidio_analyzer/entity_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/entity_recognizer.py
@@ -44,9 +44,7 @@ class EntityRecognizer:
         self.supported_entities = supported_entities
 
         if name is None:
-            self.name = (
-                f"{self.__class__.__name__}_{id(self)}"  # assign class name as name
-            )
+            self.name = f"{self.__class__.__name__}_{id(self)}"
         else:
             self.name = name
 

--- a/presidio-analyzer/presidio_analyzer/entity_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/entity_recognizer.py
@@ -44,7 +44,9 @@ class EntityRecognizer:
         self.supported_entities = supported_entities
 
         if name is None:
-            self.name = self.__class__.__name__  # assign class name as name
+            self.name = (
+                f"{self.__class__.__name__}_{id(self)}"  # assign class name as name
+            )
         else:
             self.name = name
 

--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizer_registry.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizer_registry.py
@@ -211,6 +211,12 @@ class RecognizerRegistry:
         if not isinstance(recognizer, EntityRecognizer):
             raise ValueError("Input is not of type EntityRecognizer")
 
+        if recognizer.name in [r.name for r in self.recognizers]:
+            raise ValueError(
+                f"Recognizer with name {recognizer.name} already exists. "
+                f"Names must be unique."
+            )
+
         self.recognizers.append(recognizer)
 
     def remove_recognizer(self, recognizer_name: str) -> None:

--- a/presidio-analyzer/tests/assertions.py
+++ b/presidio-analyzer/tests/assertions.py
@@ -31,4 +31,4 @@ def assert_result_within_score_range(
     )
     min_score = max(0, expected_score_min - error)
     max_score = min(1, expected_score_max + error)
-    assert result.score >= min_score and result.score <= max_score
+    assert min_score <= result.score <= max_score

--- a/presidio-analyzer/tests/test_analyzer_engine.py
+++ b/presidio-analyzer/tests/test_analyzer_engine.py
@@ -11,7 +11,6 @@ from presidio_analyzer import (
     RecognizerRegistry,
     EntityRecognizer,
     RecognizerResult,
-    DictAnalyzerResult,
 )
 from presidio_analyzer.nlp_engine import (
     NlpArtifacts,
@@ -715,8 +714,8 @@ def test_when_recognizer_doesnt_return_recognizer_name_no_exception(nlp_engine):
     assert results[0].end == 30
     assert results[0].score == 0.5
     assert (
-        results[0].recognition_metadata[RecognizerResult.RECOGNIZER_NAME_KEY]
-        == "MockRecognizer1"
+        "MockRecognizer1"
+        in results[0].recognition_metadata[RecognizerResult.RECOGNIZER_NAME_KEY]
     )
 
     assert results[1].entity_type == "TEST2"
@@ -724,9 +723,34 @@ def test_when_recognizer_doesnt_return_recognizer_name_no_exception(nlp_engine):
     assert results[1].end == 60
     assert results[1].score == 0.4
     assert (
-        results[1].recognition_metadata[RecognizerResult.RECOGNIZER_NAME_KEY]
-        == "MockRecognizer2"
+        "MockRecognizer2"
+        in results[1].recognition_metadata[RecognizerResult.RECOGNIZER_NAME_KEY]
     )
+
+
+def test_when_multiple_nameless_recognizers_context_is_correct(nlp_engine):
+    rocket_recognizer = PatternRecognizer(
+        supported_entity="ROCKET",
+        context=["cool"],
+        patterns=[Pattern("rocketpattern", r"(\W)(rocket)(\W)", 0.3)],
+    )
+
+    rocket_recognizer2 = PatternRecognizer(
+        supported_entity="missile",
+        context=["fast"],
+        patterns=[Pattern("missilepattern", r"(\W)(missile)(\W)", 0.3)],
+    )
+    registry = RecognizerRegistry()
+    registry.add_recognizer(rocket_recognizer)
+    registry.add_recognizer(rocket_recognizer2)
+
+    analyzer_engine = AnalyzerEngine(nlp_engine=nlp_engine, registry=registry)
+    recognizer_results = analyzer_engine.analyze(
+        "I have a cool rocket and a fast missile.", language="en"
+    )
+
+    for recognizer_result in recognizer_results:
+        assert recognizer_result.score > 0.3
 
 
 def test_when_recognizer_overrides_enhance_score_then_it_get_boosted_once(nlp_engine):
@@ -772,8 +796,10 @@ def test_when_recognizer_overrides_enhance_score_then_it_get_boosted_once(nlp_en
     assert recognizer_results[0].end == 30
     assert recognizer_results[0].score == 0.9
     assert (
-        recognizer_results[0].recognition_metadata[RecognizerResult.RECOGNIZER_NAME_KEY]
-        == "MockRecognizer"
+        "MockRecognizer"
+        in recognizer_results[0].recognition_metadata[
+            RecognizerResult.RECOGNIZER_NAME_KEY
+        ]
     )
     assert recognizer_results[0].recognition_metadata[
         RecognizerResult.IS_SCORE_ENHANCED_BY_CONTEXT_KEY
@@ -783,8 +809,10 @@ def test_when_recognizer_overrides_enhance_score_then_it_get_boosted_once(nlp_en
     assert recognizer_results[1].end == 60
     assert recognizer_results[1].score == 0.8
     assert (
-        recognizer_results[1].recognition_metadata[RecognizerResult.RECOGNIZER_NAME_KEY]
-        == "MockRecognizer"
+        "MockRecognizer"
+        in recognizer_results[1].recognition_metadata[
+            RecognizerResult.RECOGNIZER_NAME_KEY
+        ]
     )
     assert recognizer_results[1].recognition_metadata[
         RecognizerResult.IS_SCORE_ENHANCED_BY_CONTEXT_KEY

--- a/presidio-analyzer/tests/test_entity_recognizer.py
+++ b/presidio-analyzer/tests/test_entity_recognizer.py
@@ -119,3 +119,11 @@ def test_when_remove_duplicates_contained_shorter_length_results_removed():
     ]
     results = EntityRecognizer.remove_duplicates(arr)
     assert len(results) == 1
+
+
+def test_entity_recognizer_name_contains_id():
+    recognizer = EntityRecognizer(["ENTITY"])
+    initial_name = "EntityRecognizer"
+
+    assert initial_name in recognizer.name
+    assert len(recognizer.name) > len(initial_name)

--- a/presidio-analyzer/tests/test_recognizer_registry.py
+++ b/presidio-analyzer/tests/test_recognizer_registry.py
@@ -204,3 +204,20 @@ def test_recognizer_registry_exception_erroneous_yaml():
     with pytest.raises(TypeError):
         registry = RecognizerRegistry()
         registry.add_recognizers_from_yaml(test_yaml)
+
+
+def test_adding_recognizer_with_existing_name_throws_exception():
+
+    reco1 = PatternRecognizer(
+        supported_entity="ENT", name="MyRecognizer", deny_list=["A", "B", "C"]
+    )
+    reco2 = PatternRecognizer(
+        supported_entity="ENT",
+        name="MyRecognizer",
+        patterns=[Pattern(name="pattern", regex="", score=0.9)],
+    )
+    registry = RecognizerRegistry()
+    registry.add_recognizer(reco1)
+
+    with pytest.raises(ValueError):
+        registry.add_recognizer(reco2)

--- a/presidio-analyzer/tests/test_spacy_recognizer.py
+++ b/presidio-analyzer/tests/test_spacy_recognizer.py
@@ -38,7 +38,7 @@ def prepare_and_analyze(nlp, recognizer, text, ents):
         ("I bought my car in May", 1, ((19, 22),), 1),
         ("May 1st", 1, ((0, 7),), 1),
         ("May 1st, 1977", 1, ((0, 13),), 1),
-        ("I bought my car on May 1st, 1977", 1, ((19, 32),) , 1),
+        ("I bought my car on May 1st, 1977", 2, ((19, 26), (28, 32)), 1),
         # fmt: on
     ],
 )

--- a/presidio-analyzer/tests/test_spacy_recognizer.py
+++ b/presidio-analyzer/tests/test_spacy_recognizer.py
@@ -38,7 +38,7 @@ def prepare_and_analyze(nlp, recognizer, text, ents):
         ("I bought my car in May", 1, ((19, 22),), 1),
         ("May 1st", 1, ((0, 7),), 1),
         ("May 1st, 1977", 1, ((0, 13),), 1),
-        ("I bought my car on May 1st, 1977", 2, ((19, 26), (28, 32)), 1),
+        ("I bought my car on May 1st, 1977", 1, ((19, 32),) , 1),
         # fmt: on
     ],
 )


### PR DESCRIPTION
## Change Description

Added a unique identifier to each recognizer, as the context aware mechanism matches results to recognizer using their name.
Main changes:
1. Added `id(self)` to each default recognizer name
2. Added a validation to make sure no duplicate names exist.
3. Added unit tests, ran black+flake8

This was more backward compatible solution than introducing a new key (e.g., recognizer_identifier), although using the names is not perfect (e.g., the name could be used for interpretability and other mechanisms that follow the identification phase)

## Issue reference

This PR fixes issue #889

## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [X] I have signed the CLA
- [X] My code includes unit tests
- [X] All unit tests and lint checks pass locally
- [X] My PR contains documentation updates / additions if required
