### PR TITLE
Restricting spacy.cli for version 3.7.0

### DIFF
--- a/presidio-analyzer/pyproject.toml
+++ b/presidio-analyzer/pyproject.toml
@@ -36,7 +36,6 @@ azure-ai-textanalytics = { version = "*", optional = true }
 azure-core = { version = "*", optional = true }
 transformers = { version = "*", optional = true }
 huggingface_hub = { version = "*", optional = true }
-spacy = "!=3.7.0"  # Exclude spaCy 3.7.0 -> https://github.com/microsoft/presidio/issues/1487
 
 [tool.poetry.extras]
 server = ["flask"]

--- a/presidio-analyzer/pyproject.toml
+++ b/presidio-analyzer/pyproject.toml
@@ -36,6 +36,7 @@ azure-ai-textanalytics = { version = "*", optional = true }
 azure-core = { version = "*", optional = true }
 transformers = { version = "*", optional = true }
 huggingface_hub = { version = "*", optional = true }
+spacy = "!=3.7.0"  # Exclude spaCy 3.7.0 -> https://github.com/microsoft/presidio/issues/1487
 
 [tool.poetry.extras]
 server = ["flask"]

--- a/presidio-analyzer/pyproject.toml
+++ b/presidio-analyzer/pyproject.toml
@@ -23,7 +23,7 @@ include = ["conf/*",]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-spacy= ">=3.4.4, <4.0.0"
+spacy= ">=3.4.4, <4.0.0, !=3.7.0"
 regex = "*"
 tldextract = "*"
 pyyaml = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,3 @@ line-ending = "auto"
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
-
-[tool.poetry.dependencies]
-spacy = "!=3.7.0"  # Exclude spaCy 3.7.0 -> https://github.com/microsoft/presidio/issues/1487
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,7 @@ line-ending = "auto"
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.poetry.dependencies]
+spacy = "!=3.7.0"  # Exclude spaCy 3.7.0 -> https://github.com/microsoft/presidio/issues/1487
+


### PR DESCRIPTION
## Change Description

Describe your changes

Puts restriction on installing spacy 3.7.0

## Issue reference

This PR fixes issue https://github.com/microsoft/presidio/issues/1487

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
