### PR TITLE
Add keep operator as deanonymizer

### DIFF
--- a/presidio-anonymizer/presidio_anonymizer/operators/__init__.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/__init__.py
@@ -5,7 +5,7 @@ from .mask import Mask
 from .redact import Redact
 from .replace import Replace
 from .custom import Custom
-from .keep import Keep
+from .keep import Keep, DeanonymizeKeep
 from .encrypt import Encrypt
 from .decrypt import Decrypt
 from .aes_cipher import AESCipher
@@ -18,6 +18,7 @@ __all__ = [
     "Mask",
     "Redact",
     "Keep",
+    "DeanonymizeKeep",
     "Replace",
     "Custom",
     "Encrypt",

--- a/presidio-anonymizer/presidio_anonymizer/operators/keep.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/keep.py
@@ -1,14 +1,15 @@
 """Keeps the PII text unmodified."""
+from abc import ABC
 from typing import Dict
 
 from presidio_anonymizer.operators import Operator, OperatorType
 
 
-class Keep(Operator):
-    """No-op anonymizer that keeps the PII text unmodified.
+class BaseKeep(Operator, ABC):
+    """Abstract base class for keep operators.
 
-    This is useful when you don't want to anonymize some types of PII,
-    but wants to keep track of it with the other PIIs.
+    Implements the common functionality of keep operators, leaving the operator
+    type to be implemented by concrete classes
     """
 
     def operate(self, text: str = None, params: Dict = None) -> str:
@@ -19,6 +20,14 @@ class Keep(Operator):
         """Keep does not require any paramters so no validation is needed."""
         pass
 
+
+class Keep(BaseKeep, Operator):
+    """No-op anonymizer that keeps the PII text unmodified.
+
+    This is useful when you don't want to anonymize some types of PII,
+    but wants to keep track of it with the other PIIs.
+    """
+
     def operator_name(self) -> str:
         """Return operator name."""
         return "keep"
@@ -26,3 +35,19 @@ class Keep(Operator):
     def operator_type(self) -> OperatorType:
         """Return operator type."""
         return OperatorType.Anonymize
+
+
+class DeanonymizeKeep(BaseKeep, Operator):
+    """No-op deanonymizer that keeps the PII text unmodified.
+
+    This is useful when you don't want to anonymize some types of PII,
+    but wants to keep track of it with the other PIIs.
+    """
+
+    def operator_name(self) -> str:
+        """Return operator name."""
+        return "deanonymize_keep"
+
+    def operator_type(self) -> OperatorType:
+        """Return operator type."""
+        return OperatorType.Deanonymize

--- a/presidio-anonymizer/tests/integration/test_deanonymize_engine.py
+++ b/presidio-anonymizer/tests/integration/test_deanonymize_engine.py
@@ -20,7 +20,7 @@ def test_given_operator_decrypt_with_valid_params_then_decrypt_text_successfully
     decryption = engine.deanonymize(
         text,
         encryption_results,
-        {"DEFAULT": OperatorConfig(Decrypt.NAME, {"key": b'WmZq4t7w!z%C&F)J'})},
+        {"DEFAULT": OperatorConfig(Decrypt.NAME, {"key": b"WmZq4t7w!z%C&F)J"})},
     )
     assert decryption.text == "My name is Chloë"
     assert len(decryption.items) == 1
@@ -91,7 +91,7 @@ def test_given_anonymize_with_encrypt_then_text_returned_with_encrypted_content(
 
 def test_given_request_deanonymizers_return_list():
     engine = DeanonymizeEngine()
-    expected_list = ["decrypt"]
+    expected_list = ["deanonymize_keep", "decrypt"]
     anon_list = engine.get_deanonymizers()
 
     assert anon_list == expected_list

--- a/presidio-anonymizer/tests/operators/test_keep.py
+++ b/presidio-anonymizer/tests/operators/test_keep.py
@@ -1,21 +1,26 @@
 import pytest
 
-from presidio_anonymizer.operators import Keep
+from presidio_anonymizer.operators import DeanonymizeKeep, Keep
 
 
+@pytest.mark.parametrize("operator", [Keep, DeanonymizeKeep])
 @pytest.mark.parametrize(
     # fmt: off
-    "params",
+    ["params"],
     [
         {"new_value": ""},
         {},
     ],
     # fmt: on
 )
-def when_given_valid_value_then_same_string_returned(params):
-    text = Keep().operate("bla", params)
+def when_given_valid_value_then_same_string_returned(params, operator):
+    text = operator().operate("bla", params)
     assert text == "bla"
 
 
-def test_when_validate_anonymizer_then_correct_name():
-    assert Keep().operator_name() == "keep"
+@pytest.mark.parametrize(
+    ["operator", "expected_op_name"],
+    [(Keep, "keep"), (DeanonymizeKeep, "deanonymize_keep")],
+)
+def test_when_validate_anonymizer_then_correct_name(operator, expected_op_name):
+    assert operator().operator_name() == expected_op_name

--- a/presidio-anonymizer/tests/operators/test_operators_factory.py
+++ b/presidio-anonymizer/tests/operators/test_operators_factory.py
@@ -21,7 +21,7 @@ def test_given_anonymizers_list_then_all_classes_are_there():
 
 def test_given_decryptors_list_then_all_classes_are_there():
     decryptors = OperatorsFactory.get_deanonymizers()
-    assert len(decryptors) == 1
+    assert len(decryptors) == 2
     for class_name in ["decrypt"]:
         assert decryptors.get(class_name)
 


### PR DESCRIPTION
Implements the `keep` operator for deanonymisation too.

It keeps all the methods from the Keep class and extends only the ones that return the type.

Concrete classes MUST subclass `Operator` type, since operator discovery is done with `Operator.__subclasses__()`

This PR fixes issue #1254

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
