### PR TITLE
Changed default aggregation_strategy to max

### DIFF
--- a/presidio-analyzer/conf/transformers.yaml
+++ b/presidio-analyzer/conf/transformers.yaml
@@ -9,7 +9,7 @@ models:
 ner_model_configuration:
   labels_to_ignore:
   - O
-  aggregation_strategy: simple # "simple", "first", "average", "max"
+  aggregation_strategy: max     # "simple", "first", "average", "max"
   stride: 16                   # If stride >= 0, process long texts in
                                # overlapping windows of the model max
                                # length. The value is the length of the

--- a/presidio-analyzer/conf/transformers.yaml
+++ b/presidio-analyzer/conf/transformers.yaml
@@ -9,12 +9,12 @@ models:
 ner_model_configuration:
   labels_to_ignore:
   - O
-  aggregation_strategy: max     # "simple", "first", "average", "max"
-  stride: 16                   # If stride >= 0, process long texts in
-                               # overlapping windows of the model max
-                               # length. The value is the length of the
-                               # window overlap in transformer tokenizer
-                               # tokens, NOT the length of the stride.
+  aggregation_strategy: max # "simple", "first", "average", "max"
+  stride: 16                # If stride >= 0, process long texts in
+                            # overlapping windows of the model max
+                            # length. The value is the length of the
+                            # window overlap in transformer tokenizer
+                            # tokens, NOT the length of the stride.
   alignment_mode: expand # "strict", "contract", "expand"
   model_to_presidio_entity_mapping:
     PER: PERSON

--- a/presidio-analyzer/presidio_analyzer/nlp_engine/ner_model_configuration.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/ner_model_configuration.py
@@ -64,7 +64,7 @@ class NerModelConfiguration:
     """  # noqa E501
 
     labels_to_ignore: Optional[Collection[str]] = None
-    aggregation_strategy: Optional[str] = "simple"
+    aggregation_strategy: Optional[str] = "max"
     stride: Optional[int] = 14
     alignment_mode: Optional[str] = "expand"
     default_score: Optional[float] = 0.85


### PR DESCRIPTION
## Change Description

Changing the way transformers are aggregating entities from `simple` to `max`, as it has a slightly better recall on a test dataset.

## Issue reference

This PR partially addresses issue #1262

