### PR TITLE
Do not release presidio-cli as part of the release pipeline

### DIFF
--- a/.pipelines/templates/release.yml
+++ b/.pipelines/templates/release.yml
@@ -58,8 +58,6 @@ stages:
             WORKING_FOLDER: 'presidio-image-redactor'
           Structured:
             WORKING_FOLDER: 'presidio-structured'
-          Cli:
-            WORKING_FOLDER: 'presidio-cli'
       steps:
         - template: ./publish-to-pypi.yml
           parameters:


### PR DESCRIPTION
## Change Description

We no longer have permissions to release the cli package, dropping it from the release pipeline

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
