### PR TITLE
Restore pushing Docker images in CI

### DIFF
--- a/.pipelines/templates/build-and-push-containers.yml
+++ b/.pipelines/templates/build-and-push-containers.yml
@@ -24,7 +24,6 @@ steps:
           IMAGE_PREFIX=${{ parameters.IMAGE_PREFIX }}
           TAG=${{ parameters.TAG }}
   - task: DockerCompose@0
-    condition: false
     displayName: Push Presidio Images to ACR
     inputs:
         action: Push services

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -30,7 +30,6 @@ stages:
               AZURE_SUBSCRIPTION: $(ACR_AZURE_SUBSCRIPTION)
 
       - job: E2ETests
-        condition: false
         displayName: E2E Tests
         dependsOn:
           - 'BuildAndPushContainers'


### PR DESCRIPTION
## Change Description

After an ACR was provisioned, do not skip building and pushing presidio docker images and run e2e against them

## Checklist

- [ ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
