### PR TITLE
Remove constraint on empty texts for the anonymizer

### DIFF
--- a/e2e-tests/tests/test_anonymizer.py
+++ b/e2e-tests/tests/test_anonymizer.py
@@ -57,8 +57,8 @@ def test_given_anonymize_called_with_empty_text_then_invalid_input_message_retur
 
     response_status, response_content = anonymize(request_body)
 
-    expected_response = '{"error": "Invalid input, text can not be empty"}'
-    assert response_status == 422
+    expected_response = """{"text": "", "items": []}"""
+    assert response_status == 200
     assert equal_json_strings(expected_response, response_content)
 
 
@@ -142,17 +142,8 @@ def test_given_decrypt_called_with_encrypted_text_then_decrypted_text_returned()
     text = "e6HnOMnIxbd4a8Qea44LshQDnjvxwzBIaAz+YqHNnMW2mC5r3AWoay8Spsoajyyy"
     request_body = {
         "text": text,
-        "deanonymizers": {
-            "NUMBER": {
-                "type": "decrypt",
-                "key": "1111111111111111"
-            }
-        },
-        "anonymizer_results": [{
-            "start": 0,
-            "end": len(text),
-            "entity_type": "NUMBER"
-        }],
+        "deanonymizers": {"NUMBER": {"type": "decrypt", "key": "1111111111111111"}},
+        "anonymizer_results": [{"start": 0, "end": len(text), "entity_type": "NUMBER"}],
     }
 
     response_status, response_content = deanonymize(json.dumps(request_body))
@@ -168,17 +159,8 @@ def test_given_decrypt_called_with_invalid_key_then_invalid_input_response_retur
     text = "e6HnOMnIxbd4a8Qea44LshQDnjvxwzBIaAz + YqHNnMW2mC5r3AWoay8Spsoajyyy"
     request_body = {
         "text": text,
-        "deanonymizers": {
-            "NUMBER": {
-                "type": "decrypt",
-                "key": "invalidkey"
-            }
-        },
-        "anonymizer_results": [{
-            "start": 0,
-            "end": len(text),
-            "entity_type": "NUMBER"
-        }],
+        "deanonymizers": {"NUMBER": {"type": "decrypt", "key": "invalidkey"}},
+        "anonymizer_results": [{"start": 0, "end": len(text), "entity_type": "NUMBER"}],
     }
 
     response_status, response_content = deanonymize(json.dumps(request_body))
@@ -252,8 +234,10 @@ def test_given_encrypt_called_then_decrypt_returns_the_original_encrypted_text()
     key = "1111111111111111"
     anonymize_request = {
         "text": text_for_encryption,
-        "anonymizers": {"DEFAULT": {"type": "encrypt", "key": key},
-                        "TITLE": {"type": "encrypt", "key": "2222222222222222"}},
+        "anonymizers": {
+            "DEFAULT": {"type": "encrypt", "key": key},
+            "TITLE": {"type": "encrypt", "key": "2222222222222222"},
+        },
         "analyzer_results": [
             {
                 "start": 0,
@@ -266,7 +250,7 @@ def test_given_encrypt_called_then_decrypt_returns_the_original_encrypted_text()
                 "end": len(text_for_encryption),
                 "score": 0.8,
                 "entity_type": "TITLE",
-            }
+            },
         ],
     }
     _, anonymize_response_content = anonymize(json.dumps(anonymize_request))
@@ -275,14 +259,8 @@ def test_given_encrypt_called_then_decrypt_returns_the_original_encrypted_text()
     decrypt_request = {
         "text": encrypted_text,
         "deanonymizers": {
-            "DEFAULT": {
-                "type": "decrypt",
-                "key": "1111111111111111"
-            },
-            "TITLE": {
-                "type": "decrypt",
-                "key": "2222222222222222"
-            }
+            "DEFAULT": {"type": "decrypt", "key": "1111111111111111"},
+            "TITLE": {"type": "decrypt", "key": "2222222222222222"},
         },
         "anonymizer_results": [
             {
@@ -294,7 +272,7 @@ def test_given_encrypt_called_then_decrypt_returns_the_original_encrypted_text()
                 "start": 50,
                 "end": 114,
                 "entity_type": "TITLE",
-            }
+            },
         ],
     }
 

--- a/presidio-anonymizer/presidio_anonymizer/core/text_replace_builder.py
+++ b/presidio-anonymizer/presidio_anonymizer/core/text_replace_builder.py
@@ -9,16 +9,10 @@ class TextReplaceBuilder:
 
     def __init__(self, original_text: str):
         self.logger = logging.getLogger("presidio-anonymizer")
-        self.__validate_text_not_empty(original_text)
         self.output_text = original_text
         self.original_text = original_text
         self.text_len = len(original_text)
         self.last_replacement_index = self.text_len
