### PR TITLE
Upgrade codeql

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -48,6 +48,6 @@ jobs:
       uses: microsoft/security-devops-action@v1.11.0
       id: msdo
     - name: Upload results to Security tab
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ steps.msdo.outputs.sarifFile }}


### PR DESCRIPTION
## Change Description

Upgradel codeql to v3:
https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
