### PR TITLE
[Build failure] Add accelerate missing dependency

### DIFF
--- a/presidio-analyzer/pyproject.toml
+++ b/presidio-analyzer/pyproject.toml
@@ -37,6 +37,7 @@ server = [
 ]
 transformers = [
     "transformers",
+    "accelerate",
     "huggingface_hub",
     "spacy_huggingface_pipelines"]
 stanza = [


### PR DESCRIPTION
## Change Description

transformers project extension is failing due to missing library accelerate

On CI:
https://dev.azure.com/csedevil/Presidio/_build/results?buildId=16960&view=logs&jobId=c95b3c98-5406-5374-cc38-efae5747f3c6&j=c159508c-3a29-50e1-f978-bea95db34528&t=673971d3-9f65-5b91-5977-6c3f5fbb7816

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
