### PR TITLE
Use base64 encoded key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Changed
+* Use base64 encoded keys in encrypt and decrypt operators
 
 ## [2.2.33] - June 1st 2023
 ### Added

--- a/docs/anonymizer/index.md
+++ b/docs/anonymizer/index.md
@@ -98,7 +98,7 @@ with some other value by applying a certain operator (e.g. replace, mask, redact
         entities=[
             OperatorResult(start=11, end=55, entity_type="PERSON"),
         ],
-        operators={"DEFAULT": OperatorConfig("decrypt", {"key": "WmZq4t7w!z%C&F)J"})},
+        operators={"DEFAULT": OperatorConfig("decrypt", {"key": base64.b64encode(b"WmZq4t7w!z%C&F)J").decode('utf-8')})},
     )
 
     print(result)
@@ -176,7 +176,7 @@ with some other value by applying a certain operator (e.g. replace, mask, redact
     "deanonymizers": {
         "PERSON": {
             "type": "decrypt",
-            "key": "WmZq4t7w!z%C&F)J"
+            "key": base64.b64encode(b"WmZq4t7w!z%C&F)J").decode('utf-8')
         }
     },
     "anonymizer_results": [

--- a/docs/api-docs/api-docs.yml
+++ b/docs/api-docs/api-docs.yml
@@ -360,7 +360,7 @@ components:
                   "deanonymizers": {
                     "PERSON": {
                       "type": "decrypt",
-                      "key": "WmZq4t7w!z%C&F)J"
+                      "key": base64.b64encode(b"WmZq4t7w!z%C&F)J").decode('utf-8')
                     }
                   },
                   "anonymizer_results": [ {
@@ -461,7 +461,7 @@ components:
             anyOf:
               - $ref: "#/components/schemas/Decrypt"
           default:
-            { "DEFAULT": { "type": "decrypt", "key": "3t6w9z$C&F)J@NcR" } }
+            { "DEFAULT": { "type": "decrypt", "key": base64.b64encode(b"3t6w9z$C&F)J@NcR").decode('utf-8') } }
         anonymizer_results:
           type: array
           description: "Array of anonymized PIIs"

--- a/docs/presidio_V2.md
+++ b/docs/presidio_V2.md
@@ -184,7 +184,7 @@ Below is a detailed outline of all the changes done to the Analyzer and Anonymiz
 | Redact             | NONE                                                                                    | NONE                                                                                       |
 | Mask               | <pre>string maskingCharacter = 1;<br>int32 charsToMask = 2; <br>bool fromEnd = 3;</pre> | <pre>{<br> "chars_to_mask": 10,<br> "from_end": true,<br> "masking_char": "\*" <br>}</pre> |
 | Hash               | NONE                                                                                    | <pre>{"hash_type": "VALUE"}</pre>                                                          |
-| FPE (now Encrypt)  | <pre>string key = 3t6w9z$C&F)J@NcR;<br>int32 tweak = D8E7920AFA330A73</pre>             | <pre>{"key": "3t6w9z$C&F)J@NcR"}</pre>                                                          |
+| FPE (now Encrypt)  | <pre>string key = 3t6w9z$C&F)J@NcR;<br>int32 tweak = D8E7920AFA330A73</pre>             | <pre>{"key": base64.b64encode(b"3t6w9z$C&F)J@NcR").decode('utf-8')}</pre>                                                          |
 
 !!! note "Note"
 	The V2 API keeps changing please [follow the change log](https://github.com/microsoft/presidio/blob/main/CHANGELOG.md) for updates.

--- a/docs/tutorial/12_encryption.md
+++ b/docs/tutorial/12_encryption.md
@@ -12,13 +12,15 @@ from presidio_anonymizer.entities import (
     OperatorResult,
     OperatorConfig,
 )
+import base64
+import os
 ```
 
 ## Define a cryptographic key (for both encryption and decryption)
 
 <!--pytest-codeblocks:cont-->
 ```python
-crypto_key = "WmZq4t7w!z%C&F)J"
+crypto_key = base64.b64encode(os.urandom(16)).decode('utf-8')
 ```
 
 ## Presidio Anonymizer: Encrypt

--- a/presidio-anonymizer/README.MD
+++ b/presidio-anonymizer/README.MD
@@ -164,7 +164,7 @@ and decrypt it back to the original text:
 ```python
 from presidio_anonymizer import DeanonymizeEngine
 from presidio_anonymizer.entities import OperatorResult, OperatorConfig
-
+import base64
 # Initialize the engine with logger.
 engine = DeanonymizeEngine()
 
@@ -175,7 +175,7 @@ result = engine.deanonymize(
     entities=[
         OperatorResult(start=11, end=55, entity_type="PERSON"),
     ],
-    operators={"DEFAULT": OperatorConfig("decrypt", {"key": "WmZq4t7w!z%C&F)J"})},
+    operators={"DEFAULT": OperatorConfig("decrypt", {"key": base64.b64encode(b"WmZq4t7w!z%C&F)J").decode('utf-8')})},
 )
 
 print(result)

--- a/presidio-anonymizer/presidio_anonymizer/operators/decrypt.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/decrypt.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+import base64
 from presidio_anonymizer.entities import InvalidParamException
 from presidio_anonymizer.operators import Operator
 from presidio_anonymizer.operators import OperatorType
@@ -19,11 +20,12 @@ class Decrypt(Operator):
 
         :param text: The text for decryption.
         :param params:
-            **key* The key supplied by the user for the encryption.
+            **key* The key supplied by the user for the encryption
+            in a base64 encoded string.
         :return: The encrypted text
         """
-        encoded_key = params.get(self.KEY).encode("utf8")
-        decrypted_text = AESCipher.decrypt(key=encoded_key, text=text)
+        key_bytes = base64.b64decode(params.get(self.KEY), validate=True)
+        decrypted_text = AESCipher.decrypt(key=key_bytes, text=text)
         return decrypted_text
 
     def validate(self, params: Dict = None) -> None:
@@ -31,15 +33,22 @@ class Decrypt(Operator):
         Validate Decrypt parameters.
 
         :param params:
-            * *key* The key supplied by the user for the encryption.
-                    Should be a string of 128, 192 or 256 bits length.
+            * *key* The key supplied by the user for the encryption in
+            a base64 encoded string. The base64 decoded key should be bytes
+            of 128, 192 or 256 bits length.
         :raises InvalidParamException in case on an invalid parameter.
         """
-        key = params.get(self.KEY)
-        validate_parameter(key, self.KEY, str)
-        if not AESCipher.is_valid_key_size(key.encode("utf8")):
+        try:
+            key_bytes = base64.b64decode(params.get(self.KEY), validate=True)
+        except Exception as e:
             raise InvalidParamException(
-                f"Invalid input, {self.KEY} must be of length 128, 192 or 256 bits"
+                f"Invalid input, {self.KEY} must be base64 encoded"
+            ) from e
+        validate_parameter(params.get(self.KEY), self.KEY, str)
+        if not AESCipher.is_valid_key_size(key_bytes):
+            raise InvalidParamException(
+                f"Invalid input, {self.KEY} must be of base64 encoded bytes "
+                "of length 128, 192 or 256 bits"
             )
 
     def operator_name(self) -> str:

--- a/presidio-anonymizer/presidio_anonymizer/operators/encrypt.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/encrypt.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+import base64
 from presidio_anonymizer.entities import InvalidParamException
 from presidio_anonymizer.operators import Operator, OperatorType
 from presidio_anonymizer.operators.aes_cipher import AESCipher
@@ -17,11 +18,17 @@ class Encrypt(Operator):
 
         :param text: The text for encryption.
         :param params:
-            * *key* The key supplied by the user for the encryption.
+            * *key* The key supplied by the user for the encryption in
+            a base64 encoded string.
         :return: The encrypted text
         """
-        encoded_key = params.get(self.KEY).encode("utf8")
-        encrypted_text = AESCipher.encrypt(encoded_key, text)
+        try:
+            key_bytes = base64.b64decode(params.get(self.KEY), validate=True)
+        except Exception as e:
+            raise InvalidParamException(
+                f"Invalid input, {self.KEY} must be base64 encoded"
+            ) from e
+        encrypted_text = AESCipher.encrypt(key_bytes, text)
         return encrypted_text
 
     def validate(self, params: Dict = None) -> None:
@@ -29,15 +36,22 @@ class Encrypt(Operator):
         Validate Encrypt parameters.
 
         :param params:
-            * *key* The key supplied by the user for the encryption.
-                    Should be a string of 128, 192 or 256 bits length.
+            * *key* The key supplied by the user for the encryption in
+            a base64 encoded string. The base64 decoded key should be bytes
+            of 128, 192 or 256 bits length.
         :raises InvalidParamException in case on an invalid parameter.
         """
-        key = params.get(self.KEY)
-        validate_parameter(key, self.KEY, str)
-        if not AESCipher.is_valid_key_size(key.encode("utf8")):
+        try:
+            key_bytes = base64.b64decode(params.get(self.KEY), validate=True)
+        except Exception as e:
             raise InvalidParamException(
-                f"Invalid input, {self.KEY} must be of length 128, 192 or 256 bits"
+                f"Invalid input, {self.KEY} must be base64 encoded"
+            ) from e
+        validate_parameter(params.get(self.KEY), self.KEY, str)
+        if not AESCipher.is_valid_key_size(key_bytes):
+            raise InvalidParamException(
+                f"Invalid input, {self.KEY} must be of base64 encoded bytes "
+                "of length 128, 192 or 256 bits"
             )
 
     def operator_name(self) -> str:

--- a/presidio-anonymizer/tests/integration/test_anonymize_engine.py
+++ b/presidio-anonymizer/tests/integration/test_anonymize_engine.py
@@ -1,4 +1,5 @@
 import pytest
+import base64
 
 from presidio_anonymizer import AnonymizerEngine
 from presidio_anonymizer.entities import (
@@ -34,8 +35,8 @@ def test_given_operator_decrypt_then_we_fail():
     ]
     engine = AnonymizerEngine()
     with pytest.raises(
-            InvalidParamException,
-            match="Invalid operator class 'decrypt'.",
+        InvalidParamException,
+        match="Invalid operator class 'decrypt'.",
     ):
         engine.anonymize(text, analyzer_results, anonymizers_config)
 
@@ -246,7 +247,7 @@ def test_given_anonymize_with_encrypt_then_text_returned_with_encrypted_content(
     text = unencrypted_text + expected_encrypted_text
     start_index = 11
     end_index = 16
-    key = "WmZq4t7w!z%C&F)J"
+    key = base64.b64encode(b"WmZq4t7w!z%C&F)J").decode("utf-8")
     analyzer_results = [RecognizerResult("PERSON", start_index, end_index, 0.8)]
     anonymizers_config = {"PERSON": OperatorConfig("encrypt", {"key": key})}
 
@@ -257,7 +258,9 @@ def test_given_anonymize_with_encrypt_then_text_returned_with_encrypted_content(
     assert actual_anonymize_result[:start_index] == unencrypted_text
     actual_encrypted_text = actual_anonymize_result[start_index:]
     assert actual_encrypted_text != expected_encrypted_text
-    actual_decrypted_text = AESCipher.decrypt(key.encode(), actual_encrypted_text)
+    actual_decrypted_text = AESCipher.decrypt(
+        base64.b64decode(key), actual_encrypted_text
+    )
     assert actual_decrypted_text == expected_encrypted_text
 
 

--- a/presidio-anonymizer/tests/operators/test_decrypt.py
+++ b/presidio-anonymizer/tests/operators/test_decrypt.py
@@ -1,5 +1,5 @@
 from unittest import mock
-
+import base64
 import pytest
 
 from presidio_anonymizer.entities import InvalidParamException
@@ -13,18 +13,21 @@ def test_given_anonymize_then_aes_encrypt_called_and_its_result_is_returned(
     expected_decrypted_text = "decrypted_text"
     mock_encrypt.return_value = expected_decrypted_text
 
-    anonymized_text = Decrypt().operate(text="text", params={"key": "key"})
+    base64_encoded_key = base64.b64encode(b"key").decode("utf-8")
+    anonymized_text = Decrypt().operate(text="text", params={"key": base64_encoded_key})
 
     assert anonymized_text == expected_decrypted_text
 
 
 def test_given_verifying_an_valid_length_key_no_exceptions_raised():
-    Decrypt().validate(params={"key": "128bitslengthkey"})
+    base64_encoded_key = base64.b64encode(b"128bitslengthkey").decode("utf-8")
+    Decrypt().validate(params={"key": base64_encoded_key})
 
 
 def test_given_verifying_an_invalid_length_key_then_ipe_raised():
     with pytest.raises(
         InvalidParamException,
-        match="Invalid input, key must be of length 128, 192 or 256 bits",
+        match="Invalid input, key must be of base64 encoded bytes of length 128, 192 or 256 bits",
     ):
-        Decrypt().validate(params={"key": "key"})
+        base64_encoded_key = base64.b64encode(b"key").decode("utf-8")
+        Decrypt().validate(params={"key": base64_encoded_key})

--- a/presidio-anonymizer/tests/operators/test_encrypt.py
+++ b/presidio-anonymizer/tests/operators/test_encrypt.py
@@ -1,5 +1,5 @@
 from unittest import mock
-
+import base64
 import pytest
 
 from presidio_anonymizer.operators import Encrypt, AESCipher
@@ -13,18 +13,21 @@ def test_given_anonymize_then_aes_encrypt_called_and_its_result_is_returned(
     expected_anonymized_text = "encrypted_text"
     mock_encrypt.return_value = expected_anonymized_text
 
-    anonymized_text = Encrypt().operate(text="text", params={"key": "key"})
+    base64_encoded_key = base64.b64encode(b"key").decode("utf-8")
+    anonymized_text = Encrypt().operate(text="text", params={"key": base64_encoded_key})
 
     assert anonymized_text == expected_anonymized_text
 
 
 def test_given_verifying_an_valid_length_key_no_exceptions_raised():
-    Encrypt().validate(params={"key": "128bitslengthkey"})
+    base64_encoded_key = base64.b64encode(b"128bitslengthkey").decode("utf-8")
+    Encrypt().validate(params={"key": base64_encoded_key})
 
 
 def test_given_verifying_an_invalid_length_key_then_ipe_raised():
     with pytest.raises(
         InvalidParamException,
-        match="Invalid input, key must be of length 128, 192 or 256 bits",
+        match="Invalid input, key must be of base64 encoded bytes of length 128, 192 or 256 bits",
     ):
-        Encrypt().validate(params={"key": "key"})
+        base64_encoded_key = base64.b64encode(b"key").decode("utf-8")
+        Encrypt().validate(params={"key": base64_encoded_key})

--- a/presidio-anonymizer/tests/test_readme.py
+++ b/presidio-anonymizer/tests/test_readme.py
@@ -1,3 +1,6 @@
+import base64
+
+
 def test_readme():
     # Tests that the readme code snippet doesn't fail
     from presidio_anonymizer import AnonymizerEngine
@@ -35,7 +38,12 @@ def test_readme_decrypt():
         entities=[
             OperatorResult(start=11, end=55, entity_type="PERSON"),
         ],
-        operators={"DEFAULT": OperatorConfig("decrypt", {"key": "WmZq4t7w!z%C&F)J"})},
+        operators={
+            "DEFAULT": OperatorConfig(
+                "decrypt",
+                {"key": base64.b64encode(b"WmZq4t7w!z%C&F)J").decode("utf-8")},
+            )
+        },
     )
 
     print(result)


### PR DESCRIPTION
## Change Description

This PR enables that the encrypt operator and decrypt operator to use base64 encoded keys.

## Issue reference

This PR fixes issue #1131
## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
