### PR TITLE
Updating DICOM redact box fill color selection

### DIFF
--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
@@ -326,7 +326,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
 
     @staticmethod
     def _get_array_corners(
-        pixel_array: np.ndarray, crop_ratio: float = 0.5
+        pixel_array: np.ndarray, crop_ratio: float = 0.75
     ) -> np.ndarray:
         """Crop a pixel array to just return the corners in a single array.
 
@@ -366,7 +366,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
             cropped_pixel_arrays.append(pixel_array[x_start:x_end, y_start:y_end])
 
         # Combine the cropped pixel arrays
-        cropped_array = np.concatenate(cropped_pixel_arrays)
+        cropped_array = np.vstack(cropped_pixel_arrays)
 
         return cropped_array
 
@@ -383,8 +383,11 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
 
         :return: Most or least common pixel value (depending on fill).
         """
+        # Crop down to just only look at image corners
+        cropped_array = cls._get_array_corners(instance.pixel_array)
+
         # Get flattened pixel array
-        flat_pixel_array = np.array(instance.pixel_array).flatten()
+        flat_pixel_array = np.array(cropped_array).flatten()
 
         is_greyscale = cls._check_if_greyscale(instance)
         if is_greyscale:

--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
@@ -28,6 +28,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         image: pydicom.dataset.FileDataset,
         fill: str = "contrast",
         padding_width: int = 25,
+        crop_ratio: float = 0.75,
         **kwargs,
     ):
         """Redact method to redact the given DICOM image.
@@ -38,6 +39,8 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         :param image: Loaded DICOM instance including pixel data and metadata.
         :param fill: Fill setting to use for redaction box ("contrast" or "background").
         :param padding_width: Padding width to use when running OCR.
+        :param crop_ratio: Determines proportion of image to use when
+        determining background color (remainder excludes the center).
         :param kwargs: Additional values for the analyze method in AnalyzerEngine
 
         :return: DICOM instance with redacted pixel data.
@@ -67,7 +70,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
 
         # Redact all bounding boxes from DICOM file
         bboxes = self._format_bboxes(analyzer_results, padding_width)
-        redacted_image = self._add_redact_box(instance, bboxes, fill)
+        redacted_image = self._add_redact_box(instance, bboxes, crop_ratio, fill)
 
         return redacted_image
 
@@ -76,6 +79,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         input_dicom_path: str,
         output_dir: str,
         padding_width: int = 25,
+        crop_ratio: float = 0.75,
         fill: str = "contrast",
         **kwargs,
     ) -> None:
@@ -107,6 +111,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         # Process DICOM file
         output_location = self._redact_single_dicom_image(
             dcm_path=dst_path,
+            crop_ratio=crop_ratio,
             fill=fill,
             padding_width=padding_width,
             overwrite=True,
@@ -123,6 +128,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         input_dicom_path: str,
         output_dir: str,
         padding_width: int = 25,
+        crop_ratio: float = 0.75,
         fill: str = "contrast",
         **kwargs,
     ) -> None:
@@ -134,6 +140,8 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         :param input_dicom_path: String path to directory of DICOM images.
         :param output_dir: String path to parent output directory.
         :param padding_width : Padding width to use when running OCR.
+        :param crop_ratio: Determines what proportion of the image to
+        use when determining background color.
         :param fill: Color setting to use for redaction box
         ("contrast" or "background").
         :param kwargs: Additional values for the analyze method in AnalyzerEngine
@@ -154,6 +162,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         # Process DICOM files
         output_location = self._redact_multiple_dicom_images(
             dcm_dir=dst_path,
+            crop_ratio=crop_ratio,
             fill=fill,
             padding_width=padding_width,
             overwrite=True,
@@ -325,9 +334,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         return bg_color
 
     @staticmethod
-    def _get_array_corners(
-        pixel_array: np.ndarray, crop_ratio: float = 0.75
-    ) -> np.ndarray:
+    def _get_array_corners(pixel_array: np.ndarray, crop_ratio: float) -> np.ndarray:
         """Crop a pixel array to just return the corners in a single array.
 
         Args:
@@ -367,11 +374,16 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
 
     @classmethod
     def _get_most_common_pixel_value(
-        cls, instance: pydicom.dataset.FileDataset, fill: str = "contrast"
+        cls,
+        instance: pydicom.dataset.FileDataset,
+        crop_ratio: float,
+        fill: str = "contrast",
     ) -> Union[int, Tuple[int, int, int]]:
         """Find the most common pixel value.
 
         :param instance: A singe DICOM instance.
+        :param crop_ratio: Used to select how much of the image to consider
+        when determining image background color.
         :param fill: Determines how box color is selected.
         'contrast' - Masks stand out relative to background.
         'background' - Masks are same color as background.
@@ -379,7 +391,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         :return: Most or least common pixel value (depending on fill).
         """
         # Crop down to just only look at image corners
