### PR TITLE
Fix bug where "bank" and "check" wouldn't work for `US_BANK_NUMBER` recognizer

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/us_bank_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/us_bank_recognizer.py
@@ -22,13 +22,13 @@ class UsBankRecognizer(PatternRecognizer):
     ]
 
     CONTEXT = [
-        "bank"
         # Task #603: Support keyphrases: change to "checking account"
         # as part of keyphrase change
         "check",
         "account",
         "account#",
         "acct",
+        "bank",
         "save",
         "debit",
     ]


### PR DESCRIPTION
Those two keywords in US_BANK_NUMBER wouldn't bump the entity's score because of Python multiline concatenation.

## Change Description

- Added a comma to prevent concatenation
- Move the keyword _below_ the comment to avoid such mistakes in the future

Additionally, I checked every other recognizer, but it didn't seem to occur elsewhere.
Here was my `grep` to look for it:

```
rg --multiline-dotall -U 'CONTEXT.*[^"]+"\n' presidio-analyzer/presidio_analyzer/predefined_recognizers/*.py
```

## Issue reference

~~This PR fixes issue #XX~~ No issue made. The fix is so simple I didn't thing this was needed.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
