### PR TITLE
Add support for allow_list, allow_list_match, regex_flags in REST API

### DIFF
--- a/e2e-tests/tests/test_analyzer.py
+++ b/e2e-tests/tests/test_analyzer.py
@@ -531,7 +531,7 @@ def test_given_allow_list_without_setting_allow_list_match_then_normal_entity_is
     {
         "text": "email: admin@github.com", 
         "language": "en", 
-        "allow_list": [".*@github.com"],
+        "allow_list": [".*@github.com"]
     }
     """
 
@@ -539,7 +539,7 @@ def test_given_allow_list_without_setting_allow_list_match_then_normal_entity_is
 
     expected_response = """
      [
-         {"entity_type": "EMAIL_ADDRESS", "start": 7, "end": 23, "score": 0.85, "analysis_explanation":null},
+         {"entity_type": "EMAIL_ADDRESS", "start": 7, "end": 23, "score": 0.85, "analysis_explanation":null}
      ]
     """
     assert response_status == 200
@@ -564,7 +564,7 @@ def test_given_regex_flags_and_normal_entities_are_returned():
 
     expected_response = """
      [
-         {"entity_type": "EMAIL_ADDRESS", "start": 7, "end": 23, "score": 0.85, "analysis_explanation":null},
+         {"entity_type": "EMAIL_ADDRESS", "start": 7, "end": 23, "score": 0.85, "analysis_explanation":null}
      ]
     """
     assert response_status == 200

--- a/e2e-tests/tests/test_analyzer.py
+++ b/e2e-tests/tests/test_analyzer.py
@@ -550,13 +550,14 @@ def test_given_allow_list_without_setting_allow_list_match_then_normal_entity_is
 
 @pytest.mark.api
 def test_given_regex_flags_and_normal_entities_are_returned():
+    # case sensitive flags are turned off, GitHub != github
     request_body = """
     {
-        "text": "email: admin@GitHub.com", # case sensitive
+        "text": "email: admin@GitHub.com",
         "language": "en", 
         "allow_list": [".*@github.com"],
         "allow_list_match": "regex",
-        "regex_flags": 0 # case insensitive flag is turned off
+        "regex_flags": 0
     }
     """
 

--- a/e2e-tests/tests/test_analyzer.py
+++ b/e2e-tests/tests/test_analyzer.py
@@ -480,3 +480,94 @@ def test_given_ad_hoc_deny_list_recognizer_the_right_entities_are_returned():
     assert equal_json_strings(
         expected_response, response_content, ignore_keys=["recognition_metadata"]
     )
+
+
+@pytest.mark.api
+def test_given_allow_list_then_no_entity_is_returned():
+    request_body = """
+    {
+        "text": "email: admin@github.com", 
+        "language": "en", 
+        "allow_list": ["admin@github.com"]
+    }
+    """
+
+    response_status, response_content = analyze(request_body)
+
+    expected_response = """
+     []
+    """
+    assert response_status == 200
+    assert equal_json_strings(
+        expected_response, response_content
+    )
+
+
+@pytest.mark.api
+def test_given_allow_list_with_regex_match_then_no_entity_is_returned():
+    request_body = """
+    {
+        "text": "email: admin@github.com", 
+        "language": "en", 
+        "allow_list": [".*@github.com"],
+        "allow_list_match": "regex"
+    }
+    """
+
+    response_status, response_content = analyze(request_body)
+
+    expected_response = """
+     []
+    """
+    assert response_status == 200
+    assert equal_json_strings(
+        expected_response, response_content
+    )
+
+
+@pytest.mark.api
+def test_given_allow_list_without_setting_allow_list_match_then_normal_entity_is_returned():
+    request_body = """
+    {
+        "text": "email: admin@github.com", 
+        "language": "en", 
+        "allow_list": [".*@github.com"],
+    }
+    """
+
+    response_status, response_content = analyze(request_body)
+
+    expected_response = """
+     [
+         {"entity_type": "EMAIL_ADDRESS", "start": 7, "end": 23, "score": 0.85, "analysis_explanation":null},
+     ]
+    """
+    assert response_status == 200
+    assert equal_json_strings(
+        expected_response, response_content, ignore_keys=["recognition_metadata"]
+    )
+
+
+@pytest.mark.api
+def test_given_regex_flags_and_normal_entities_are_returned():
+    request_body = """
+    {
+        "text": "email: admin@GitHub.com", 
+        "language": "en", 
+        "allow_list": [".*@github.com"],
+        "allow_list_match": "regex",
+        "regex_flags": 0
+    }
+    """
+
+    response_status, response_content = analyze(request_body)
+
+    expected_response = """
+     [
+         {"entity_type": "EMAIL_ADDRESS", "start": 7, "end": 23, "score": 0.85, "analysis_explanation":null},
+     ]
+    """
+    assert response_status == 200
+    assert equal_json_strings(
+        expected_response, response_content, ignore_keys=["recognition_metadata"]
+    )

--- a/e2e-tests/tests/test_analyzer.py
+++ b/e2e-tests/tests/test_analyzer.py
@@ -552,11 +552,11 @@ def test_given_allow_list_without_setting_allow_list_match_then_normal_entity_is
 def test_given_regex_flags_and_normal_entities_are_returned():
     request_body = """
     {
-        "text": "email: admin@GitHub.com", 
+        "text": "email: admin@GitHub.com", # case sensitive
         "language": "en", 
         "allow_list": [".*@github.com"],
         "allow_list_match": "regex",
-        "regex_flags": 0
+        "regex_flags": 0 # case insensitive flag is turned off
     }
     """
 

--- a/presidio-analyzer/app.py
+++ b/presidio-analyzer/app.py
@@ -74,6 +74,9 @@ class Server:
                     return_decision_process=req_data.return_decision_process,
                     ad_hoc_recognizers=req_data.ad_hoc_recognizers,
                     context=req_data.context,
+                    allow_list=req_data.allow_list,
+                    allow_list_match=req_data.allow_list_match,
+                    regex_flags=req_data.regex_flags
                 )
 
                 return Response(

--- a/presidio-analyzer/presidio_analyzer/analyzer_request.py
+++ b/presidio-analyzer/presidio_analyzer/analyzer_request.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict
 
 from presidio_analyzer import PatternRecognizer
@@ -34,3 +35,6 @@ class AnalyzerRequest:
                 PatternRecognizer.from_dict(rec) for rec in ad_hoc_recognizers
             ]
         self.context = req_data.get("context")
+        self.allow_list = req_data.get("allow_list")
+        self.allow_list_match = req_data.get("allow_list_match", "exact")
+        self.regex_flags = req_data.get("regex_flags", re.DOTALL | re.MULTILINE | re.IGNORECASE)

--- a/presidio-analyzer/presidio_analyzer/analyzer_request.py
+++ b/presidio-analyzer/presidio_analyzer/analyzer_request.py
@@ -37,5 +37,5 @@ class AnalyzerRequest:
         self.context = req_data.get("context")
         self.allow_list = req_data.get("allow_list")
         self.allow_list_match = req_data.get("allow_list_match", "exact")
-        self.regex_flags = req_data.get("regex_flags", 
+        self.regex_flags = req_data.get("regex_flags",
                                         re.DOTALL | re.MULTILINE | re.IGNORECASE)

--- a/presidio-analyzer/presidio_analyzer/analyzer_request.py
+++ b/presidio-analyzer/presidio_analyzer/analyzer_request.py
@@ -37,4 +37,5 @@ class AnalyzerRequest:
         self.context = req_data.get("context")
         self.allow_list = req_data.get("allow_list")
         self.allow_list_match = req_data.get("allow_list_match", "exact")
-        self.regex_flags = req_data.get("regex_flags", re.DOTALL | re.MULTILINE | re.IGNORECASE)
+        self.regex_flags = req_data.get("regex_flags", 
+                                        re.DOTALL | re.MULTILINE | re.IGNORECASE)


### PR DESCRIPTION
## Change Description

Add support for allow_list, allow_list_match, regex_flags in REST API

## Issue reference

This PR fixes issue [#1470 ](https://github.com/microsoft/presidio/issues/1470)

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
