### PR TITLE
Addition of leniency parameter in predefined PhoneRecognizer

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/phone_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/phone_recognizer.py
@@ -18,6 +18,8 @@ class PhoneRecognizer(LocalRecognizer):
     :param context: Base context words for enhancing the assurance scores.
     :param supported_language: Language this recognizer supports
     :param supported_regions: The regions for phone number matching and validation
+    :param leniency: The strictness level of phone number formats.
+    Accepts values from 0 to 3, where 0 is the lenient and 3 is the most strictest.
     """
 
     SCORE = 0.4
@@ -30,9 +32,11 @@ class PhoneRecognizer(LocalRecognizer):
         supported_language: str = "en",
         # For all regions, use phonenumbers.SUPPORTED_REGIONS
         supported_regions=DEFAULT_SUPPORTED_REGIONS,
+        leniency: Optional[int] = 1,
     ):
         context = context if context else self.CONTEXT
         self.supported_regions = supported_regions
+        self.leniency = leniency
         super().__init__(
             supported_entities=self.get_supported_entities(),
             supported_language=supported_language,
@@ -59,7 +63,8 @@ class PhoneRecognizer(LocalRecognizer):
         """
         results = []
         for region in self.supported_regions:
-            for match in phonenumbers.PhoneNumberMatcher(text, region, leniency=1):
+            for match in phonenumbers.PhoneNumberMatcher(text, region,
+                                                         leniency=self.leniency):
                 results += [
                     self._get_recognizer_result(match, text, region, nlp_artifacts)
                 ]

--- a/presidio-analyzer/tests/test_phone_recognizer.py
+++ b/presidio-analyzer/tests/test_phone_recognizer.py
@@ -41,3 +41,44 @@ def test_when_all_phones_then_succeed(
     assert len(results) == expected_len
     for i, (res, (st_pos, fn_pos)) in enumerate(zip(results, expected_positions)):
         assert_result(res, entities[i], st_pos, fn_pos, score)
+
+
+@pytest.mark.parametrize(
+    "text, expected_len, entities, expected_positions, score, leniency",
+    [
+        # fmt: off
+        ("My US number is (415) 555-0132, and my international one is415-555-0132",
+         1, ["PHONE_NUMBER"], ((16, 30), ), 0.4, 1),
+        ("My US number is (415) 555-0132, and my international one is415-555-0132",
+         2, ["PHONE_NUMBER", "PHONE_NUMBER"], ((16, 30), (59, 71), ), 0.4, 0),
+
+        ("My US number is (415) 555-0132, and my international one is 91-415-555-0132",
+         1, ["PHONE_NUMBER"], ((16, 30), ), 0.4, 2),
+        ("My US number is (415) 555-0132, and my international one is 91-415-555-0132",
+         2, ["PHONE_NUMBER", "PHONE_NUMBER"], ((16, 30), (60, 75), ), 0.4, 1),
+
+        ("My US number is (415) 555-0132, and my international one is +91 4155 550132",
+         1, ["PHONE_NUMBER"], ((16, 30), ), 0.4, 3),
+        ("My US number is (415) 555-0132, and my international one is +91 4155 550132",
+         2, ["PHONE_NUMBER", "PHONE_NUMBER"], ((16, 30), (60, 75), ), 0.4, 2),
+
+        ("My US number is (415) 555-0132, and my international one is +91 4155550132",
+         2, ["PHONE_NUMBER", "PHONE_NUMBER"], ((16, 30), (60, 74), ), 0.4, 3),
+        # fmt: on
+    ],
+)
+def test_when_phone_with_leniency_then_succeed(
+    spacy_nlp_engine,
+    text,
+    expected_len,
+    entities,
+    expected_positions,
+    score,
+    leniency,
+):
+    nlp_artifacts = spacy_nlp_engine.process_text(text, "en")
+    recognizer = PhoneRecognizer(leniency=leniency)
+    results = recognizer.analyze(text, entities, nlp_artifacts=nlp_artifacts)
+    assert len(results) == expected_len
+    for i, (res, (st_pos, fn_pos)) in enumerate(zip(results, expected_positions)):
+        assert_result(res, entities[i], st_pos, fn_pos, score)


### PR DESCRIPTION
Addition of `leniency` parameter in predefined `PhoneRecognizer`
## Change Description
-> The `PhoneRecognizer` failed to detect phone numbers when they appeared without any space between text and number, as seen in cases like `testdata630-596-1111`.

-> Internally, the `PhoneRecognizer` utilizes the [phonenumbers](https://github.com/daviddrysdale/python-phonenumbers) library for phone number detection. This library offers a parameter known as `leniency`, which determines the flexibility of the phone number format. The leniency parameter ranges from `0 to 3`, with higher values indicating more strict phone number format match.

-> Initially, the leniency factor in `PhoneRecognizer` was set to `1`, causing it to overlook phone numbers lacking spaces between text and digits. To address this issue, we've enhanced PhoneRecognizer to allow users to adjust the leniency parameter according to their requirements, with a default value of `1`.

-> This enhancement resolves various phone number format issues and empowers users to tailor its behavior to their specific needs.


## Issue reference

This PR fixes issue #1301 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
