### PR TITLE
feat: Support 'M' prefix in SG_NRIC_FIN Recognizer and expand tests

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/sg_fin_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/sg_fin_recognizer.py
@@ -19,7 +19,7 @@ class SgFinRecognizer(PatternRecognizer):
 
     PATTERNS = [
         Pattern("Nric (weak)", r"(?i)(\b[A-Z][0-9]{7}[A-Z]\b)", 0.3),
-        Pattern("Nric (medium)", r"(?i)(\b[STFG][0-9]{7}[A-Z]\b)", 0.5),
+        Pattern("Nric (medium)", r"(?i)(\b[STFGM][0-9]{7}[A-Z]\b)", 0.5),
     ]
 
     CONTEXT = ["fin", "fin#", "nric", "nric#"]

--- a/presidio-analyzer/tests/test_sg_fin_recognizer.py
+++ b/presidio-analyzer/tests/test_sg_fin_recognizer.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests import assert_result
+from tests import assert_result_within_score_range
 from presidio_analyzer.predefined_recognizers import SgFinRecognizer
 
 
@@ -15,28 +15,57 @@ def entities():
 
 
 @pytest.mark.parametrize(
-    "text, expected_len, expected_position, expected_score",
+    "text, expected_len, expected_positions, expected_score_ranges",
     [
         # fmt: off
-        ("G1122144L", 1, (0, 9), 0.5), ("PA12348L", 0, (), (),)
+        ## Medium match
+        # Test with valid NRIC/FIN starting with S
+        ("S2740116C", 1, [(0, 9)], [(0.5, 0.8)]),
+        # Test with valid NRIC/FIN starting with T
+        ("T1234567Z", 1, [(0, 9)], [(0.5, 0.8)]),
+        # Test with valid NRIC/FIN starting with F
+        ("F2346401L", 1, [(0, 9)], [(0.5, 0.8)]),
+        # Test with valid NRIC/FIN starting with G
+        ("G1122144L", 1, [(0, 9)], [(0.5, 0.8)]),
+        # Test with valid NRIC/FIN starting with M
+        ("M4332674T", 1, [(0, 9)], [(0.5, 0.8)]),
+        # Test with multiple valid NRIC/FINs
+        ("S9108268C T7572225C", 2, [(0, 9), (10, 19)], [(0.5, 0.8)] * 2),
+
+        # ## Weak match
+        # Test with invalid NRIC/FIN starting with A
+        ("A1234567Z", 1, [(0, 9)], [(0, 0.3)]),
+        # # Test with invalid NRIC/FIN starting with B
+        ("B1234567Z", 1, [(0, 9)], [(0, 0.3)]),
+        
+        ## No match
+        # Test with invalid length
+        ("PA12348L", 0, [], []),
+        # Test with empty string
+        ("", 0, [], []),
         # fmt: on
     ],
 )
 def test_when_sgfins_in_text_then_all_sg_fins_found(
     text,
     expected_len,
-    expected_position,
-    expected_score,
+    expected_positions,
+    expected_score_ranges,
     recognizer,
     entities,
+    max_score,
 ):
     results = recognizer.analyze(text, entities)
     assert len(results) == expected_len
-    if results:
-        assert_result(
-            results[0],
-            entities[0],
-            expected_position[0],
-            expected_position[1],
-            expected_score,
+
+    for result, (start_pos, end_pos), (start_score, end_score) in zip(
+        results, expected_positions, expected_score_ranges
+    ):
+        # Adjust end_score if it's marked with a placeholder value that indicates it should be considered as max_score
+        if end_score == "max":
+            end_score = max_score
+
+        # Assuming assert_result_within_score_range checks the position and verifies the score is within the specified range
+        assert_result_within_score_range(
+            result, entities[0], start_pos, end_pos, start_score, end_score
         )


### PR DESCRIPTION
- Updated SG_NRIC_FIN Recognizer to include 'M' prefix for validating NRIC numbers issued to foreigners from 2022 onwards.
- Added new test cases to ensure comprehensive coverage and validation accuracy for all supported NRIC prefixes (S, T, F, G, M).

## Change Description

Describe your changes

## Issue reference

This PR fixes issue #XX

## Checklist

- [ ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
