### PR TITLE
Remove ignored labels from supported entities

### DIFF
--- a/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
@@ -73,16 +73,6 @@ class SpacyNlpEngine(NlpEngine):
         if not isinstance(model["model_name"], str):
             raise ValueError("model_name must be a string")
 
-    def get_supported_entities(self) -> List[str]:
-        """Return the supported entities for this NLP engine."""
-        if not self.ner_model_configuration.model_to_presidio_entity_mapping:
-            raise ValueError(
-                "model_to_presidio_entity_mapping is missing from model configuration"
-            )
-        return list(
-            set(self.ner_model_configuration.model_to_presidio_entity_mapping.values())
-        )
-
     def get_supported_languages(self) -> List[str]:
         """Return the supported languages for this NLP engine."""
         if not self.nlp:
@@ -121,9 +111,9 @@ class SpacyNlpEngine(NlpEngine):
             raise ValueError("NLP engine is not loaded. Consider calling .load()")
 
         texts = (str(text) for text in texts)
-        docs = self.nlp[language].pipe(texts,
-                                       as_tuples=as_tuples,
-                                       batch_size=batch_size)
+        docs = self.nlp[language].pipe(
+            texts, as_tuples=as_tuples, batch_size=batch_size
+        )
         for doc in docs:
             yield doc.text, self._doc_to_nlp_artifact(doc, language)
 

--- a/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
@@ -73,6 +73,22 @@ class SpacyNlpEngine(NlpEngine):
         if not isinstance(model["model_name"], str):
             raise ValueError("model_name must be a string")
 
+    def get_supported_entities(self) -> List[str]:
+        """Return the supported entities for this NLP engine."""
+        if not self.ner_model_configuration.model_to_presidio_entity_mapping:
+            raise ValueError(
+                "model_to_presidio_entity_mapping is missing from model configuration"
+            )
+        entities_from_mapping = list(
+            set(self.ner_model_configuration.model_to_presidio_entity_mapping.values())
+        )
+        entities = [
+            ent
+            for ent in entities_from_mapping
+            if ent not in self.ner_model_configuration.labels_to_ignore
+        ]
+        return entities
+
     def get_supported_languages(self) -> List[str]:
         """Return the supported languages for this NLP engine."""
         if not self.nlp:

--- a/presidio-analyzer/tests/test_spacy_nlp_engine.py
+++ b/presidio-analyzer/tests/test_spacy_nlp_engine.py
@@ -67,3 +67,16 @@ def test_default_configuration_correct():
     )
 
     assert actual_config_json == expected_config_json
+
+
+def test_get_supported_entities_doesnt_include_ignored():
+    ner_config = NerModelConfiguration(labels_to_ignore=["A","B"],
+                                       model_to_presidio_entity_mapping=dict(A="A",
+                                                                             B="B",
+                                                                             C="C"))
+    spacy_nlp_engine = SpacyNlpEngine(ner_model_configuration=ner_config)
+    entities = spacy_nlp_engine.get_supported_entities()
+
+    assert "A" not in entities
+    assert "B" not in entities
+    assert "C" in entities


### PR DESCRIPTION
A small fix which makes sure that ignored labels (in ner_model_configuration) are not part of the supported entities when calling `get_supported_entities`