### PR TITLE
Update CI due to DockerCompose project name issue

### DIFF
--- a/.pipelines/templates/build-and-push-containers.yml
+++ b/.pipelines/templates/build-and-push-containers.yml
@@ -23,13 +23,15 @@ steps:
           REGISTRY_NAME=${{ parameters.REGISTRY_NAME }}
           IMAGE_PREFIX=${{ parameters.IMAGE_PREFIX }}
           TAG=${{ parameters.TAG }}
-  - task: DockerCompose@0
+        projectName: 'microsoft_presidio'
+  - task: DockerCompose@1
     displayName: Push Presidio Images to ACR
     inputs:
         action: 'Push services'
         dockerComposeFile: ${{ parameters.DOCKER_COMPOSE_FILE }}
         containerregistrytype: 'Container Registry'
         dockerRegistryEndpoint: 'presidio-acr'
+        projectName: 'microsoft_presidio'
         dockerComposeFileArgs: |
           REGISTRY_NAME=${{ parameters.REGISTRY_NAME }}
           IMAGE_PREFIX=${{ parameters.IMAGE_PREFIX }}

--- a/.pipelines/templates/build-and-push-containers.yml
+++ b/.pipelines/templates/build-and-push-containers.yml
@@ -14,7 +14,7 @@ parameters:
   type: string
   default: 'docker-compose.yml'
 steps:
-  - task: DockerCompose@0
+  - task: DockerCompose@1
     displayName: Build Presidio Images
     inputs:
         action: Build services

--- a/.pipelines/templates/build-and-push-containers.yml
+++ b/.pipelines/templates/build-and-push-containers.yml
@@ -14,7 +14,7 @@ parameters:
   type: string
   default: 'docker-compose.yml'
 steps:
-  - task: DockerCompose@1
+  - task: DockerCompose@0
     displayName: Build Presidio Images
     inputs:
         action: Build services
@@ -24,7 +24,8 @@ steps:
           IMAGE_PREFIX=${{ parameters.IMAGE_PREFIX }}
           TAG=${{ parameters.TAG }}
         projectName: 'microsoft_presidio'
-  - task: DockerCompose@1
+        
+  - task: DockerCompose@0
     displayName: Push Presidio Images to ACR
     inputs:
         action: 'Push services'

--- a/.pipelines/templates/e2e-tests.yml
+++ b/.pipelines/templates/e2e-tests.yml
@@ -9,7 +9,7 @@ parameters:
     type: string
     default: ''
 steps:
-    - task: DockerCompose@0
+    - task: DockerCompose@1
       displayName: Start Presidio Cluster
       inputs:
           action: Run services

--- a/.pipelines/templates/e2e-tests.yml
+++ b/.pipelines/templates/e2e-tests.yml
@@ -13,11 +13,11 @@ steps:
       displayName: Start Presidio Cluster
       inputs:
           action: Run services
+          projectName: 'microsoft_presidio'
           dockerComposeFile: docker-compose.yml
           buildImages: false
       # Start cluster when testing against remote cluster, when an external url is not provided.
       condition: eq('${{ parameters.anonymizer_base_url }}', '')
-      projectName: 'microsoft_presidio'
       
     - task: UsePythonVersion@0
       inputs:
@@ -50,6 +50,7 @@ steps:
     - task: DockerCompose@0
       displayName: Docker Logs
       inputs:
+        projectName: 'microsoft_presidio'
         dockerComposeCommand: logs
         dockerComposeFile: docker-compose.yml
         buildImages: false

--- a/.pipelines/templates/e2e-tests.yml
+++ b/.pipelines/templates/e2e-tests.yml
@@ -9,7 +9,7 @@ parameters:
     type: string
     default: ''
 steps:
-    - task: DockerCompose@1
+    - task: DockerCompose@0
       displayName: Start Presidio Cluster
       inputs:
           action: Run services
@@ -17,7 +17,8 @@ steps:
           buildImages: false
       # Start cluster when testing against remote cluster, when an external url is not provided.
       condition: eq('${{ parameters.anonymizer_base_url }}', '')
-
+      projectName: 'microsoft_presidio'
+      
     - task: UsePythonVersion@0
       inputs:
           versionSpec: '3.9'

