### PR TITLE
(docs) Use Presidio across Anthropic, Bedrock, VertexAI, Azure OpenAI, etc. w/ LiteLLM Proxy

### DIFF
--- a/docs/samples/docker/litellm.md
+++ b/docs/samples/docker/litellm.md
@@ -4,6 +4,8 @@ Run Presidio PII Masking across Anthropic/Gemini/Bedrock/etc. calls with [LiteLL
 
 [👉 **Refer to LiteLLM Docs for detailed guide**](https://docs.litellm.ai/docs/proxy/pii_masking)
 
+**Flow:** App <-> `LiteLLM Proxy + Presidio PII Masking` <-> LLM Provider
+
 ## Pre-Requiesites
 - Run `pip install 'litellm[proxy]'` [Docs](https://docs.litellm.ai/docs/proxy/quick_start)
 - Setup [Presidio Docker](https://microsoft.github.io/presidio/installation/#using-docker)
@@ -99,6 +101,8 @@ Presidio PII Masking: Redacted pii message: <PERSON> AHV number is <AHV_NUMBER>.
 
 ## Turn on/off per key 
 
+LiteLLM lets you create [virtual keys](https://docs.litellm.ai/docs/proxy/virtual_keys) for calling the proxy. You can use these to control model access, set budgets, track usage, etc. 
+
 Turn off PII masking for a given key. 
 
 Do this by setting `permissions: {"pii": false}`, when generating a key. 
@@ -115,10 +119,10 @@ curl --location 'http://0.0.0.0:4000/key/generate' \
 
 ## Turn on/off per request 
 
-The proxy support 2 request-level PII controls:
+The proxy supports 2 request-level PII controls:
 
 - *no-pii*: Optional(bool) - Allow user to turn off pii masking per request.
-- *output_parse_pii*: Optional(bool) - Allow user to turn off pii output parsing per request.
+- *output_parse_pii*: Optional(bool) - Allow user to turn off pii output parsing per request. [**Output Parsing**](#output-parsing)
 
 ### Usage 
 

--- a/docs/samples/docker/litellm.md
+++ b/docs/samples/docker/litellm.md
@@ -1,35 +1,44 @@
 # LiteLLM (OpenAI Proxy) with Presidio
 
-LiteLLM supports [Microsoft Presidio](https://github.com/microsoft/presidio/) for PII masking. 
+Run Presidio PII Masking across Anthropic/Gemini/Bedrock/etc. calls with [LiteLLM](https://github.com/BerriAI/litellm)
 
 [👉 **Refer to LiteLLM Docs for detailed guide**](https://docs.litellm.ai/docs/proxy/pii_masking)
 
+## Pre-Requiesites
+- Run `pip install 'litellm[proxy]'` [Docs](https://docs.litellm.ai/docs/proxy/quick_start)
+- Setup [Presidio Docker](https://microsoft.github.io/presidio/installation/#using-docker)
+
 ## Quick Start
-### Step 1. Add env
+
+### Step 1. Add to env
 
 ```bash
 export PRESIDIO_ANALYZER_API_BASE="http://localhost:5002"
 export PRESIDIO_ANONYMIZER_API_BASE="http://localhost:5001"
+export OPENAI_API_KEY="sk-..."
 ```
 
-### Step 2. Set it as a callback in config.yaml
+### Step 2. Set Presidio as a callback in config.yaml
 
 ```yaml
+model_list:
+  - model_name: my-openai-model ### RECEIVED MODEL NAME ###
+    litellm_params: # all params accepted by litellm.completion() - https://docs.litellm.ai/docs/completion/input
+      model: gpt-3.5-turbo ### MODEL NAME sent to `litellm.completion()` ###
+
 litellm_settings: 
-    callbacks = ["presidio", ...] # e.g. ["presidio", custom_callbacks.proxy_handler_instance]
+    callbacks = ["presidio"]
 ```
 
 ### Step 3. Start proxy 
 
 
-```
+```bash
 litellm --config /path/to/config.yaml
 ```
 
 
 This will mask the input going to the llm provider
-
-<Image img={require('../../img/presidio_screenshot.png')} />
 
 ## Output parsing 
 
@@ -75,7 +84,7 @@ litellm --config /path/to/config.yaml --debug
 
 Make a chat completions request, example:
 
-```
+```bash
 {
   "model": "azure-gpt-3.5",
   "messages": [{"role": "user", "content": "John Smith AHV number is 756.3026.0705.92. Zip code: 1334023"}]
@@ -83,7 +92,7 @@ Make a chat completions request, example:
 ```
 
 And search for any log starting with `Presidio PII Masking`, example:
-```
+```bash
 Presidio PII Masking: Redacted pii message: <PERSON> AHV number is <AHV_NUMBER>. Zip code: <US_DRIVER_LICENSE>
 ```
 
@@ -154,7 +163,7 @@ chat_completion = client.chat.completions.create(
 
 **Step 3: See response**
 
-```
+```bash
 {
   "id": "chatcmpl-8c5qbGTILZa1S4CK3b31yj5N40hFN",
   "choices": [

--- a/docs/samples/docker/litellm.md
+++ b/docs/samples/docker/litellm.md
@@ -1,0 +1,234 @@
+# LiteLLM (OpenAI Proxy) with Presidio
+
+LiteLLM supports [Microsoft Presidio](https://github.com/microsoft/presidio/) for PII masking. 
+
+[👉 **Refer to LiteLLM Docs for detailed guide**](https://docs.litellm.ai/docs/proxy/pii_masking)
+
+## Quick Start
+### Step 1. Add env
+
+```bash
+export PRESIDIO_ANALYZER_API_BASE="http://localhost:5002"
+export PRESIDIO_ANONYMIZER_API_BASE="http://localhost:5001"
+```
+
+### Step 2. Set it as a callback in config.yaml
+
+```yaml
+litellm_settings: 
+    callbacks = ["presidio", ...] # e.g. ["presidio", custom_callbacks.proxy_handler_instance]
+```
+
+### Step 3. Start proxy 
+
+
+```
+litellm --config /path/to/config.yaml
+```
+
+
+This will mask the input going to the llm provider
+
+<Image img={require('../../img/presidio_screenshot.png')} />
+
+## Output parsing 
+
+LLM responses can sometimes contain the masked tokens. 
+
+For presidio 'replace' operations, LiteLLM can check the LLM response and replace the masked token with the user-submitted values. 
+
+Just set `litellm.output_parse_pii = True`, to enable this. 
+
+
+```yaml
+litellm_settings:
+    output_parse_pii: true
+```
+
+**Expected Flow: **
+
+1. User Input: "hello world, my name is Jane Doe. My number is: 034453334"
+
+2. LLM Input: "hello world, my name is [PERSON]. My number is: [PHONE_NUMBER]"
+
+3. LLM Response: "Hey [PERSON], nice to meet you!"
+
+4. User Response: "Hey Jane Doe, nice to meet you!"
+
+## Ad-hoc recognizers 
+
+Send ad-hoc recognizers to presidio `/analyze` by passing a json file to the proxy 
+
+[**Example** ad-hoc recognizer](../../../../litellm/proxy/hooks/example_presidio_ad_hoc_recognizer.json)
+
+```yaml
+litellm_settings: 
+  callbacks: ["presidio"]
+  presidio_ad_hoc_recognizers: "./hooks/example_presidio_ad_hoc_recognizer.json"
+```
+
+You can see this working, when you run the proxy: 
+
+```bash
+litellm --config /path/to/config.yaml --debug
+```
+
+Make a chat completions request, example:
+
+```
+{
+  "model": "azure-gpt-3.5",
+  "messages": [{"role": "user", "content": "John Smith AHV number is 756.3026.0705.92. Zip code: 1334023"}]
+}
+```
+
+And search for any log starting with `Presidio PII Masking`, example:
+```
+Presidio PII Masking: Redacted pii message: <PERSON> AHV number is <AHV_NUMBER>. Zip code: <US_DRIVER_LICENSE>
+```
+
+
+## Turn on/off per key 
+
+Turn off PII masking for a given key. 
+
+Do this by setting `permissions: {"pii": false}`, when generating a key. 
+
+```shell 
+curl --location 'http://0.0.0.0:4000/key/generate' \
+--header 'Authorization: Bearer sk-1234' \
+--header 'Content-Type: application/json' \
+--data '{
+    "permissions": {"pii": false}
+}'
+```
+
+
+## Turn on/off per request 
+
+The proxy support 2 request-level PII controls:
+
+- *no-pii*: Optional(bool) - Allow user to turn off pii masking per request.
+- *output_parse_pii*: Optional(bool) - Allow user to turn off pii output parsing per request.
+
+### Usage 
+
+**Step 1. Create key with pii permissions**
+
+Set `allow_pii_controls` to true for a given key. This will allow the user to set request-level PII controls.
+
+```bash
+curl --location 'http://0.0.0.0:4000/key/generate' \
+--header 'Authorization: Bearer my-master-key' \
+--header 'Content-Type: application/json' \
+--data '{
+    "permissions": {"allow_pii_controls": true}
+}'
+```
+
+**Step 2. Turn off pii output parsing**
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    # This is the default and can be omitted
+    api_key=os.environ.get("OPENAI_API_KEY"),
+        base_url="http://0.0.0.0:4000"
+)
+
+chat_completion = client.chat.completions.create(
+    messages=[
+        {
+            "role": "user",
+            "content": "My name is Jane Doe, my number is 8382043839",
+        }
+    ],
+    model="gpt-3.5-turbo",
+    extra_body={
+        "content_safety": {"output_parse_pii": False} 
+    }
+)
+```
+
+**Step 3: See response**
+
+```
+{
+  "id": "chatcmpl-8c5qbGTILZa1S4CK3b31yj5N40hFN",
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "Hi [PERSON], what can I help you with?",
+        "role": "assistant"
+      }
+    }
+  ],
+  "created": 1704089632,
+  "model": "gpt-35-turbo",
+  "object": "chat.completion",
+  "system_fingerprint": null,
+  "usage": {
+    "completion_tokens": 47,
+    "prompt_tokens": 12,
+    "total_tokens": 59
+  },
+  "_response_ms": 1753.426
+}
+```
+
+
+## Turn on for logging only
+
+Only apply PII Masking before logging to Langfuse, etc.
+
+Not on the actual llm api request / response.
+
+This is currently only applied for 
+- `/chat/completion` requests
+- on 'success' logging
+
+1. Setup config.yaml
+```yaml
+litellm_settings:
+  presidio_logging_only: true 
+
+model_list:
+  - model_name: gpt-3.5-turbo
+    litellm_params:
+      model: gpt-3.5-turbo
+      api_key: os.environ/OPENAI_API_KEY
+```
+
+2. Start proxy
+
+```bash
+litellm --config /path/to/config.yaml
+```
+
+3. Test it! 
+
+```bash
+curl -X POST 'http://0.0.0.0:4000/chat/completions' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: Bearer sk-1234' \
+-D '{
+  "model": "gpt-3.5-turbo",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hi, my name is Jane!"
+    }
+  ]
+  }'
+```
+
+
+**Expected Logged Response**
+
+```
+Hi, my name is <PERSON>!
+```

--- a/docs/samples/docker/litellm.md
+++ b/docs/samples/docker/litellm.md
@@ -68,7 +68,7 @@ litellm_settings:
 
 Send ad-hoc recognizers to presidio `/analyze` by passing a json file to the proxy 
 
-[**Example** ad-hoc recognizer](../../../../litellm/proxy/hooks/example_presidio_ad_hoc_recognizer.json)
+[**Example** ad-hoc recognizer](https://github.com/BerriAI/litellm/blob/b69b7503db5aa039a49b7ca96ae5b34db0d25a3d/litellm/proxy/hooks/example_presidio_ad_hoc_recognizer.json#L4)
 
 ```yaml
 litellm_settings: 

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -24,6 +24,7 @@
 | Usage | Text      | Python file                            | [Pseudonomization (replace PII values using mappings)](python/pseudonomyzation.ipynb)|
 | Usage | Text      | Python file                            | [Passing a lambda as a Presidio anonymizer using Faker](python/example_custom_lambda_anonymizer.py)|
 | Usage | Text      | Python file                            | [Synthetic data generation with OpenAI](python/synth_data_with_openai.ipynb)|
+| Usage | Text      | LiteLLM Proxy                            | [PII Masking LLM calls across Anthropic/Gemini/Bedrock/Azure, etc.](docker/litellm.md)|
 | Usage      | | REST API (postman)                          | [Presidio as a REST endpoint](docker/index.md)|
 | Deployment | | App Service                                 | [Presidio with App Service](deployments/app-service/index.md)|
 | Deployment | | Kubernetes                                  | [Presidio with Kubernetes](deployments/k8s/index.md)|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,11 +53,11 @@ nav:
   - Samples: 
     - Home: samples/index.md  
     - Selected samples:
-      - LiteLLM (OpenAI Proxy): samples/docker/litellm.md
       - Customizing Presidio Analyzer: samples/python/customizing_presidio_analyzer.ipynb
       - NER model configuration: samples/python/ner_model_configuration.ipynb
       - Presidio Structured Basic Usage: samples/python/example_structured.ipynb
       - Using an allow list with image redaction: samples/python/image_redaction_allow_list_approach.ipynb
+      - LiteLLM (OpenAI Proxy): samples/docker/litellm.md
       - Redacting Text PII from DICOM images: samples/python/example_dicom_image_redactor.ipynb
       - Annotating PII in a PDF: samples/python/example_pdf_annotation.ipynb
       - Pseudonomization: samples/python/pseudonomyzation.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,6 @@ nav:
       - NER model configuration: samples/python/ner_model_configuration.ipynb
       - Presidio Structured Basic Usage: samples/python/example_structured.ipynb
       - Using an allow list with image redaction: samples/python/image_redaction_allow_list_approach.ipynb
-      - LiteLLM (OpenAI Proxy): samples/docker/litellm.md
       - Redacting Text PII from DICOM images: samples/python/example_dicom_image_redactor.ipynb
       - Annotating PII in a PDF: samples/python/example_pdf_annotation.ipynb
       - Pseudonomization: samples/python/pseudonomyzation.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
   - Samples: 
     - Home: samples/index.md  
     - Selected samples:
+      - LiteLLM (OpenAI Proxy): samples/docker/litellm.md
       - Customizing Presidio Analyzer: samples/python/customizing_presidio_analyzer.ipynb
       - NER model configuration: samples/python/ner_model_configuration.ipynb
       - Presidio Structured Basic Usage: samples/python/example_structured.ipynb


### PR DESCRIPTION
## Change Description

Adds a sample doc for setting up Presidio (docker image) with LiteLLM Proxy for implementing PII Masking across 100+ LLMs. 

## Issue reference

n/a 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] My PR contains documentation updates / additions if required

cc: @omri374 @SharonHart