### PR TITLE
anonymize_list return type hint fix

### DIFF
--- a/presidio-anonymizer/presidio_anonymizer/batch_anonymizer_engine.py
+++ b/presidio-anonymizer/presidio_anonymizer/batch_anonymizer_engine.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Union, Iterable, Optional
 
 from presidio_anonymizer import AnonymizerEngine
 from presidio_anonymizer.entities import DictRecognizerResult
-from presidio_anonymizer.entities import EngineResult, RecognizerResult
+from presidio_anonymizer.entities import RecognizerResult
 
 
 class BatchAnonymizerEngine:
@@ -22,7 +22,7 @@ class BatchAnonymizerEngine:
         texts: List[Union[str, bool, int, float]],
         recognizer_results_list: List[List[RecognizerResult]],
         **kwargs
-    ) -> List[EngineResult]:
+    ) -> List[Union[str, object]]:
         """
         Anonymize a list of strings.
 


### PR DESCRIPTION
## Change Description

The anonymize_list function of the BatchAnonymizerEngine class never returns List[EngineResult].
Changed the return type hint to List[Union[str, object]] and import

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