-        cropped_array = cls._get_array_corners(instance.pixel_array)
+        cropped_array = cls._get_array_corners(instance.pixel_array, crop_ratio)
 
         # Get flattened pixel array
         flat_pixel_array = np.array(cropped_array).flatten()
@@ -702,12 +714,15 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         cls,
         instance: pydicom.dataset.FileDataset,
         bounding_boxes_coordinates: list,
+        crop_ratio: float,
         fill: str = "contrast",
     ) -> pydicom.dataset.FileDataset:
         """Add redaction bounding boxes on a DICOM instance.
 
         :param instance: A single DICOM instance.
         :param bounding_boxes_coordinates: Bounding box coordinates.
+        :param crop_ratio: Determines proportion of image to use
+        when determining background color.
         :param fill: Determines how box color is selected.
         'contrast' - Masks stand out relative to background.
         'background' - Masks are same color as background.
@@ -720,7 +735,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         # Select masking box color
         is_greyscale = cls._check_if_greyscale(instance)
         if is_greyscale:
-            box_color = cls._get_most_common_pixel_value(instance, fill)
+            box_color = cls._get_most_common_pixel_value(instance, crop_ratio, fill)
         else:
             box_color = cls._set_bbox_color(redacted_instance, fill)
 
@@ -742,6 +757,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
     def _redact_single_dicom_image(
         self,
         dcm_path: str,
+        crop_ratio: float,
         fill: str,
         padding_width: int,
         overwrite: bool,
@@ -751,6 +767,8 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         """Redact text PHI present on a DICOM image.
 
         :param dcm_path: String path to the DICOM file.
+        :param crop_ratio: Determines what proportion of image
+        to use when determining background color.
         :param fill: Color setting to use for bounding boxes
         ("contrast" or "background").
         :param padding_width: Pixel width of padding (uniform).
@@ -796,7 +814,9 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
 
         # Redact all bounding boxes from DICOM file
         bboxes = self._format_bboxes(analyzer_results, padding_width)
-        redacted_dicom_instance = self._add_redact_box(instance, bboxes, fill)
+        redacted_dicom_instance = self._add_redact_box(
+            instance, bboxes, crop_ratio, fill
+        )
         redacted_dicom_instance.save_as(dst_path)
 
         return dst_path
