### PR TITLE
Updating verification engines to include latest updates to redactor engines

### DIFF
--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_pii_verify_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_pii_verify_engine.py
@@ -13,7 +13,7 @@ from presidio_image_redactor import (
 from presidio_image_redactor import ImagePiiVerifyEngine, BboxProcessor
 from presidio_analyzer import PatternRecognizer
 
-from typing import Tuple, List, Optional, Union
+from typing import Tuple, List, Optional
 
 
 class DicomImagePiiVerifyEngine(ImagePiiVerifyEngine, DicomImageRedactorEngine):

--- a/presidio-image-redactor/presidio_image_redactor/image_pii_verify_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/image_pii_verify_engine.py
@@ -21,11 +21,6 @@ def fig2img(fig):
 class ImagePiiVerifyEngine(ImageRedactorEngine):
     """ImagePiiVerifyEngine class only supporting Pii verification currently."""
 
-    def __init__(self, image_analyzer_engine: Optional[ImageAnalyzerEngine] = None):
-        if not image_analyzer_engine:
-            image_analyzer_engine = ImageAnalyzerEngine()
-        self.image_analyzer_engine = image_analyzer_engine
-
     def verify(
         self,
         image: Image,

--- a/presidio-image-redactor/presidio_image_redactor/image_pii_verify_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/image_pii_verify_engine.py
@@ -1,5 +1,4 @@
 from PIL import Image, ImageChops
-from presidio_image_redactor.image_analyzer_engine import ImageAnalyzerEngine
 from presidio_image_redactor.image_redactor_engine import ImageRedactorEngine
 from presidio_analyzer import PatternRecognizer
 import matplotlib

--- a/presidio-image-redactor/presidio_image_redactor/image_pii_verify_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/image_pii_verify_engine.py
@@ -1,9 +1,11 @@
 from PIL import Image, ImageChops
 from presidio_image_redactor.image_analyzer_engine import ImageAnalyzerEngine
+from presidio_image_redactor.image_redactor_engine import ImageRedactorEngine
+from presidio_analyzer import PatternRecognizer
 import matplotlib
 import io
 from matplotlib import pyplot as plt
-from typing import Optional
+from typing import Optional, List
 
 
 def fig2img(fig):
@@ -16,7 +18,7 @@ def fig2img(fig):
     return img
 
 
-class ImagePiiVerifyEngine:
+class ImagePiiVerifyEngine(ImageRedactorEngine):
     """ImagePiiVerifyEngine class only supporting Pii verification currently."""
 
     def __init__(self, image_analyzer_engine: Optional[ImageAnalyzerEngine] = None):
@@ -25,7 +27,11 @@ class ImagePiiVerifyEngine:
         self.image_analyzer_engine = image_analyzer_engine
 
     def verify(
-        self, image: Image, ocr_kwargs: Optional[dict] = None, **text_analyzer_kwargs
+        self,
+        image: Image,
+        ocr_kwargs: Optional[dict] = None,
+        ad_hoc_recognizers: Optional[List[PatternRecognizer]] = None,
+        **text_analyzer_kwargs
     ) -> Image:
         """Annotate image with the detect PII entity.
 
@@ -34,6 +40,8 @@ class ImagePiiVerifyEngine:
 
         :param image: PIL Image to be processed.
         :param ocr_kwargs: Additional params for OCR methods.
+        :param ad_hoc_recognizers: List of PatternRecognizer objects to use
+        for ad-hoc recognizer.
         :param text_analyzer_kwargs: Additional values for the analyze method
         in ImageAnalyzerEngine.
 
@@ -42,9 +50,23 @@ class ImagePiiVerifyEngine:
 
         image = ImageChops.duplicate(image)
         image_x, image_y = image.size
-        bboxes = self.image_analyzer_engine.analyze(
-            image, ocr_kwargs, **text_analyzer_kwargs
-        )
+
+        # Detect PII
+        self._check_ad_hoc_recognizer_list(ad_hoc_recognizers)
+        if ad_hoc_recognizers is None:
+            bboxes = self.image_analyzer_engine.analyze(
+                image,
+                ocr_kwargs=ocr_kwargs,
+                **text_analyzer_kwargs,
+            )
+        else:
+            bboxes = self.image_analyzer_engine.analyze(
+                image,
+                ocr_kwargs=ocr_kwargs,
+                ad_hoc_recognizers=ad_hoc_recognizers,
+                **text_analyzer_kwargs,
+            )
+
         fig, ax = plt.subplots()
         image_r = 70
         fig.set_size_inches(image_x / image_r, image_y / image_r)

--- a/presidio-image-redactor/tests/test_dicom_image_pii_verify_engine.py
+++ b/presidio-image-redactor/tests/test_dicom_image_pii_verify_engine.py
@@ -86,21 +86,11 @@ def test_verify_dicom_instance_happy_path(
     mock_add_padding = mocker.patch.object(
         DicomImagePiiVerifyEngine, "_add_padding", return_value=None
     )
-    mock_get_metadata = mocker.patch.object(
-        DicomImagePiiVerifyEngine, "_get_text_metadata", return_value=[None, None, None]
-    )
-    mock_make_phi_list = mocker.patch.object(
-        DicomImagePiiVerifyEngine, "_make_phi_list", return_value=None
-    )
-    mock_patternrecognizer = mocker.patch(
-        "presidio_image_redactor.dicom_image_pii_verify_engine.PatternRecognizer",
-        return_value=None,
-    )
     mock_perform_ocr = mocker.patch.object(
         TesseractOCR, "perform_ocr", return_value=None
     )
     mock_analyze = mocker.patch.object(
-        ImageAnalyzerEngine, "analyze", return_value=None
+        DicomImagePiiVerifyEngine, "_get_analyzer_results", return_value=None
     )
     mock_verify = mocker.patch.object(
         DicomImagePiiVerifyEngine, "verify", return_value=None
@@ -115,9 +105,6 @@ def test_verify_dicom_instance_happy_path(
     assert mock_save_pixel_array.call_count == 1
     assert mock_image_open.call_count == 1
     assert mock_add_padding.call_count == 1
-    assert mock_get_metadata.call_count == 1
-    assert mock_make_phi_list.call_count == 1
-    assert mock_patternrecognizer.call_count == 1
     assert mock_perform_ocr.call_count == 1
     assert mock_analyze.call_count == 1
     assert mock_verify.call_count == 1


### PR DESCRIPTION
## Change Description

Updating both the standard and the DICOM image PII verification engines to allow use of ad-hoc recognizers and the allow list approach, as recently enabled with the redactor engines.

## Issue reference

This PR fixes issue #XX

## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [X] My code includes unit tests
- [X] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
