### PR TITLE
fixes bug #1227

### DIFF
--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
@@ -338,9 +338,8 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
             image_2d_scaled = image_2d_float
         else:
             # Rescaling grey scale between 0-255
-            image_2d_scaled = (
-                np.maximum(image_2d_float, 0) / image_2d_float.max()
-            ) * 255.0
+            image_2d_scaled = ((image_2d_float.max() - image_2d_float) / (
+                    image_2d_float.max() - image_2d_float.min())) * 255.0
 
         # Convert to uint
         image_2d_scaled = np.uint8(image_2d_scaled)


### PR DESCRIPTION
## Change Description

In dicom_image_radactor_engine.py, the image intensity are rescaled using the function _rescale_dcm_pixel_array(). In the rescaling formula, changes are made to use the max and min intensity of the image, instead of assuming the smallest intensity is 0. 

## Issue reference

This PR fixes issue #1227 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
