### PR TITLE
Fixed wrong condition for dicom metadata

### DIFF
--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
@@ -955,7 +955,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
                 supported_entity="PERSON", deny_list=phi_list
             )
 
-            if type(ad_hoc_recognizers) is None:
+            if ad_hoc_recognizers is None:
                 ad_hoc_recognizers = [deny_list_recognizer]
             elif type(ad_hoc_recognizers) is list:
                 ad_hoc_recognizers.append(deny_list_recognizer)

--- a/presidio-image-redactor/tests/integration/test_dicom_image_redactor_engine_integration.py
+++ b/presidio-image-redactor/tests/integration/test_dicom_image_redactor_engine_integration.py
@@ -75,6 +75,20 @@ def test_redact_image_correctly(engine_builder: Callable, dcm_filepath: Path):
     )
 
 
+def test_compare_original_to_redacted():
+    """Test the redact_and_return_bbox function."""
+    input_path = Path(RESOURCES_PARENT_DIR, "0_ORIGINAL.dcm")
+    input_image = pydicom.dcmread(input_path)
+    redacted_path = Path(RESOURCES_PARENT_DIR, "0_ORIGINAL_redacted.dcm")
+    expected_redacted = pydicom.dcmread(redacted_path)
+    engine = DicomImageRedactorEngine()
+    actual_redacted, bboxes = engine.redact_and_return_bbox(
+        image=input_image,
+        use_metadata=True
+    )
+    assert np.array_equal(expected_redacted.pixel_array, actual_redacted.pixel_array)
+
+
 @pytest.mark.parametrize("engine_builder", all_engines_required())
 def test_redact_from_single_file_correctly(engine_builder: Callable):
     """Test the redact_from_file function with single file case.


### PR DESCRIPTION
## Change Description

Metadata gathered from DICOM was not passed as an ad-hoc deny-list due to a bug in the code

## Issue reference

This PR fixes issue #1309 
## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [X] I have signed the CLA (if required)
- [X] My code includes unit tests
- [X] All unit tests and lint checks pass locally
- [X] My PR contains documentation updates / additions if required
