### PR TITLE
Update presidio_streamlit.py

### DIFF
--- a/docs/samples/python/streamlit/presidio_streamlit.py
+++ b/docs/samples/python/streamlit/presidio_streamlit.py
@@ -298,15 +298,13 @@ try:
     analyzer = analyzer_engine(*analyzer_params)
     analyzer_load_state.empty()
 
-    st_analyze_results = analyze(
-        *analyzer_params,
+    st_analyze_results = analyzer.analyze(
         text=st_text,
         entities=st_entities,
         language="en",
         score_threshold=st_threshold,
         return_decision_process=st_return_decision_process,
-        allow_list=st_allow_list,
-        deny_list=st_deny_list,
+        allow_list=st_allow_list
     )
 
     # After


### PR DESCRIPTION
In the demo the analyzer is being instantiated but not used.
This might work in Streamlit (because of st.cache), but in other scenarios the model will get reloaded on each run of the function.