### PR TITLE
Allow local Spacy Models to be loaded in NLP Engine

### DIFF
--- a/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import Optional, Dict, Iterator, Tuple, Union, List
 
 import spacy
@@ -59,7 +60,7 @@ class SpacyNlpEngine(NlpEngine):
 
     @staticmethod
     def _download_spacy_model_if_needed(model_name: str) -> None:
-        if not spacy.util.is_package(model_name):
+        if not (spacy.util.is_package(model_name) or Path(name).exists()):
             logger.warning(f"Model {model_name} is not installed. Downloading...")
             spacy.cli.download(model_name)
             logger.info(f"Finished downloading model {model_name}")

--- a/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
@@ -60,7 +60,7 @@ class SpacyNlpEngine(NlpEngine):
 
     @staticmethod
     def _download_spacy_model_if_needed(model_name: str) -> None:
-        if not (spacy.util.is_package(model_name) or Path(name).exists()):
+        if not (spacy.util.is_package(model_name) or Path(model_name).exists()):
             logger.warning(f"Model {model_name} is not installed. Downloading...")
             spacy.cli.download(model_name)
             logger.info(f"Finished downloading model {model_name}")


### PR DESCRIPTION
Currently `SpacyNlpEngine` does not support use of local model paths. This is important for offline/airgapped environments where it is not possible to download spacy model on the fly

## Change Description

Follows Spacy's internal logic in `.load`
```py
if is_package(name):  # installed as package
    465     return load_model_from_package(name, **kwargs)  # type: ignore[arg-type]
    466 if Path(name).exists():  # path to model data directory
    467     return load_model_from_path(Path(name), **kwargs)  # type: ignore[arg-type]
```

## Issue reference

This PR fixes issue #XX

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
