### PR TITLE
hotfix for removing fixed dependency versions

### DIFF
--- a/presidio-image-redactor/setup.py
+++ b/presidio-image-redactor/setup.py
@@ -6,15 +6,14 @@ from setuptools import setup, find_packages
 
 requirements = [
     "pillow>=9.0",
-    "pytesseract==0.3.7",
+    "pytesseract>=0.3.7,<0.4",
     "presidio-analyzer>=1.9.0",
-    "matplotlib==3.6.2",
-    "pydantic==1.7.4",
+    "matplotlib>=3.6",
     "pydicom>=2.3.0",
     "pypng>=0.20220715.0",
 ]
 
-test_requirements = ["pytest>=3", "pytest-mock>=3.10.0", "flake8==3.7.9"]
+test_requirements = ["pytest>=3", "pytest-mock>=3.10.0", "flake8>=3.7.9"]
 
 __version__ = ""
 this_directory = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
## Change Description

`presidio-image-redactor` uses some fixed dependencies, such as pydantic==1.7.4. Changed to more flexible dependency versions
