### PR TITLE
Anonymize with instances

### DIFF
--- a/presidio-anonymizer/presidio_anonymizer/anonymizer_engine.py
+++ b/presidio-anonymizer/presidio_anonymizer/anonymizer_engine.py
@@ -80,6 +80,15 @@ class AnonymizerEngine(EngineBase):
 
         operators = self.__check_or_add_default_operator(operators)
 
+        instances = []
+        for result in analyzer_results:
+            instance = text[result.start:result.end]
+            if instance in instances:
+                result.instance_id = instances.index(instance)
+            else:
+                instances.append(instance)
+                result.instance_id = len(instances) - 1
+
         return self._operate(text, analyzer_results, operators, OperatorType.Anonymize)
 
     def _remove_conflicts_and_get_text_manipulation_data(

--- a/presidio-anonymizer/presidio_anonymizer/core/engine_base.py
+++ b/presidio-anonymizer/presidio_anonymizer/core/engine_base.py
@@ -65,7 +65,8 @@ class EngineBase(ABC):
                 operator.entity_type,
                 changed_text,
                 operator_metadata.operator_name,
-                operator.instance_id
+                operator.instance_id,
+                text_to_operate_on
             )
             engine_result.add_item(result_item)
 

--- a/presidio-anonymizer/presidio_anonymizer/core/engine_base.py
+++ b/presidio-anonymizer/presidio_anonymizer/core/engine_base.py
@@ -65,6 +65,7 @@ class EngineBase(ABC):
                 operator.entity_type,
                 changed_text,
                 operator_metadata.operator_name,
+                operator.instance_id
             )
             engine_result.add_item(result_item)
 
@@ -88,6 +89,7 @@ class EngineBase(ABC):
         operator.validate(params=operator_metadata.params)
         params = operator_metadata.params
         params["entity_type"] = entity_type
+        params["instance_id"] = text_metadata.instance_id
         self.logger.debug(f"operating on {entity_type} with {operator}")
         operated_on_text = operator.operate(params=params, text=text_to_operate_on)
         return operated_on_text

--- a/presidio-anonymizer/presidio_anonymizer/entities/engine/pii_entity.py
+++ b/presidio-anonymizer/presidio_anonymizer/entities/engine/pii_entity.py
@@ -14,10 +14,11 @@ class PIIEntity(ABC):
 
     logger = logging.getLogger("presidio-anonymizer")
 
-    def __init__(self, start: int, end: int, entity_type: str):
+    def __init__(self, start: int, end: int, entity_type: str, instance_id: int = None):
         self.start = start
         self.end = end
         self.entity_type = entity_type
+        self.instance_id = instance_id
         self.__validate_fields()
 
     def __repr__(self):
@@ -25,7 +26,8 @@ class PIIEntity(ABC):
         return (
             f"start: {self.start}"
             f"end: {self.end},"
-            f"entity_type: {self.entity_type}"
+            f"entity_type: {self.entity_type},"
+            f"instance_id: {self.instance_id}"
         )
 
     def __gt__(self, other):
@@ -55,3 +57,5 @@ class PIIEntity(ABC):
                 f"Invalid input, start index '{self.start}' "
                 f"must be smaller than end index '{self.end}'"
             )
+        if self.instance_id is not None:
+            validate_type(self.instance_id, "instance_id", int)

--- a/presidio-anonymizer/presidio_anonymizer/entities/engine/result/engine_result.py
+++ b/presidio-anonymizer/presidio_anonymizer/entities/engine/result/engine_result.py
@@ -38,9 +38,15 @@ class EngineResult:
             result_item.start = text_len - result_item.end
             result_item.end = result_item.start + len(result_item.text)
 
+    @staticmethod
+    def _serialize_json(x) -> dict:
+        if isinstance(x, OperatorResult):
+            return {k: x.__dict__[k] for k in x.__dict__ if k != "instance_id"}
+        return x.__dict__
+
     def to_json(self) -> str:
         """Return a json string serializing this instance."""
-        return json.dumps(self, default=lambda x: x.__dict__)
+        return json.dumps(self, default=EngineResult._serialize_json)
 
     def __repr__(self):
         """Return a string representation of the object."""

--- a/presidio-anonymizer/presidio_anonymizer/entities/engine/result/operator_result.py
+++ b/presidio-anonymizer/presidio_anonymizer/entities/engine/result/operator_result.py
@@ -13,8 +13,9 @@ class OperatorResult(PIIEntity):
         entity_type: str,
         text: str = None,
         operator: str = None,
