### PR TITLE
Fix regex match_time output

### DIFF
--- a/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
@@ -196,10 +196,9 @@ class PatternRecognizer(LocalRecognizer):
             matches = pattern.compiled_regex.finditer(text)
             match_time = datetime.datetime.now() - match_start_time
             logger.debug(
-                "--- match_time[%s]: %s.%s seconds",
+                "--- match_time[%s]: %.6f seconds",
                 pattern.name,
-                match_time.seconds,
-                match_time.microseconds,
+                match_time.total_seconds()
             )
 
             for match in matches:


### PR DESCRIPTION
## Change Description

The microseconds were output incorrectly before (missing leading zeros). Also, `seconds` was used instead of `total_seconds` (should be irrelevant in practice, though).

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
