### PR TITLE
Make sure that configuration files are closed when loading them

### DIFF
--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
@@ -316,25 +316,24 @@ class RecognizerConfigurationLoader:
 
         if conf_file:
             try:
-                config_from_file = yaml.safe_load(open(conf_file))
+                with open(conf_file) as file:
+                    config_from_file = yaml.safe_load(file)
 
             except OSError:
                 logger.warning(
                     f"configuration file {conf_file} not found.  "
                     f"Using default config."
                 )
-                config_from_file = yaml.safe_load(
-                    open(RecognizerConfigurationLoader._get_full_conf_path())
-                )
+                with open(RecognizerConfigurationLoader._get_full_conf_path()) as file:
+                    config_from_file = yaml.safe_load(file)
 
             except Exception as e:
                 raise ValueError(
                     f"Failed to parse file {conf_file}." f"Error: {str(e)}"
                 )
         else:
-            config_from_file = yaml.safe_load(
-                open(RecognizerConfigurationLoader._get_full_conf_path())
-            )
+            with open(RecognizerConfigurationLoader._get_full_conf_path()) as file:
+                config_from_file = yaml.safe_load(file)
 
         if config_from_file and not isinstance(config_from_file, dict):
             raise TypeError(


### PR DESCRIPTION
## Change Description

When configuration is loaded, the current version of the code only does an `open` call which leaves a dangling file reference that is never closed. While this isn't a major issue, we found that in the project where we use presidio, this causes pytest to issue warnings about unclosed resources (that for us is set up to be converted into test errors).

I'm not sure why, but this happens only with version `2.2.354` but not `2.2.353`.

## Issue reference

Didn't create an issue as just contributing a fix was faster for me.

## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [X] All unit tests and lint checks pass locally
