### PR TITLE
rm empty cell in synth_data_with_openai.ipynb

### DIFF
--- a/docs/samples/python/synth_data_with_openai.ipynb
+++ b/docs/samples/python/synth_data_with_openai.ipynb
@@ -723,14 +723,6 @@
     "3. LLMs re-uses context from other sentences, which could cause phone numbers are sometimes generated using a credit card pattern or other similar mistakes.\n",
     "4. Co-references are sometimes missed (i.e. two name placeholders that should be filled with the same name, or referencing he/she to a male/female name)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7ff32f21-33c4-4df1-9626-73cbdf5145df",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Change Description

An empty cell was present at the end of the synthetic data generation notebook and is now removed (synth_data_with_openai.ipynb).

## Issue reference

N/A

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [ N/A ] My code includes unit tests
- [ N/A] All unit tests and lint checks pass locally
- [ N/A ] My PR contains documentation updates / additions if required
