### PR TITLE
Updated index.md of transformers_recognizer documentation

### DIFF
--- a/docs/samples/python/transformers_recognizer/index.md
+++ b/docs/samples/python/transformers_recognizer/index.md
@@ -9,7 +9,7 @@
 
 When initializing the `TransformersRecognizer`, choose from the following options:
 
-1. A string referencing an uploaded model to HuggingFace. See the different available options for models [here](https://huggingface.co/models?pipeline_tag=token-classification&sort=downloads>).
+1. A string referencing an uploaded model to HuggingFace. See the different available options for models [here](https://huggingface.co/models?pipeline_tag=token-classification&sort=downloads).
 
 2. Initialize your own `TokenClassificationPipeline` instance using your custom transformers model and use it for inference.
 


### PR DESCRIPTION
Removed the extra symbol that causing error to load the site from transformers_recognizer documentation.

## Change Description

The earlier link was - https://huggingface.co/models?pipeline_tag=token-classification&sort=downloads> this link contains an extra symbol ">" that causing the error to load this link. Updated the link by removing that symbol now new link is this - https://huggingface.co/models?pipeline_tag=token-classification&sort=downloads. 

## Issue reference

This PR fixes issue #1240 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
