### PR TITLE
FIX: Update broken hyperlink to CONTRIBUTING.md

### DIFF
--- a/docs/analyzer/developing_recognizers.md
+++ b/docs/analyzer/developing_recognizers.md
@@ -14,7 +14,7 @@ For tools and documentation on evaluating and analyzing recognizers, refer to th
     When contributing recognizers to the Presidio OSS,
     new predefined recognizers should be added to the
     [supported entities list](../supported_entities.md),
-    and follow the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.MD).
+    and follow the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md).
 
 ### Performance
 


### PR DESCRIPTION
## Change Description

This PR contains a simple fix to broken hyperlink found in the docs. The old link points to `CONTRIBUTING.MD` and the fix points to `CONTRIBUTING.md`.

## Issue reference

-

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
