### PR TITLE
Reduce memory usage of Analyzer test suite

### DIFF
--- a/presidio-analyzer/tests/test_analyzer_engine.py
+++ b/presidio-analyzer/tests/test_analyzer_engine.py
@@ -108,6 +108,7 @@ def test_when_analyze_with_unsupported_language_must_match(registry_config, anal
         AnalyzerEngine(
             registry=registry,
             supported_languages=analyzer_lang,
+            nlp_engine=NlpEngineMock(),
         )
 
 def test_when_analyze_with_defaults_success(

--- a/presidio-analyzer/tests/test_analyzer_engine.py
+++ b/presidio-analyzer/tests/test_analyzer_engine.py
@@ -59,11 +59,6 @@ def unit_test_guid():
     return "00000000-0000-0000-0000-000000000000"
 
 
-@pytest.fixture(scope="module")
-def nlp_engine(nlp_engines):
-    return nlp_engines["spacy_en"]
-
-
 def test_simple():
     dic = {
         "text": "John Smith drivers license is AC432223",

--- a/presidio-analyzer/tests/test_nlp_engine_provider.py
+++ b/presidio-analyzer/tests/test_nlp_engine_provider.py
@@ -47,17 +47,6 @@ def nlp_configuration_dict() -> Dict:
     return nlp_configuration
 
 
-@pytest.fixture(scope="session")
-def ner_model_configuration_dict() -> Dict:
-    ner_model_configuration = {
-        "nlp_engine_name": "transformers",
-        "aggregation_strategy": "simple",
-        "alignment_mode": "strict",
-        "low_score_entity_names": ["O"],
-    }
-    return ner_model_configuration
-
-
 def test_when_create_nlp_engine__then_return_default_configuration():
     provider = NlpEngineProvider()
     engine = provider.create_engine()

--- a/presidio-analyzer/tests/test_recognizer_registry.py
+++ b/presidio-analyzer/tests/test_recognizer_registry.py
@@ -13,11 +13,6 @@ from presidio_analyzer import (
 from presidio_analyzer.predefined_recognizers import SpacyRecognizer
 
 
-@pytest.fixture(scope="module")
-def request_id():
-    return "UT"
-
-
 def create_mock_pattern_recognizer(lang, entity, name):
     return PatternRecognizer(
         supported_entity=entity,

--- a/presidio-analyzer/tests/test_stanza_recognizer.py
+++ b/presidio-analyzer/tests/test_stanza_recognizer.py
@@ -23,13 +23,6 @@ def nlp_recognizer(nlp_recognizers):
     return nlp_recognizers.get("stanza", None)
 
 
-def prepare_and_analyze(nlp, recognizer, text, ents):
-    nlp.load()
-    nlp_artifacts = nlp.process_text(text, "en")
-    results = recognizer.analyze(text, ents, nlp_artifacts)
-    return results
-
-
 @pytest.mark.skip_engine("stanza_en")
 @pytest.mark.parametrize(
     "text, expected_len, expected_positions, entity_num",
@@ -65,7 +58,8 @@ def test_when_using_stanza_then_all_stanza_result_correct(
     ner_strength,
     max_score,
 ):
-    results = prepare_and_analyze(stanza_nlp_engine, nlp_recognizer, text, entities)
+    nlp_artifacts = stanza_nlp_engine.process_text(text, "en")
+    results = nlp_recognizer.analyze(text, entities, nlp_artifacts)
     assert len(results) == expected_len
     entity_to_check = entities[entity_num]
     for res, (st_pos, fn_pos) in zip(results, expected_positions):

--- a/presidio-analyzer/tests/test_stanza_recognizer.py
+++ b/presidio-analyzer/tests/test_stanza_recognizer.py
@@ -23,6 +23,12 @@ def nlp_recognizer(nlp_recognizers):
     return nlp_recognizers.get("stanza", None)
 
 
+def prepare_and_analyze(nlp, recognizer, text, entities):
+    nlp_artifacts = nlp.process_text(text, "en")
+    results = recognizer.analyze(text, entities, nlp_artifacts)
+    return results
+
+
 @pytest.mark.skip_engine("stanza_en")
 @pytest.mark.parametrize(
     "text, expected_len, expected_positions, entity_num",
@@ -58,8 +64,7 @@ def test_when_using_stanza_then_all_stanza_result_correct(
     ner_strength,
     max_score,
 ):
-    nlp_artifacts = stanza_nlp_engine.process_text(text, "en")
-    results = nlp_recognizer.analyze(text, entities, nlp_artifacts)
+    results = prepare_and_analyze(stanza_nlp_engine, nlp_recognizer, text, entities)
     assert len(results) == expected_len
     entity_to_check = entities[entity_num]
     for res, (st_pos, fn_pos) in zip(results, expected_positions):

--- a/presidio-analyzer/tests/test_transformers_recognizer.py
+++ b/presidio-analyzer/tests/test_transformers_recognizer.py
@@ -23,13 +23,6 @@ def nlp_engine(nlp_engines):
     return nlp_engine
 
 
-def prepare_and_analyze(nlp, recognizer, text, entities):
-    nlp.load()
-    nlp_artifacts = nlp.process_text(text, "en")
-    results = recognizer.analyze(text, entities, nlp_artifacts)
-    return results
-
-
 @pytest.mark.skip_engine("transformers_en")
 @pytest.mark.parametrize(
     "text, expected_len, expected_positions, entity_num",
@@ -65,7 +58,8 @@ def test_when_using_transformers_then_all_transformers_result_correct(
     min_score,
     max_score,
 ):
-    results = prepare_and_analyze(nlp_engine, nlp_recognizer, text, entities)
+    nlp_artifacts = nlp_engine.process_text(text, "en")
+    results = nlp_recognizer.analyze(text, entities, nlp_artifacts)
     assert len(results) == expected_len
     entity_to_check = entities[entity_num]
     for res, (st_pos, fn_pos) in zip(results, expected_positions):
@@ -85,7 +79,8 @@ def test_when_person_in_text_then_person_full_name_complex_found(
     nlp_engine, nlp_recognizer, entities
 ):
     text = "Richard (Rick) C. Henderson"
-    results = prepare_and_analyze(nlp_engine, nlp_recognizer, text, entities)
+    nlp_artifacts = nlp_engine.process_text(text, "en")
+    results = nlp_recognizer.analyze(text, entities, nlp_artifacts)
 
     assert len(results) > 0
 

--- a/presidio-analyzer/tests/test_transformers_recognizer.py
+++ b/presidio-analyzer/tests/test_transformers_recognizer.py
@@ -23,6 +23,12 @@ def nlp_engine(nlp_engines):
     return nlp_engine
 
 
+def prepare_and_analyze(nlp, recognizer, text, entities):
+    nlp_artifacts = nlp.process_text(text, "en")
+    results = recognizer.analyze(text, entities, nlp_artifacts)
+    return results
+
+
 @pytest.mark.skip_engine("transformers_en")
 @pytest.mark.parametrize(
     "text, expected_len, expected_positions, entity_num",
@@ -58,8 +64,7 @@ def test_when_using_transformers_then_all_transformers_result_correct(
     min_score,
     max_score,
 ):
-    nlp_artifacts = nlp_engine.process_text(text, "en")
-    results = nlp_recognizer.analyze(text, entities, nlp_artifacts)
+    results = prepare_and_analyze(nlp_engine, nlp_recognizer, text, entities)
     assert len(results) == expected_len
     entity_to_check = entities[entity_num]
     for res, (st_pos, fn_pos) in zip(results, expected_positions):
@@ -79,8 +84,7 @@ def test_when_person_in_text_then_person_full_name_complex_found(
     nlp_engine, nlp_recognizer, entities
 ):
     text = "Richard (Rick) C. Henderson"
-    nlp_artifacts = nlp_engine.process_text(text, "en")
-    results = nlp_recognizer.analyze(text, entities, nlp_artifacts)
+    results = prepare_and_analyze(nlp_engine, nlp_recognizer, text, entities)
 
     assert len(results) > 0
 


### PR DESCRIPTION
## Change Description

Reduce memory usage of Presidio Analyzer test suite (excluding Azure AI language recognizer tests) down to ~6GB from ~8GB. When run locally the tests runtime went from ~60 seconds to ~25 seconds.

### [Memray](https://bloomberg.github.io/memray/index.html) memory usgae graphs

#### Before
![Test suite memory usage before](https://github.com/user-attachments/assets/4327f08a-cfe9-4f4a-94d4-553b662afd52)

#### After
![Test suite memory usage after](https://github.com/user-attachments/assets/7823894b-3d51-4537-9823-562df7f9efc3)

### Changes

- Removed duplicate `nlp.load` call on each iteration of Stanza and transformers recognizer tests.
- Paramatized `test_when_analyze_with_unsupported_language_must_match` tests to avoid calling `AnalyzerEngine` five times in single test
- Mocked nlp engine in `test_when_analyze_with_unsupported_language_must_match` as test doesn't require nlp model to be loaded
- Removed unused fixtures - [pytest-unused-fixtures](https://github.com/mikicz/pytest-unused-fixtures) plugin used to detect them

## Issue reference

This PR fixes issue #1427

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