@@ -804,6 +824,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
     def _redact_multiple_dicom_images(
         self,
         dcm_dir: str,
+        crop_ratio: float,
         fill: str,
         padding_width: int,
         overwrite: bool,
@@ -813,6 +834,8 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         """Redact text PHI present on all DICOM images in a directory.
 
         :param dcm_dir: String path to directory containing DICOM files (can be nested).
+        :param crop_ratio: Determines what proportion of image
+        to use when determining background color.
         :param fill: Color setting to use for bounding boxes
         ("contrast" or "background").
         :param padding_width: Pixel width of padding (uniform).
@@ -840,7 +863,13 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         all_dcm_files = self._get_all_dcm_files(Path(dst_dir))
         for dst_path in all_dcm_files:
             self._redact_single_dicom_image(
-                dst_path, fill, padding_width, overwrite, dst_parent_dir, **kwargs
+                dst_path,
+                crop_ratio,
+                fill,
+                padding_width,
+                overwrite,
+                dst_parent_dir,
+                **kwargs,
             )
 
         return dst_dir

--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
@@ -39,8 +39,8 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         :param image: Loaded DICOM instance including pixel data and metadata.
         :param fill: Fill setting to use for redaction box ("contrast" or "background").
         :param padding_width: Padding width to use when running OCR.
-        :param crop_ratio: Determines proportion of image to use when
-        determining background color (remainder excludes the center).
+        :param crop_ratio: Portion of image to consider when selecting
+        most common pixel value as the background color value.
         :param kwargs: Additional values for the analyze method in AnalyzerEngine
 
         :return: DICOM instance with redacted pixel data.
@@ -140,8 +140,8 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         :param input_dicom_path: String path to directory of DICOM images.
         :param output_dir: String path to parent output directory.
         :param padding_width : Padding width to use when running OCR.
-        :param crop_ratio: Determines what proportion of the image to
-        use when determining background color.
+        :param crop_ratio: Portion of image to consider when selecting
+        most common pixel value as the background color value.
         :param fill: Color setting to use for redaction box
         ("contrast" or "background").
         :param kwargs: Additional values for the analyze method in AnalyzerEngine
@@ -337,12 +337,11 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
     def _get_array_corners(pixel_array: np.ndarray, crop_ratio: float) -> np.ndarray:
         """Crop a pixel array to just return the corners in a single array.
 
-        Args:
-            pixel_array (np.ndarray): Numpy array containing the pixel data.
-            crop_ratio (float): Ratio to crop to.
+        :param pixel_array: Numpy array containing the pixel data.
+        :param crop_ratio: Portion of image to consider when selecting
+        most common pixel value as the background color value.
 
-        Return:
-            cropped_array (np.ndarray): Cropped input array.
+        :return: Cropped input array.
         """
         if crop_ratio >= 1.0 or crop_ratio <= 0:
             raise ValueError("crop_ratio must be between 0 and 1")
@@ -350,9 +349,8 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         # Set dimensions
         width = pixel_array.shape[0]
         height = pixel_array.shape[1]
-        effective_crop = crop_ratio / 2
-        crop_width = int(np.floor(width * effective_crop))
-        crop_height = int(np.floor(height * effective_crop))
+        crop_width = int(np.floor(width * crop_ratio / 2))
+        crop_height = int(np.floor(height * crop_ratio / 2))
 
         # Get coordinates for corners
         # (left, top, right, bottom)
@@ -382,8 +380,8 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         """Find the most common pixel value.
 
         :param instance: A singe DICOM instance.
-        :param crop_ratio: Used to select how much of the image to consider
-        when determining image background color.
+        :param crop_ratio: Portion of image to consider when selecting
+        most common pixel value as the background color value.
         :param fill: Determines how box color is selected.
         'contrast' - Masks stand out relative to background.
         'background' - Masks are same color as background.
@@ -721,8 +719,8 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
 
         :param instance: A single DICOM instance.
         :param bounding_boxes_coordinates: Bounding box coordinates.
-        :param crop_ratio: Determines proportion of image to use
-        when determining background color.
+        :param crop_ratio: Portion of image to consider when selecting
+        most common pixel value as the background color value.
         :param fill: Determines how box color is selected.
         'contrast' - Masks stand out relative to background.
         'background' - Masks are same color as background.
@@ -767,8 +765,8 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         """Redact text PHI present on a DICOM image.
 
         :param dcm_path: String path to the DICOM file.
-        :param crop_ratio: Determines what proportion of image
-        to use when determining background color.
+        :param crop_ratio: Portion of image to consider when selecting
+        most common pixel value as the background color value.
         :param fill: Color setting to use for bounding boxes
         ("contrast" or "background").
         :param padding_width: Pixel width of padding (uniform).
@@ -834,8 +832,8 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         """Redact text PHI present on all DICOM images in a directory.
 
         :param dcm_dir: String path to directory containing DICOM files (can be nested).
-        :param crop_ratio: Determines what proportion of image
-        to use when determining background color.
+        :param crop_ratio: Portion of image to consider when selecting
+        most common pixel value as the background color value.
         :param fill: Color setting to use for bounding boxes
         ("contrast" or "background").
         :param padding_width: Pixel width of padding (uniform).

--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
@@ -356,14 +356,9 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         boxes = [box_top_left, box_top_right, box_bottom_left, box_bottom_right]
 
         # Only keep box pixels
-        cropped_pixel_arrays = list()
-        for box in boxes:
-            x_start = box[0]  # left
-            x_end = box[2]  # right
-            y_start = box[1]  # up
-            y_end = box[3]  # down
-
-            cropped_pixel_arrays.append(pixel_array[x_start:x_end, y_start:y_end])
+        cropped_pixel_arrays = [
+            pixel_array[box[0] : box[2], box[1] : box[3]] for box in boxes
+        ]
 
         # Combine the cropped pixel arrays
         cropped_array = np.vstack(cropped_pixel_arrays)

--- a/presidio-image-redactor/tests/test_dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/tests/test_dicom_image_redactor_engine.py
@@ -415,10 +415,13 @@ def test_get_most_common_pixel_value_happy_path(
         expected_color (int or Tuple of int): The expected color returned for the image.
     """
     # Arrange
+    crop_ratio = 0.75
     test_instance = pydicom.dcmread(dcm_file)
 
     # Act
-    test_color = mock_engine._get_most_common_pixel_value(test_instance, fill)
+    test_color = mock_engine._get_most_common_pixel_value(
+        test_instance, crop_ratio, fill
+    )
 
     # Assert
     assert test_color == expected_color
@@ -441,10 +444,13 @@ def test_get_most_common_pixel_value_exceptions(
     """
     with pytest.raises(Exception) as exc_info:
         # Arrange
+        crop_ratio = 0.75
         test_instance = pydicom.dcmread(dcm_file)
 
         # Act
-        _ = mock_engine._get_most_common_pixel_value(test_instance, "contrast")
+        _ = mock_engine._get_most_common_pixel_value(
+            test_instance, crop_ratio, "contrast"
+        )
 
         # Assert
         assert expected_error_type == exc_info.typename
@@ -1127,6 +1133,7 @@ def test_add_redact_box_happy_path(
     """
     # Arrange
     test_instance = pydicom.dcmread(dcm_path)
+    crop_ratio = 0.75
     mock_check_if_greyscale = mocker.patch.object(
         DicomImageRedactorEngine,
         "_check_if_greyscale",
@@ -1146,7 +1153,7 @@ def test_add_redact_box_happy_path(
 
     # Act
     test_redacted_instance = mock_engine._add_redact_box(
-        test_instance, bounding_boxes_coordinates
+        test_instance, bounding_boxes_coordinates, crop_ratio
     )
 
     # Assert
@@ -1312,6 +1319,7 @@ def test_DicomImageRedactorEngine_redact_single_dicom_image_happy_path(
         overwrite (bool): True if overwriting original files.
     """
     # Arrange
+    crop_ratio = 0.75
     mock_copy_files = mocker.patch(
         "presidio_image_redactor.dicom_image_redactor_engine.DicomImageRedactorEngine._copy_files_for_processing",
         return_value=dcm_path,
@@ -1363,7 +1371,7 @@ def test_DicomImageRedactorEngine_redact_single_dicom_image_happy_path(
 
     # Act
     mock_engine._redact_single_dicom_image(
-        dcm_path, "contrast", 25, overwrite, output_dir
+        dcm_path, crop_ratio, "contrast", 25, overwrite, output_dir
     )
 
     # Assert
@@ -1403,7 +1411,9 @@ def test_DicomImageRedactorEngine_redact_single_dicom_image_exceptions(
     """
     with pytest.raises(Exception) as exc_info:
         # Act
-        mock_engine._redact_single_dicom_image(dcm_path, "contrast", 25, False, ".")
+        mock_engine._redact_single_dicom_image(
+            dcm_path, 0.75, "contrast", 25, False, "."
+        )
 
     # Assert
     assert expected_error_type == exc_info.typename
@@ -1438,6 +1448,7 @@ def test_DicomImageRedactorEngine_redact_multiple_dicom_images_happy_path(
         overwrite (bool): True if overwriting original files.
     """
     # Arrange
+    crop_ratio = 0.75
     mock_copy_files = mocker.patch(
         "presidio_image_redactor.dicom_image_redactor_engine.DicomImageRedactorEngine._copy_files_for_processing",
         return_value=dcm_path,
@@ -1458,7 +1469,7 @@ def test_DicomImageRedactorEngine_redact_multiple_dicom_images_happy_path(
 
     # Act
     mock_engine._redact_multiple_dicom_images(
-        dcm_path, "contrast", 25, overwrite, output_dir
+        dcm_path, crop_ratio, "contrast", 25, overwrite, output_dir
     )
 
     # Assert
@@ -1491,7 +1502,9 @@ def test_DicomImageRedactorEngine_redact_multiple_dicom_images_exceptions(
     """
     with pytest.raises(Exception) as exc_info:
         # Act
-        mock_engine._redact_multiple_dicom_images(dcm_path, "contrast", 25, False, ".")
+        mock_engine._redact_multiple_dicom_images(
+            dcm_path, 0.75, "contrast", 25, False, "."
+        )
 
     # Assert
     assert expected_error_type == exc_info.typename

--- a/presidio-image-redactor/tests/test_dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/tests/test_dicom_image_redactor_engine.py
@@ -402,7 +402,6 @@ def test_get_array_corners_exceptions(
     ],
 )
 def test_get_most_common_pixel_value_happy_path(
-    mocker,
     mock_engine: DicomImageRedactorEngine,
     dcm_file: Path,
     fill: str,


### PR DESCRIPTION
## Change Description

This Pull Request updates the logic for determining a DICOM pixel array's most common pixel value in defining the background color. The new logic now only focuses on large corner sections rather than the full image to more likely pick up on the pixel value most commonly associated with the background.

For more details, please see the issue this is referencing.

## Issue reference

This PR fixes issue #971 

## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [X] My code includes unit tests
- [X] All unit tests and lint checks pass locally
- [X] My PR contains documentation updates / additions if required
