### PR TITLE
Don't set a default for LABELS_TO_IGNORE if not specified

### DIFF
--- a/presidio-analyzer/presidio_analyzer/nlp_engine/ner_model_configuration.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/ner_model_configuration.py
@@ -27,21 +27,6 @@ MODEL_TO_PRESIDIO_ENTITY_MAPPING = dict(
 )
 
 LOW_SCORE_ENTITY_NAMES = set()
-LABELS_TO_IGNORE = {
-    "O",
-    "ORG",
-    "ORGANIZATION",
-    "CARDINAL",
-    "EVENT",
-    "LANGUAGE",
-    "LAW",
-    "MONEY",
-    "ORDINAL",
-    "PERCENT",
-    "PRODUCT",
-    "QUANTITY",
-    "WORK_OF_ART",
-}
 
 
 @dataclass
@@ -89,7 +74,7 @@ class NerModelConfiguration:
             logger.warning(
                 "labels_to_ignore is missing from configuration, " "using default"
             )
-            self.labels_to_ignore = LABELS_TO_IGNORE
+            self.labels_to_ignore = {}
 
     @classmethod
     def _validate_input(cls, ner_model_configuration_dict: Dict) -> None:

--- a/presidio-analyzer/tests/test_nlp_engine_provider.py
+++ b/presidio-analyzer/tests/test_nlp_engine_provider.py
@@ -171,6 +171,12 @@ def test_when_both_conf_and_config_then_fail(mocker):
         NlpEngineProvider(conf_file=conf_file, nlp_configuration=nlp_configuration)
 
 
+def test_when_labels_to_ignore_not_define_in_conf_file_default_into_empty_set(mocker):
+    conf_file = "conf/spacy_multilingual.yaml"
+
+    engine = NlpEngineProvider(conf_file=conf_file).create_engine()
+    assert len(engine.ner_model_configuration.labels_to_ignore) == 0
+
 @pytest.mark.skip_engine("transformers_en")
 def test_when_create_transformers_nlp_engine_then_succeeds(mocker):
     mocker.patch(


### PR DESCRIPTION
## Change Description

Following [this](https://stackoverflow.com/questions/79549787/why-does-presidio-with-spacy-nlp-engine-not-recognize-organizations-and-pesel-wh) issue, drop LABELS_TO_IGNORE default list as it is defined in the default, now used, analyzer configuration

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