-
-    def __validate_text_not_empty(self, text: str):
-        if not text:
-            self.logger.debug("invalid input, json is missing text field")
-            raise InvalidParamException("Invalid input, text can not be empty")
 
     def get_text_in_position(self, start: int, end: int) -> str:
         """

--- a/presidio-anonymizer/tests/integration/test_anonymize_engine.py
+++ b/presidio-anonymizer/tests/integration/test_anonymize_engine.py
@@ -12,9 +12,7 @@ from presidio_anonymizer.operators import AESCipher
 def test_given_url_at_the_end_then_we_redact_is_successfully():
     text = "The url is http://microsoft.com"
     anonymizer_config = {
-        "URL": OperatorConfig(
-            "redact"
-        ),
+        "URL": OperatorConfig("redact"),
     }
 
     analyzer_results = [
@@ -246,3 +244,12 @@ def test_given_anonymize_with_encrypt_then_text_returned_with_encrypted_content(
     assert actual_encrypted_text != expected_encrypted_text
     actual_decrypted_text = AESCipher.decrypt(key.encode(), actual_encrypted_text)
     assert actual_decrypted_text == expected_encrypted_text
+
+
+def test_empty_text_returns_correct_results():
+    text = ""
+    analyzer_results = []
+
+    actual_anonymize_result = AnonymizerEngine().anonymize(text, analyzer_results)
+
+    assert actual_anonymize_result.text == text

--- a/presidio-anonymizer/tests/test_anonymizer_engine.py
+++ b/presidio-anonymizer/tests/test_anonymizer_engine.py
@@ -22,15 +22,6 @@ def test_given_request_anonymizers_return_list():
     assert anon_list == expected_list
 
 
-def test_given_empty_text_to_engine_then_we_fail():
-    engine = AnonymizerEngine()
-    analyzer_result = RecognizerResult("SSN", 0, 1, 0.5)
-    with pytest.raises(
-        InvalidParamException, match="Invalid input, text can not be empty"
-    ):
-        engine.anonymize("", [analyzer_result], {})
-
-
 def test_given_empty_analyzers_list_then_we_get_same_text_back():
     engine = AnonymizerEngine()
     text = "one two three"
@@ -47,18 +38,20 @@ def test_given_empty_anonymziers_list_then_we_fall_to_default():
 
 def test_given_custom_anonymizer_then_we_manage_to_anonymize_successfully():
     engine = AnonymizerEngine()
-    text = "Fake card number 4151 3217 6243 3448.com that " \
-           "overlaps with nonexisting URL."
+    text = (
+        "Fake card number 4151 3217 6243 3448.com that "
+        "overlaps with nonexisting URL."
+    )
     analyzer_result = RecognizerResult("CREDIT_CARD", 17, 36, 0.8)
     analyzer_result2 = RecognizerResult("URL", 32, 40, 0.8)
-    anonymizer_config = OperatorConfig(
-        "custom", {"lambda": lambda x: f"<ENTITY: {x}>"}
-    )
+    anonymizer_config = OperatorConfig("custom", {"lambda": lambda x: f"<ENTITY: {x}>"})
     result = engine.anonymize(
         text, [analyzer_result, analyzer_result2], {"DEFAULT": anonymizer_config}
     ).text
-    resp = "Fake card number <ENTITY: 4151 3217 6243 3448>" \
-           "<ENTITY: 3448.com> that overlaps with nonexisting URL."
+    resp = (
+        "Fake card number <ENTITY: 4151 3217 6243 3448>"
+        "<ENTITY: 3448.com> that overlaps with nonexisting URL."
+    )
     assert result == resp
 
 

--- a/presidio-anonymizer/tests/test_text_replace_builder.py
+++ b/presidio-anonymizer/tests/test_text_replace_builder.py
@@ -25,13 +25,6 @@ def test_given_text_then_we_replace_the_original_with_anonymized_correctly(
     assert expected_end_text == end_text_num
 
 
-def test_given_empty_text_then_we_fail():
-    with pytest.raises(
-        InvalidParamException, match="Invalid input, text can not be empty"
-    ):
-        TextReplaceBuilder("")
-
-
 @pytest.mark.parametrize(
     # fmt: off
     "original_text,start,end,expected",


### PR DESCRIPTION
## Change Description

In batch mode, we often encounter empty strings. Currently the anonymizer engine throws an error if the user passed an empty string. This PR removes this constraint and allows empty strings to be anonymized (into empty strings...)

## Issue reference

This PR fixes issue #937

## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [X] I have signed the CLA
- [X] My code includes unit tests
- [X] All unit tests and lint checks pass locally
- [X] My PR contains documentation updates / additions if required
