### PR TITLE
Updated the Evaluating DICOM Redaction documentation to reflect chang…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### General
 
+- Updated the `Evaluating DICOM Redaction` documentation to reflect changes in verify_dicom_instance() within the DicomImagePiiVerifyEngine class.
 
 ## [2.3.357] - 2025-01-13
 

--- a/docs/image-redactor/evaluating_dicom_redaction.md
+++ b/docs/image-redactor/evaluating_dicom_redaction.md
@@ -85,15 +85,11 @@ padding_width = 25
 
 # Get OCR and NER results
 verification_image, ocr_results, analyzer_results = dicom_engine.verify_dicom_instance(instance, padding_width)
-
-# Format results for more direct comparison
-ocr_results_formatted = dicom_engine.bbox_processor.get_bboxes_from_ocr_results(ocr_results)
-analyzer_results_formatted = dicom_engine.bbox_processor.get_bboxes_from_analyzer_results(analyzer_results)
 ```
 
 By looking at the output of `verify_dicom_instance`, we can create a ground truth labels json.
 
-Save `analyzer_results_formatted` as a json file and then perform the following
+Save `analyzer_results` as a json file and then perform the following
 
 1. Group the results into a new item with the file name set as the key.
 2. For each item in this group:
@@ -108,10 +104,10 @@ Pixel position and size data can be obtained using any labeling software or imag
 
 ### Example
 
-Let's say we ran the above code block and see the following for `ocr_results_formatted` and `analyzer_results_formatted`.
+Let's say we ran the above code block and see the following for `ocr_results` and `analyzer_results`.
 
 ```json
-// OCR Results (formatted)
+// OCR Results
 [
     {
         "left": 25,
@@ -131,7 +127,7 @@ Let's say we ran the above code block and see the following for `ocr_results_for
     }
 ]
 
-// Analyzer Results (formatted)
+// Analyzer Results
 [
     {
         "entity_type": "PERSON",


### PR DESCRIPTION
## Change Description

The latest implementation of `verify_dicom_instance()` in the `DicomImagePiiVerifyEngine` class returns `verify_image`, `ocr_bboxes`, and `analyzer_bboxes`. However, it appears that this function previously returned `ocr_results`, which was a dictionary directly returned by the OCR engine's `perform_ocr()` method.

Therefore, minor revision is required for `Evaluating DICOM de-identification` docs to reflect updated `verify_dicom_instance()`.

## Issue reference

This PR fixes issue #1548 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