+        instance_id: int = None,
     ):
-        PIIEntity.__init__(self, start, end, entity_type)
+        PIIEntity.__init__(self, start, end, entity_type, instance_id)
         self.text = text
         self.operator = operator
 

--- a/presidio-anonymizer/presidio_anonymizer/entities/engine/result/operator_result.py
+++ b/presidio-anonymizer/presidio_anonymizer/entities/engine/result/operator_result.py
@@ -14,10 +14,12 @@ class OperatorResult(PIIEntity):
         text: str = None,
         operator: str = None,
         instance_id: int = None,
+        plaintext: str = None,
     ):
         PIIEntity.__init__(self, start, end, entity_type, instance_id)
         self.text = text
         self.operator = operator
+        self.plaintext = plaintext
 
     def __repr__(self):
         """Return a string representation of the object."""

--- a/presidio-anonymizer/presidio_anonymizer/operators/replace.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/replace.py
@@ -9,11 +9,16 @@ class Replace(Operator):
     """Receives new text to replace old PII text entity with."""
 
     NEW_VALUE = "new_value"
+    PRESERVE_INSTANCES = "preserve_instances"
+    INSTANCE_ID = "instance_id"
 
     def operate(self, text: str = None, params: Dict = None) -> str:
         """:return: new_value."""
         new_val = params.get(self.NEW_VALUE)
         if not new_val:
+            instance_id = params.get(self.INSTANCE_ID)
+            if params.get(self.PRESERVE_INSTANCES) and instance_id is not None:
+                return f"<{params.get('entity_type')} {instance_id}>"
             return f"<{params.get('entity_type')}>"
         return new_val
 

--- a/presidio-anonymizer/tests/integration/test_anonymize_engine.py
+++ b/presidio-anonymizer/tests/integration/test_anonymize_engine.py
@@ -268,3 +268,25 @@ def test_empty_text_returns_correct_results():
     actual_anonymize_result = AnonymizerEngine().anonymize(text, analyzer_results)
 
     assert actual_anonymize_result.text == text
+
+
+def test_given_name_then_we_replace_and_preserve_instances_correctly():
+    text = "hello world, my name is Jane Doe. Thats Bob Smith, but I am Jane Doe."
+    anonymizer_config = {
+        "DEFAULT": OperatorConfig(
+            "replace", {"preserve_instances": True}
+        ),
+    }
+    analyzer_results = [
+        RecognizerResult(start=24, end=32, score=0.8, entity_type="NAME"),
+        RecognizerResult(start=40, end=49, score=0.8, entity_type="NAME"),
+        RecognizerResult(start=60, end=68, score=0.8, entity_type="NAME"),
+    ]
+    expected_result = (
+        '{"text": "hello world, my name is <NAME 0>. Thats <NAME 1>, but I am <NAME 0>.'
+        '", "items": [{"start": 59, "end": 67, "entity_type": "NAME", "text": "<NAME 0>'
+        '", "operator": "replace"}, {"start": 40, "end": 48, "entity_type": "NAME", "te'
+        'xt": "<NAME 1>", "operator": "replace"}, {"start": 24, "end": 32, "entity_type'
+        '": "NAME", "text": "<NAME 0>", "operator": "replace"}]}'
+    )
+    run_engine_and_validate(text, anonymizer_config, analyzer_results, expected_result)

--- a/presidio-anonymizer/tests/operators/test_replace.py
+++ b/presidio-anonymizer/tests/operators/test_replace.py
@@ -28,3 +28,12 @@ def test_given_no_value_for_replace_then_we_return_default_value_from_entity_typ
 
 def test_when_validate_anonymizer_then_correct_name():
     assert Replace().operator_name() == "replace"
+
+
+def test_instance_preserving():
+    text = Replace().operate("", {
+        "entity_type": "PHONE_NUMBER",
+        "preserve_instances": True,
+        "instance_id": 1
+    })
+    assert text == "<PHONE_NUMBER 1>"


### PR DESCRIPTION
## Change Description

Adds instance identifiers to `replace` anonymizer entities.

NOTE: we overrode JSON serialization to exclude the instance identifiers so that existing tests could pass with minimal changes; let me know if we'd rather update the assertions themselves (all serialized JSONs for `PIIEntity` in tests will need to be changed to include this new `instance_id` field).

## Issue reference

Fixes #1102

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