--- a/.pipelines/templates/test-docs.yml
+++ b/.pipelines/templates/test-docs.yml
@@ -16,7 +16,7 @@ steps:
     versionSpec: '>= 10.x'
     checkLatest: true
 
-- task: DockerCompose@0
+- task: DockerCompose@1
   displayName: 'Run service with docker compose'
   inputs:
     containerregistrytype: 'Azure Container Registry'

--- a/.pipelines/templates/test-docs.yml
+++ b/.pipelines/templates/test-docs.yml
@@ -18,9 +18,9 @@ steps:
 
 - task: DockerCompose@0
   displayName: 'Run service with docker compose'
-  projectName: 'microsoft_presidio'
   inputs:
     containerregistrytype: 'Azure Container Registry'
+    projectName: 'microsoft_presidio'
     dockerComposeFile: '**/docker-compose.yml'
     action: 'Run services'
 

--- a/.pipelines/templates/test-docs.yml
+++ b/.pipelines/templates/test-docs.yml
@@ -16,8 +16,9 @@ steps:
     versionSpec: '>= 10.x'
     checkLatest: true
 
-- task: DockerCompose@1
+- task: DockerCompose@0
   displayName: 'Run service with docker compose'
+  projectName: 'microsoft_presidio'
   inputs:
     containerregistrytype: 'Azure Container Registry'
     dockerComposeFile: '**/docker-compose.yml'

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -39,8 +39,9 @@ stages:
           REGISTRY_NAME: '$(ACR_REGISTRY_NAME).azurecr.io/'
           TAG: ':$(Build.BuildId)'
         steps:
-          - task: DockerCompose@1
+          - task: DockerCompose@0
             displayName: Pull Presidio Images from ACR
+            projectName: 'microsoft_presidio'
             inputs:
               action: Run a Docker Compose command
               dockerComposeCommand: pull

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -39,7 +39,7 @@ stages:
           REGISTRY_NAME: '$(ACR_REGISTRY_NAME).azurecr.io/'
           TAG: ':$(Build.BuildId)'
         steps:
-          - task: DockerCompose@0
+          - task: DockerCompose@1
             displayName: Pull Presidio Images from ACR
             inputs:
               action: Run a Docker Compose command

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -41,9 +41,9 @@ stages:
         steps:
           - task: DockerCompose@0
             displayName: Pull Presidio Images from ACR
-            projectName: 'microsoft_presidio'
             inputs:
               action: Run a Docker Compose command
+              projectName: 'microsoft_presidio'
               dockerComposeCommand: pull
               dockerComposeFile: docker-compose.yml
               containerregistrytype: 'Container Registry'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ stages:
         REGISTRY_NAME: '$(ACR_REGISTRY_NAME).azurecr.io/'
         TAG: ':$(Build.BuildId)'
       steps:
-        - task: DockerCompose@0
+        - task: DockerCompose@1
           displayName: Build Presidio Images
           inputs:
               action: Build services

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,9 +23,10 @@ stages:
       steps:
         - task: DockerCompose@0
           displayName: Build Presidio Images
-          projectName: 'microsoft_presidio'
+
           inputs:
               action: Build services
+              projectName: 'microsoft_presidio'
               dockerComposeFile: docker-compose.yml
               dockerComposeFileArgs: |
                 REGISTRY_NAME=$(REGISTRY_NAME)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,8 +21,9 @@ stages:
         REGISTRY_NAME: '$(ACR_REGISTRY_NAME).azurecr.io/'
         TAG: ':$(Build.BuildId)'
       steps:
-        - task: DockerCompose@1
+        - task: DockerCompose@0
           displayName: Build Presidio Images
+          projectName: 'microsoft_presidio'
           inputs:
               action: Build services
               dockerComposeFile: docker-compose.yml


### PR DESCRIPTION
## Change Description
Updating `projectName` on DockerCompose task due to CI issues:
```bash
##[warning]The project name "microsoft/presidio" must be a valid docker compose project name. Follow the link for more details: https://aka.ms/azdo-docker-compose-v1
##[error]invalid project name "microsoft/presidio": must consist only of lowercase alphanumeric characters, hyphens, and underscores as well as start with a letter or number
##[error]The process '/usr/bin/docker' failed with exit code 15

```

@SharonHart @RoeyBC merging this to unblock the CI, but please review. Thanks!
