### PR TITLE
Removed python 3.8 support (EOL) and added 3.12

### DIFF
--- a/.pipelines/templates/e2e-tests.yml
+++ b/.pipelines/templates/e2e-tests.yml
@@ -21,7 +21,7 @@ steps:
       
     - task: UsePythonVersion@0
       inputs:
-          versionSpec: '3.9'
+          versionSpec: '3.10'
 
     - script: |
           set -eux  # fail on error

--- a/.pipelines/templates/lint-build-test.yml
+++ b/.pipelines/templates/lint-build-test.yml
@@ -32,14 +32,14 @@ stages:
                 vmImage: 'ubuntu-latest'
             strategy:
                 matrix:
-                    Python38:
-                        python.version: '3.8'
                     Python39:
                         python.version: '3.9'
                     Python310:
                         python.version: '3.10'
                     Python311:
                         python.version: '3.11'
+                    Python312:
+                        python.version: '3.12'
 
             steps:
                 - task: UsePythonVersion@0
@@ -54,14 +54,14 @@ stages:
                 vmImage: 'ubuntu-latest'
             strategy:
                 matrix:
-                    Python38:
-                        python.version: '3.8'
                     Python39:
                         python.version: '3.9'
                     Python310:
                         python.version: '3.10'
                     Python311:
                         python.version: '3.11'
+                    Python312:
+                        python.version: '3.12'
 
             steps:
                 - task: UsePythonVersion@0
@@ -76,14 +76,14 @@ stages:
                 vmImage: 'ubuntu-latest'
             strategy:
                 matrix:
-                    Python38:
-                        python.version: '3.8'
                     Python39:
                         python.version: '3.9'
                     Python310:
                         python.version: '3.10'
                     Python311:
                         python.version: '3.11'
+                    Python312:
+                        python.version: '3.12'
 
             steps:
                 - task: UsePythonVersion@0
@@ -99,13 +99,14 @@ stages:
             strategy:
                 matrix:
                     Python38:
-                        python.version: '3.8'
                     Python39:
                         python.version: '3.9'
                     Python310:
                         python.version: '3.10'
                     Python311:
                         python.version: '3.11'
+                    Python312:
+                        python.version: '3.12'
 
             steps:
                 - task: UsePythonVersion@0
@@ -120,14 +121,14 @@ stages:
                 vmImage: 'ubuntu-latest'
             strategy:
                 matrix:
-                    Python38:
-                        python.version: '3.8'
                     Python39:
                         python.version: '3.9'
                     Python310:
                         python.version: '3.10'
                     Python311:
                         python.version: '3.11'
+                    Python312:
+                        python.version: '3.12'
 
             steps:
                 - task: UsePythonVersion@0

--- a/.pipelines/templates/lint-build-test.yml
+++ b/.pipelines/templates/lint-build-test.yml
@@ -98,7 +98,6 @@ stages:
                 vmImage: 'ubuntu-latest'
             strategy:
                 matrix:
-                    Python38:
                     Python39:
                         python.version: '3.9'
                     Python310:

--- a/.pipelines/templates/test-docs.yml
+++ b/.pipelines/templates/test-docs.yml
@@ -7,7 +7,7 @@ pool:
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.9'
+    versionSpec: '3.10'
     addToPath: true
     architecture: 'x64'
 

--- a/docker-compose-image.yml
+++ b/docker-compose-image.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   presidio-image-redactor:
     image: ${REGISTRY_NAME}${IMAGE_PREFIX}presidio-image-redactor${TAG}

--- a/docker-compose-text.yml
+++ b/docker-compose-text.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   presidio-anonymizer:
     image: ${REGISTRY_NAME}${IMAGE_PREFIX}presidio-anonymizer${TAG}

