### PR TITLE
Enhancing the log by adding an entity_text and creating a new line for every case

### DIFF
--- a/presidio-analyzer/presidio_analyzer/analyzer_engine.py
+++ b/presidio-analyzer/presidio_analyzer/analyzer_engine.py
@@ -228,7 +228,7 @@ class AnalyzerEngine:
         if self.log_decision_process:
             self.app_tracer.trace(
                 correlation_id,
-                json.dumps([str(result.to_dict()) for result in results]),
+                json.dumps([str(result.to_dict()) for result in results],indent=4),
             )
 
         # Remove duplicates or low score results

--- a/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
@@ -218,6 +218,7 @@ class PatternRecognizer(LocalRecognizer):
                 )
                 pattern_result = RecognizerResult(
                     entity_type=self.supported_entities[0],
+                    entity_text=text[start:end],
                     start=start,
                     end=end,
                     score=score,

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/azure_ai_language.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/azure_ai_language.py
@@ -138,6 +138,7 @@ class AzureAILanguageRecognizer(RemoteRecognizer):
                 recognizer_results.append(
                     RecognizerResult(
                         entity_type=entity.category,
+                        entity_text=text[entity.offset:entity.offset + entity.length],
                         start=entity.offset,
                         end=entity.offset + entity.length,
                         score=entity.confidence_score,

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/iban_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/iban_recognizer.py
@@ -158,6 +158,7 @@ class IbanRecognizer(PatternRecognizer):
                     )
                     pattern_result = RecognizerResult(
                         entity_type=self.supported_entities[0],
+                        entity_text=text[start:end],
                         start=start,
                         end=end,
                         score=score,

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/phone_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/phone_recognizer.py
@@ -74,6 +74,7 @@ class PhoneRecognizer(LocalRecognizer):
     def _get_recognizer_result(self, match, text, region, nlp_artifacts):
         result = RecognizerResult(
             entity_type="PHONE_NUMBER",
+            entity_text = text[match.start:match.end],
             start=match.start,
             end=match.end,
             score=self.SCORE,

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/spacy_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/spacy_recognizer.py
@@ -115,6 +115,7 @@ class SpacyRecognizer(LocalRecognizer):
             explanation = self.build_explanation(ner_score, textual_explanation)
             spacy_result = RecognizerResult(
                 entity_type=ner_entity.label_,
+                entity_text=text[ner_entity.start_char: ner_entity.end_char],
                 start=ner_entity.start_char,
                 end=ner_entity.end_char,
                 score=ner_score,

--- a/presidio-analyzer/presidio_analyzer/recognizer_result.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_result.py
@@ -34,6 +34,7 @@ class RecognizerResult:
     def __init__(
         self,
         entity_type: str,
+        entity_text:str,
         start: int,
         end: int,
         score: float,
@@ -42,6 +43,7 @@ class RecognizerResult:
     ):
 
         self.entity_type = entity_type
+        self.entity_text = entity_text
         self.start = start
         self.end = end
         self.score = score

--- a/presidio-image-redactor/presidio_image_redactor/entities/image_recognizer_result.py
+++ b/presidio-image-redactor/presidio_image_redactor/entities/image_recognizer_result.py
@@ -18,6 +18,7 @@ class ImageRecognizerResult(RecognizerResult):
     def __init__(
         self,
         entity_type: str,
+        entity_text: str,
         start: int,
         end: int,
         score: float,
@@ -27,7 +28,7 @@ class ImageRecognizerResult(RecognizerResult):
         height: int,
     ):
 
-        super().__init__(entity_type, start, end, score)
+        super().__init__(entity_type,entity_text, start, end, score)
         self.left = left
         self.top = top
         self.width = width
@@ -52,6 +53,7 @@ class ImageRecognizerResult(RecognizerResult):
         """Return a string representation of the instance."""
         return (
             f"type: {self.entity_type}, "
+            f"type: {self.entity_text}, "
             f"start: {self.start}, "
             f"end: {self.end}, "
             f"score: {self.score}, "

--- a/presidio-image-redactor/presidio_image_redactor/image_analyzer_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/image_analyzer_engine.py
@@ -74,7 +74,7 @@ class ImageAnalyzerEngine:
         if "language" not in text_analyzer_kwargs:
             text_analyzer_kwargs["language"] = "en"
         analyzer_result = self.analyzer_engine.analyze(
-            text=text.lower(), **text_analyzer_kwargs
+            text=text, **text_analyzer_kwargs
         )
         allow_list = self._check_for_allow_list(text_analyzer_kwargs)
         bboxes = self.map_analyzer_results_to_bounding_boxes(

--- a/presidio-image-redactor/presidio_image_redactor/image_analyzer_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/image_analyzer_engine.py
@@ -74,7 +74,7 @@ class ImageAnalyzerEngine:
         if "language" not in text_analyzer_kwargs:
             text_analyzer_kwargs["language"] = "en"
         analyzer_result = self.analyzer_engine.analyze(
-            text=text, **text_analyzer_kwargs
+            text=text.lower(), **text_analyzer_kwargs
         )
         allow_list = self._check_for_allow_list(text_analyzer_kwargs)
         bboxes = self.map_analyzer_results_to_bounding_boxes(
@@ -178,6 +178,7 @@ class ImageAnalyzerEngine:
                             bboxes.append(
                                 ImageRecognizerResult(
                                     element.entity_type,
+                                    text_element,
                                     element.start,
                                     element.end,
                                     element.score,
@@ -204,6 +205,7 @@ class ImageAnalyzerEngine:
                                     bboxes.append(
                                         ImageRecognizerResult(
                                             element.entity_type,
+                                            text_element,
                                             element.start,
                                             element.end,
                                             element.score,


### PR DESCRIPTION
## Change Description

The log by default contains information about the entity_type, start, end and the score in addition to the analysis explanation. Added an entity_text too pin point the text in question too for investigation purposes. 
Also changed the json dumbs to begin in a new line for every case to enhance readability.

## Issue reference

This PR fixes issue #1361

## Checklist

No unit tests , I tracked down every file that is affected manually and tested on my own data. 
