### PR TITLE
Add a link to HashiCorp vault operator resource

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -14,5 +14,6 @@ This section collects different resources developed with Presidio.
 | [HebSafeHarbor](https://github.com/8400TheHealthNetwork/HebSafeHarbor) | Clinical notes anonymization in Hebrew. |
 | [Presidio Github Action](https://github.com/marketplace/actions/presidio-action) | Github Action that analyzes text for PII entities with Microsoft's Presidio framework. |
 | [Presidio CLI](https://github.com/insightsengineering/presidio-cli) | CLI tool that analyzes text for PII Entities with Microsoft Presidio framework. |
+| [HashiCorp Vault Operator](https://github.com/sahajsoft/presidio-vault) | A library that allows to integrate Presidio with HashiCorp Vault for anonymization and deanonymization. |
 
 * Please create a PR if you're interested in adding your tool to this list.


### PR DESCRIPTION
## Change Description

This change allows presidio users to integrate with HashiCorp Vault using a [python library](https://github.com/sahajsoft/presidio-vault).

## Issue reference

N/A

## Checklist

- [x ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [x ] My PR contains documentation updates / additions if required