--- a/docker-compose-transformers.yml
+++ b/docker-compose-transformers.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   presidio-anonymizer:
     image: ${REGISTRY_NAME}${IMAGE_PREFIX}presidio-anonymizer${TAG}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   presidio-anonymizer:
     image: ${REGISTRY_NAME}${IMAGE_PREFIX}presidio-anonymizer${TAG}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,11 +17,10 @@ Presidio suite using `pip` (as Python packages) or using `Docker` (As containeri
 
 Presidio is supported for the following python versions:
 
-* 3.7
-* 3.8
 * 3.9
 * 3.10
 * 3.11
+* 3.12
 
 ### PII anonymization on text
 

--- a/docs/samples/python/streamlit/Dockerfile
+++ b/docs/samples/python/streamlit/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/e2e-tests/resources/demo.txt
+++ b/e2e-tests/resources/demo.txt
@@ -3,7 +3,7 @@ Here are a few examples sentences we currently support:
 Hello, my name is David Johnson and I live in Maine.
 My credit card number is 4095-2609-9393-4932 and my crypto wallet id is 16Yeky6GMjeNkAiNcBY7ZhrLoMSgg1BoyZ.
 
-On September 18 I visited microsoft.com and sent an email to test@presidio.site,  from the IP 192.168.0.1.
+On September 18 I visited microsoft.com and sent an email to test@presidio.site,  from IP 192.168.0.1.
 
 My passport: 191280342 and my phone number: (212) 555-1234.
 

--- a/e2e-tests/resources/demo_anonymized.txt
+++ b/e2e-tests/resources/demo_anonymized.txt
@@ -3,7 +3,7 @@ Here are a few examples sentences we currently support:
 Hello, my name is <PERSON> and I live in <LOCATION>.
 My credit card number is <CREDIT_CARD> and my crypto wallet id is <CRYPTO>.
 
-On <DATE_TIME> I visited <URL> and sent an email to <EMAIL_ADDRESS>,  from the IP <IP_ADDRESS>.
+On <DATE_TIME> I visited <URL> and sent an email to <EMAIL_ADDRESS>,  from IP <IP_ADDRESS>.
 
 My passport: <US_PASSPORT> and my phone number: <PHONE_NUMBER>.
 

--- a/presidio-analyzer/Dockerfile.dev
+++ b/presidio-analyzer/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG DEV_MODE=dev
 ARG POETRY_EXTRAS=""

--- a/presidio-analyzer/pyproject.toml
+++ b/presidio-analyzer/pyproject.toml
@@ -11,10 +11,10 @@ license = "MIT"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 keywords = ["presidio_analyzer"]
 urls = {Homepage = "https://github.com/Microsoft/presidio"}
@@ -22,7 +22,7 @@ readme = "README.md"
 include = ["conf/*",]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 spacy= ">=3.4.4, <4.0.0"
 regex = "*"
 tldextract = "*"

--- a/presidio-anonymizer/pyproject.toml
+++ b/presidio-anonymizer/pyproject.toml
@@ -11,17 +11,17 @@ license = "MIT"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 keywords = ["presidio_anonymizer"]
 urls = {Homepage = "https://github.com/Microsoft/presidio"}
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 pycryptodome = ">=3.10.1"
 azure-core = { version = "*", optional = true }
 flask = { version = ">=1.1", optional = true }

--- a/presidio-cli/README.md
+++ b/presidio-cli/README.md
@@ -10,7 +10,7 @@ CLI tool that analyzes text for PII Entities using Presidio Analyzer.
 
 ## Prerequisities
 
-`Python` version: 3.8, 3.9, 3.10
+`Python` version: 3.9, 3.10, 3.11
 
 `poetry` tool installed:
 

--- a/presidio-cli/pyproject.toml
+++ b/presidio-cli/pyproject.toml
@@ -11,10 +11,10 @@ license = "MIT"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 keywords = ["pii", "checker", "presidio_cli"]
 urls = {Homepage = "https://github.com/microsoft/presidio"}
@@ -22,7 +22,7 @@ readme = "README.md"
 include = ["conf/*", ".presidiocli"]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 presidio-analyzer = ">= 2.2"
 pyyaml = "*"
 pathspec = "*"

--- a/presidio-image-redactor/Dockerfile
+++ b/presidio-image-redactor/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 ARG NAME
 ARG NLP_CONF_FILE

--- a/presidio-image-redactor/Dockerfile.dev
+++ b/presidio-image-redactor/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 RUN apt-get update \
   && apt-get install -y build-essential

--- a/presidio-image-redactor/pyproject.toml
+++ b/presidio-image-redactor/pyproject.toml
@@ -11,17 +11,17 @@ license = "MIT"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 keywords = ["presidio_image_redactor"]
 urls = {Homepage = "https://github.com/Microsoft/presidio"}
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 pillow = ">=9.0"
 pytesseract = ">=0.3.7,<0.4"
 presidio-analyzer = ">=1.9.0"

--- a/presidio-structured/pyproject.toml
+++ b/presidio-structured/pyproject.toml
@@ -11,17 +11,17 @@ license = "MIT"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 keywords = ["presidio_structured"]
 urls = {Homepage = "https://github.com/microsoft/presidio"}
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 presidio-analyzer = ">=2.2"
 presidio-anonymizer = ">=2.2"
 pandas = ">=1.5.2"


### PR DESCRIPTION
## Change Description

1. Python 3.8 EOL date is 2024-10-07. Removed 3.8 and added 3.12
2. removed obsolete `version` parameter from docker-compose
Fixes issue #1473 
3. Fixed failing e2e test (demo website text validation, also updated the demo website's text)