### PR TITLE
Align Docker ports with documentation and postman collection.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -99,9 +99,9 @@ docker pull mcr.microsoft.com/presidio-analyzer
 docker pull mcr.microsoft.com/presidio-anonymizer
 
 # Run containers with default ports
-docker run -d -p 5001:3000 mcr.microsoft.com/presidio-analyzer:latest
+docker run -d -p 5002:3000 mcr.microsoft.com/presidio-analyzer:latest
 
-docker run -d -p 5002:3000 mcr.microsoft.com/presidio-anonymizer:latest
+docker run -d -p 5001:3000 mcr.microsoft.com/presidio-anonymizer:latest
 ```
 
 ### For PII redaction in images


### PR DESCRIPTION
The ports on the samples on this page (https://microsoft.github.io/presidio/samples/docker/) and the postman collection do not align with the documentation found here. This PR is to align it.

## Change Description

Updated port references to match documentation and postman collections.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
