### PR TITLE
Cache compiled regexes in analyzer

### DIFF
--- a/presidio-analyzer/presidio_analyzer/pattern.py
+++ b/presidio-analyzer/presidio_analyzer/pattern.py
@@ -16,6 +16,8 @@ class Pattern:
         self.name = name
         self.regex = regex
         self.score = score
+        self.compiled_regex = None
+        self.compiled_with_flags = None
 
     def to_dict(self) -> Dict:
         """

--- a/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
@@ -182,7 +182,13 @@ class PatternRecognizer(LocalRecognizer):
         results = []
         for pattern in self.patterns:
             match_start_time = datetime.datetime.now()
-            matches = re.finditer(pattern.regex, text, flags=flags)
+
+            # Compile regex if flags differ from flags the regex was compiled with
+            if not pattern.compiled_regex or pattern.compiled_with_flags != flags:
+                pattern.compiled_with_flags = flags
+                pattern.compiled_regex = re.compile(pattern.regex, flags=flags)
+
+            matches = pattern.compiled_regex.finditer(text)
             match_time = datetime.datetime.now() - match_start_time
             logger.debug(
                 "--- match_time[%s]: %s.%s seconds",


### PR DESCRIPTION
## Change Description

This change caches the compiled regexes of `Pattern`s in `presidio-analyzer`.

A large portion of time is spent compiling the regex patterns when calling `/analyze` on the `presidio-analyzer`. For the following request:

```
curl -d '{"text":"Facere Konopelski alias animi dis
tinctio vel. Ratione corrupti quae consequuntur omnis eligendi. Excepturi et atque vol
uptas nemo reiciendis. Doloribus odio dolor http://www.nnrhwie.org/ ullam quibusdam. Q
ui sed 6011237658142640 fugiat labore et. Odio a explicabo ut maiores neque. Quidem ne
que magni 6011158690503127 qui sapiente. Necessitatibus est molestias Champlin vero vo
luptates. Tempore voluptate officiis quos error deleniti. Pariatur illum et est ipsum 
sed. Vitae voluptatem optio doloremque nulla repudiandae. Unde +6732345678 quo explica
bo eaque iure. Incidunt bc1qvg883qsjkqh2g6nr3attc0d0yfey4pk2ds06qs odio sit tempora pl
aceat. Officia ipsum quaerat et Lea soluta. Est et pariatur est non et. Officia aperia
m quisquam dolores illo occaecati. Officiis et et animi dolores cum. 6011119331161688 
quidem cumque libero minus nihil. 356a:ce5d:5eb8:ef5b:1cb1:d717:22e7:2df1 rem libero f
uga suscipit voluptas. Reiciendis ea ad consequatur assumenda Ms. Esperanza Sawayn Ver
o http://smzbxej.edu/FMCoeSQ.svg ut suscipit ab sunt. Velit dolorem Prof. Selena Wehne
r dolores voluptatibus sit.", "language":"en"}' -H "Content-Type: application/json" -X
```

the original flame graph (attached as the first image) shows that over 50% of the duration is taken up with these compilations.

The second flame graph (attached as the second image) shows the improvement following these changes after the first request has cached the compiled regexes.

![output](https://github.com/microsoft/presidio/assets/27025023/709769d3-b2ae-4393-ad67-848d7bfcae49)
![output_new2](https://github.com/microsoft/presidio/assets/27025023/9692e38d-78c4-4fc0-b7aa-c76e7c6d2581)

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required

