### PR TITLE
Add missing comma in sample notebook

### DIFF
--- a/docs/samples/python/presidio_notebook.ipynb
+++ b/docs/samples/python/presidio_notebook.ipynb
@@ -75,7 +75,7 @@
     "                                      deny_list=[\"Mr.\",\"Mrs.\",\"Miss\"])\n",
     "\n",
     "pronoun_recognizer = PatternRecognizer(supported_entity=\"PRONOUN\",\n",
-    "                                       deny_list=[\"he\", \"He\", \"his\", \"His\", \"she\", \"She\", \"hers\" \"Hers\"])\n",
+    "                                       deny_list=[\"he\", \"He\", \"his\", \"His\", \"she\", \"She\", \"hers\", \"Hers\"])\n",
     "\n",
     "analyzer.registry.add_recognizer(titles_recognizer)\n",
     "analyzer.registry.add_recognizer(pronoun_recognizer)\n",


### PR DESCRIPTION
## Change Description

Missing comma added.
For "I have signed the CLA" -- I don't know where that is. CONTRIBUTING doesn't make an allusion to it.
I understand I should update the changelog, but I'm hoping that since this is a change to what is essentially documentation, we can skip that?

## Issue reference

I didn't open an issue for this, I went straight to a PR.

## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
