### PR TITLE
Fix return type annotation of verify_dicom_instance function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Image Redactor
 
+- Changed: Updated the return type annotation of `ocr_bboxes` in `verify_dicom_instance()` from `dict` to `list`.  
+
 ### Presidio Structured
 
 ### General

--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_pii_verify_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_pii_verify_engine.py
@@ -55,7 +55,7 @@ class DicomImagePiiVerifyEngine(ImagePiiVerifyEngine, DicomImageRedactorEngine):
         ocr_kwargs: Optional[dict] = None,
         ad_hoc_recognizers: Optional[List[PatternRecognizer]] = None,
         **text_analyzer_kwargs,
-    ) -> Tuple[Optional[PIL.Image.Image], dict, list]:
+    ) -> Tuple[Optional[PIL.Image.Image], list, list]:
         """Verify PII on a single DICOM instance.
 
         :param instance: Loaded DICOM instance including pixel data and metadata.


### PR DESCRIPTION
## Change Description

This PR corrects the type annotation for the `ocr_bboxes` return value in the `verify_dicom_instance` function. The original annotation indicated that ocr_bboxes would be of type dict, but the actual output is a list. Therefore, this PR updates the return type annotation to reflect the correct type of ocr_bboxes as a list.

## Issue reference

This PR fixes issue #1548 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
