### PR TITLE
Update anonymize_list type hints and document that sometimes items will be ignored.

### DIFF
--- a/presidio-anonymizer/presidio_anonymizer/batch_anonymizer_engine.py
+++ b/presidio-anonymizer/presidio_anonymizer/batch_anonymizer_engine.py
@@ -1,5 +1,5 @@
 import collections
-from typing import List, Dict, Union, Iterable, Optional
+from typing import Any, List, Dict, Union, Iterable, Optional
 
 from presidio_anonymizer import AnonymizerEngine
 from presidio_anonymizer.entities import DictRecognizerResult
@@ -19,14 +19,15 @@ class BatchAnonymizerEngine:
 
     def anonymize_list(
         self,
-        texts: List[Union[str, bool, int, float]],
+        texts: List[Optional[Union[str, bool, int, float]]],
         recognizer_results_list: List[List[RecognizerResult]],
         **kwargs
-    ) -> List[Union[str, object]]:
+    ) -> List[Union[str, Any]]:
         """
         Anonymize a list of strings.
 
-        :param texts: List containing the texts to be anonymized (original texts)
+        :param texts: List containing the texts to be anonymized (original texts).
+            Items with a `type` not in `(str, bool, int, float)` will not be anonymized.
         :param recognizer_results_list: A list of lists of RecognizerResult,
         the output of the AnalyzerEngine on each text in the list.
         :param kwargs: Additional kwargs for the `AnonymizerEngine.anonymize` method


### PR DESCRIPTION
Replace `object`  with `Any`. Mark the input list argument as being nullable. Document the existing behaviour in the docstring.

## Issue reference

[This PR fixes issue #1249 
](https://github.com/microsoft/presidio/issues/1249)

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- N/A My code includes unit tests
- N/A All unit tests and lint checks pass locally
- N/A My PR contains documentation updates / additions if required
