### PR TITLE
Change ner_model_configuration from list to map in languages-config.yml example

### DIFF
--- a/docs/analyzer/languages-config.yml
+++ b/docs/analyzer/languages-config.yml
@@ -10,7 +10,7 @@ models:
     lang_code: es
     model_name: es_core_news_md
 ner_model_configuration:
-  - model_to_presidio_entity_mapping:
+  model_to_presidio_entity_mapping:
     PER: PERSON
     PERSON: PERSON
     LOC: LOCATION
@@ -21,8 +21,8 @@ ner_model_configuration:
     TIME: DATE_TIME
     NORP: NRP
 
-  - low_confidence_score_multiplier: 0.4
-  - low_score_entity_names:
+  low_confidence_score_multiplier: 0.4
+  low_score_entity_names:
     - ORGANIZATION
     - ORG
-  - default_score: 0.85
+  default_score: 0.85


### PR DESCRIPTION
## Change Description

When using the provided [languages-config.yml](https://github.com/microsoft/presidio/blob/main/docs/analyzer/languages-config.yml) file from the documentation for multi-language support, I got the following error:

```
  File "[...]/site-packages/presidio_analyzer/nlp_engine/ner_model_configuration.py", line 125, in from_dict
    return cls(**nlp_engine_configuration)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: presidio_analyzer.nlp_engine.ner_model_configuration.NerModelConfiguration() argument after ** must be a mapping, not list
```

Changing the format in the YAML file fixes this.

Reproduction:
```
from presidio_analyzer.nlp_engine import NlpEngineProvider

provider = NlpEngineProvider(conf_file="languages-config.yml")
nlp_engine_eng_french = provider.create_engine()
```

- Fails with [languages-config.yml](https://github.com/microsoft/presidio/blob/main/docs/analyzer/languages-config.yml)
- Works with the provided fix


## Issue reference

No reported issues

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
