### PR TITLE
Bugfix - Fix for incorrectly referenced recognizer in analysis_explanation using PhoneRecognizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+#### Analyzer
+Fix for incorrectly referenced recognizer in analysis_explaination using PhoneRecognizer (#1330)
 
 ### Removed
 

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/phone_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/phone_recognizer.py
@@ -88,7 +88,7 @@ class PhoneRecognizer(LocalRecognizer):
 
     def _get_analysis_explanation(self, region):
         return AnalysisExplanation(
-            recognizer=PhoneRecognizer.__class__.__name__,
+            recognizer=PhoneRecognizer.__name__,
             original_score=self.SCORE,
             textual_explanation=f"Recognized as {region} region phone number, "
             f"using PhoneRecognizer",

--- a/presidio-analyzer/tests/test_phone_recognizer.py
+++ b/presidio-analyzer/tests/test_phone_recognizer.py
@@ -82,3 +82,10 @@ def test_when_phone_with_leniency_then_succeed(
     assert len(results) == expected_len
     for i, (res, (st_pos, fn_pos)) in enumerate(zip(results, expected_positions)):
         assert_result(res, entities[i], st_pos, fn_pos, score)
+
+
+def test_get_analysis_explanation():
+    phone_recognizer = PhoneRecognizer()
+    test_region = "US"
+    explanation = phone_recognizer._get_analysis_explanation(test_region)
+    assert explanation.recognizer == "PhoneRecognizer"


### PR DESCRIPTION
## Change Description

Changed how the recognizer parameter for the AnalysisExplanation is populated for the PhoneRecognizer so that it get's referenced correctly

## Issue reference

This PR fixes issue [#1330 ](https://github.com/microsoft/presidio/issues/1330)

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
