### PR TITLE
removed binder link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,7 @@ plugins:
         options:
           docstring_style: sphinx
 - mknotebooks:
-    binder: true
+    binder: false
     binder_service_name: "gh"
     binder_branch: "main"
     binder_ui: "lab"


### PR DESCRIPTION
MyBinder allows you to run any jupyter notebook. mknotebooks has a feature for automatically creating mybinder urls, but it doesn't seem to work, so removing for now until we get this sorted out.