### PR TITLE
Fix type mismatch in check_label_groups parameter in SpacyRecognizer

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/spacy_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/spacy_recognizer.py
@@ -50,7 +50,7 @@ class SpacyRecognizer(LocalRecognizer):
         supported_language: str = "en",
         supported_entities: Optional[List[str]] = None,
         ner_strength: float = 0.85,
-        check_label_groups: Optional[Tuple[Set, Set]] = None,
+        check_label_groups: Optional[List[Tuple[Set, Set]]] = None,
         context: Optional[List[str]] = None,
     ):
         self.ner_strength = ner_strength


### PR DESCRIPTION
## Change Description

This PR fixes a type mismatch of the `check_label_groups` parameter in `SpacyRecognizer`. 

The [default value](https://github.com/microsoft/presidio/blob/67833d5be37ce2ce603836e120f40bb7513ee498/presidio-analyzer/presidio_analyzer/predefined_recognizers/spacy_recognizer.py#L40-L45) is of type `List[Tuple[Set, Set]]`, and the received parameter is of type `Tuple[Set, Set]`


## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
