### PR TITLE
Update US_SSN CONTEXT and unit test

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/us_ssn_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/us_ssn_recognizer.py
@@ -27,8 +27,8 @@ class UsSsnRecognizer(PatternRecognizer):
         # "sec", # Task #603: Support keyphrases ("social sec")
         "ssn",
         "ssns",
-        "ssn#",
-        "ss#",
+        # "ssn#",  # iss:1452 - a # does not work with LemmaContextAwareEnhancer
+        # "ss#",  # iss:1452 - a # does not work with LemmaContextAwareEnhancer
         "ssid",
     ]
 

--- a/presidio-analyzer/tests/data/context_sentences_tests.txt
+++ b/presidio-analyzer/tests/data/context_sentences_tests.txt
@@ -8,16 +8,22 @@ IP_ADDRESS
 my ip: 192.168.0.1
 
 US_SSN
-my ssn is 078-051120 07805-1120
+my ssn is 078-051121
 
 US_SSN
 my social security number is 078051120
 
 US_SSN
-my social security number is 078-05-1120
+my social security number is 078-05-1121
 
 US_SSN
-my social security number is 078051120
+my social security number is 078051121
+
+US_SSN
+my ssns is 078-05-1121
+
+US_SSN
+my ssid is 078-05-1121
 
 PHONE_NUMBER
 my phone number is (425) 882-9090

--- a/presidio-analyzer/tests/test_context_support.py
+++ b/presidio-analyzer/tests/test_context_support.py
@@ -70,9 +70,9 @@ def dataset(recognizers_map):
             raise ValueError(f"bad entity type {entity_type}")
 
         test_items.append((item, recognizer, [entity_type]))
-    # Currently we have 31 sentences, this is a sanity check
-    if not len(test_items) == 32:
-        raise ValueError(f"expected 31 context sentences but found {len(test_items)}")
+    # Currently we have 34 sentences, this is a sanity check
+    if not len(test_items) == 34:
+        raise ValueError(f"expected 34 context sentences but found {len(test_items)}")
 
     yield test_items
 


### PR DESCRIPTION
## Change Description

As discussed in #1452, two of the CONTEXT words ("ssn#" and "ss#")  in UsSsnRecognizer() did not work correctly since # is tokenized.

The US_SSN tests in context_sentences_tests.txt were also updated.  078051120 is [invalidated](https://github.com/microsoft/presidio/blob/c54ce2b9cf8795a168711a9fc6954d47d3269683/presidio-analyzer/presidio_analyzer/predefined_recognizers/us_ssn_recognizer.py#L76) so most of these tests were not doing anything.  The correct place to check valid/invalid numbers is in [test_us_ssn_recognizer](https://github.com/microsoft/presidio/blob/c54ce2b9cf8795a168711a9fc6954d47d3269683/presidio-analyzer/tests/test_us_ssn_recognizer.py#L17)

#### Backwards Compatibility Note

Prior to this change if the text was "My ssn# is xxx-xx-xxxx" then "ssn" instead of "ssn#" would have been used for a context match.  Since ssn is already in the CONTEXT list, this would have matched, and will continue to match.

If the text was "My ss# is xxx-xx-xxxx" then "ss" would have been used and since that was not present in the CONTEXT list the match would have failed. Therefore, removing ss# should have no functional effect.



## Issue reference

This PR fixes issue #1452 

## Checklist

- [ x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [x ] My code includes unit tests
- [x ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
