### PR TITLE
Bugfix issue #1274

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+### Changed
+#### Image Redactor
+* Bugfix in ImageAnalyzerEngine  #1274
+
 ## [2.2.352] - Jan 22nd 2024
 ### Added
 #### Structured

--- a/presidio-image-redactor/presidio_image_redactor/image_analyzer_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/image_analyzer_engine.py
@@ -70,8 +70,11 @@ class ImageAnalyzerEngine:
         # Analyze text
         text = self.ocr.get_text_from_ocr_dict(ocr_result)
 
+        # Difines English as default language, if not specified
+        if "language" not in text_analyzer_kwargs:
+            text_analyzer_kwargs["language"] = "en"
         analyzer_result = self.analyzer_engine.analyze(
-            text=text, language="en", **text_analyzer_kwargs
+            text=text, **text_analyzer_kwargs
         )
         allow_list = self._check_for_allow_list(text_analyzer_kwargs)
         bboxes = self.map_analyzer_results_to_bounding_boxes(

--- a/presidio-image-redactor/tests/conftest.py
+++ b/presidio-image-redactor/tests/conftest.py
@@ -9,6 +9,12 @@ from presidio_image_redactor import ImageAnalyzerEngine
 from presidio_image_redactor.entities import ImageRecognizerResult
 import pytest
 
+from presidio_analyzer.nlp_engine import NlpEngine
+from presidio_analyzer.nlp_engine import NlpArtifacts
+
+from typing import Iterable, Iterator, Tuple, List
+
+
 SCRIPT_DIR = os.path.dirname(__file__)
 
 
@@ -81,3 +87,25 @@ def get_mock_dicom_verify_results():
 def get_mock_png():
     filepath = f"{SCRIPT_DIR}/test_data/png_images/0_ORIGINAL.png"
     return Image.open(filepath)
+
+@pytest.fixture(scope="module")
+def get_dummy_nlp_engine():
+    """Dummy NLP engine to use in testing"""
+    class DummyNlpEngine(NlpEngine):
+        def load(self) -> None:
+            return None
+        def is_loaded(self) -> bool:
+            return True
+        def process_text(self, text: str, language: str) -> NlpArtifacts:
+            return None
+        def process_batch(
+            self, texts: Iterable[str], language: str, **kwargs  # noqa ANN003
+        ) -> Iterator[Tuple[str, NlpArtifacts]]:
+            return None
+        def is_stopword(self, word: str, language: str) -> bool:
+            return False
+        def is_punct(self, word: str, language: str) -> bool:
+            return False
+        def get_supported_entities(self) -> List[str]:
+            return []
+    return DummyNlpEngine()

--- a/presidio-image-redactor/tests/test_image_analyzer_engine.py
+++ b/presidio-image-redactor/tests/test_image_analyzer_engine.py
@@ -385,4 +385,14 @@ def test_add_custom_bboxes_happy_path(
     else:
         assert blue_pixels > 0
 
+def test_check_analyze_supports_language_param(get_mock_png):
+    """Test that the method analyze from class ImageAnalyzerEngine
+    supports the language parameter. 
+    Before there where a bug: 
+        "TypeError: presidio_analyzer.analyzer_engine.AnalyzerEngine.analyze() got multiple values for keyword argument 'language'"
+        
+    :param get_mock_png: The mock PNG image
+    """
+    redacted = ImageAnalyzerEngine().analyze(get_mock_png, language='en')
+    assert len(redacted) > 0
     


### PR DESCRIPTION
## Change Description

Changing the method redact from class ImageAnalyzerEngine to enable select others languages in addition "en".
Now is possible use other languages like "pt" and configure tesseract to use the wished language

## Issue reference

This PR fixes issue #1274


## Checklist

- [ x ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ x ] I have signed the CLA (if required)
- [  x ] My code includes unit tests
- [ x ] All unit tests and lint checks pass locally
- [ x ] My PR contains documentation updates / additions if required
