### PR TITLE
added logic to handle phonenumbers with country code

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/phone_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/phone_recognizer.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 import phonenumbers
+from phonenumbers.phonenumberutil import NumberParseException
 
 from presidio_analyzer import (
     AnalysisExplanation,
@@ -66,9 +67,16 @@ class PhoneRecognizer(LocalRecognizer):
             for match in phonenumbers.PhoneNumberMatcher(
                 text, region, leniency=self.leniency
             ):
-                results += [
+                try:
+                    parsed_number = phonenumbers.parse(text[match.start:match.end])
+                    region = phonenumbers.region_code_for_number(parsed_number)
+                    results += [
                     self._get_recognizer_result(match, text, region, nlp_artifacts)
                 ]
+                except NumberParseException:
+                    results += [
+                        self._get_recognizer_result(match, text, region, nlp_artifacts)
+                    ]
 
         return EntityRecognizer.remove_duplicates(results)
 

--- a/presidio-analyzer/tests/__init__.py
+++ b/presidio-analyzer/tests/__init__.py
@@ -1,1 +1,1 @@
-from .assertions import assert_result, assert_result_within_score_range  # noqa
+from .assertions import assert_result, assert_result_within_score_range, assert_result_with_textual_explanation  # noqa

--- a/presidio-analyzer/tests/assertions.py
+++ b/presidio-analyzer/tests/assertions.py
@@ -32,3 +32,12 @@ def assert_result_within_score_range(
     min_score = max(0, expected_score_min - error)
     max_score = min(1, expected_score_max + error)
     assert result.score >= min_score and result.score <= max_score
+
+
+def assert_result_with_textual_explanation(
+    result, expected_entity_type, expected_start, expected_end, expected_score, expected_textual_explanation
+):
+    assert_result(
+        result, expected_entity_type, expected_start, expected_end, expected_score
+    )
+    assert result.analysis_explanation.textual_explanation == expected_textual_explanation


### PR DESCRIPTION
## Change Description

Hi, long time user but first time contributing. Happy to learn & correct if something required. This is a minor change that a bug that I reported. The currently used **phonenumbers.PhoneNumberMatcher** function doesn't handle phone number starting with country code, the fucntion docstring (below) says to use different "region" parameter for such phone numbers.   
``` 
country -- The country to assume for phone numbers not written in
international format (with a leading plus, or with the
international dialing prefix of the specified region). May be
None or "ZZ" if only numbers with a leading plus should be
considered.
```
Added code handles such phone number separately & resolves the mentioned bug.
 
## Issue reference

This PR fixes issue https://github.com/microsoft/presidio/issues/1425


## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [X] My code includes unit test
- [X] All unit tests and lint checks pass locally
