### PR TITLE
Fixing typo (photometric interpolation -> photometric interpretation)

### DIFF
--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
@@ -214,9 +214,9 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
 
         :param instance: A single DICOM instance.
 
-        :return: FALSE if the Photometric Interpolation is RGB.
+        :return: FALSE if the Photometric Interpretation is RGB.
         """
-        # Check if image is grayscale or not using the Photometric Interpolation element
+        # Check if image is grayscale or not using the Photometric Interpretation element
         color_scale = instance[0x0028, 0x0004].value
         is_greyscale = color_scale != "RGB"
 
@@ -229,7 +229,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         """Rescale DICOM pixel_array.
 
         :param instance: A singe DICOM instance.
-        :param is_greyscale: FALSE if the Photometric Interpolation is RGB.
+        :param is_greyscale: FALSE if the Photometric Interpretation is RGB.
 
         :return: Rescaled DICOM pixel_array.
         """
@@ -297,7 +297,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         """
         ds = pydicom.dcmread(filepath)
 
-        # Check if image is grayscale using the Photometric Interpolation element
+        # Check if image is grayscale using the Photometric Interpretation element
         is_greyscale = cls._check_if_greyscale(ds)
 
         # Rescale pixel array

--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
@@ -216,7 +216,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
 
         :return: FALSE if the Photometric Interpretation is RGB.
         """
-        # Check if image is grayscale or not using the Photometric Interpretation element
+        # Check if image is grayscale using the Photometric Interpretation element
         color_scale = instance[0x0028, 0x0004].value
         is_greyscale = color_scale != "RGB"
 


### PR DESCRIPTION
## Change Description

This PR fixes a minor typo where "photometric interpretation" is incorrectly referred to as "photometric interpolation", regarding DICOM images.

## Issue reference

This PR fixes issue #1017

## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [X] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
