### PR TITLE
fix issue 1574 to support as_tuples

### DIFF
--- a/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 import spacy
 from spacy.language import Language
@@ -13,7 +13,6 @@ from presidio_analyzer.nlp_engine import (
 )
 
 logger = logging.getLogger("presidio-analyzer")
-
 
 class SpacyNlpEngine(NlpEngine):
     """
@@ -118,7 +117,7 @@ class SpacyNlpEngine(NlpEngine):
         batch_size: int = 1,
         n_process: int = 1,
         as_tuples: bool = False,
-    ) -> Iterator[Optional[NlpArtifacts]]:
+    ) -> Generator[tuple[Any, NlpArtifacts, Any] | tuple[Any, NlpArtifacts], Any, None]:
         """Execute the NLP pipeline on a batch of texts using spacy pipe.
 
         :param texts: A list of texts to process.
@@ -133,12 +132,20 @@ class SpacyNlpEngine(NlpEngine):
         if not self.nlp:
             raise ValueError("NLP engine is not loaded. Consider calling .load()")
 
-        texts = (str(text) for text in texts)
-        docs = self.nlp[language].pipe(
+        if as_tuples:
+            texts = [(str(text), context) for text, context in texts]
+        else:
+            texts = (str(text) for text in texts)
+        batch_output = self.nlp[language].pipe(
             texts, as_tuples=as_tuples, batch_size=batch_size, n_process=n_process
         )
-        for doc in docs:
-            yield doc.text, self._doc_to_nlp_artifact(doc, language)
+        for output in batch_output:
+            if as_tuples:
+                doc, context = output
+                yield doc.text, self._doc_to_nlp_artifact(doc, language), context
+            else:
+                doc = output
+                yield doc.text, self._doc_to_nlp_artifact(doc, language)
 
     def is_stopword(self, word: str, language: str) -> bool:
         """

--- a/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
@@ -120,13 +120,17 @@ class SpacyNlpEngine(NlpEngine):
     ) -> Generator[tuple[Any, NlpArtifacts, Any] | tuple[Any, NlpArtifacts], Any, None]:
         """Execute the NLP pipeline on a batch of texts using spacy pipe.
 
-        :param texts: A list of texts to process.
+        :param texts: A list of texts to process. if as_tuples is set to True,
+            texts should be a list of tuples (text, context).
         :param language: The language of the texts.
         :param batch_size: Default batch size for pipe and evaluate.
         :param n_process: Number of processors to process texts.
         :param as_tuples: If set to True, inputs should be a sequence of
             (text, context) tuples. Output will then be a sequence of
             (doc, context) tuples. Defaults to False.
+
+        :return: A generator of tuples (text, NlpArtifacts, context) or
+            (text, NlpArtifacts) depending on the value of as_tuples.
         """
 
         if not self.nlp:

--- a/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
@@ -118,7 +118,9 @@ class SpacyNlpEngine(NlpEngine):
         batch_size: int = 1,
         n_process: int = 1,
         as_tuples: bool = False,
-    ) -> Generator[Union[Tuple[Any, NlpArtifacts, Any], Tuple[Any, NlpArtifacts]], Any, None]:
+    ) -> Generator[
+        Union[Tuple[Any, NlpArtifacts, Any], Tuple[Any, NlpArtifacts]], Any, None
+    ]:
         """Execute the NLP pipeline on a batch of texts using spacy pipe.
 
         :param texts: A list of texts to process. if as_tuples is set to True,

--- a/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
@@ -117,7 +117,7 @@ class SpacyNlpEngine(NlpEngine):
         batch_size: int = 1,
         n_process: int = 1,
         as_tuples: bool = False,
-    ) -> Generator[tuple[Any, NlpArtifacts, Any] | tuple[Any, NlpArtifacts], Any, None]:
+    ) -> Generator[Union[Tuple[Any, NlpArtifacts, Any] , Tuple[Any, NlpArtifacts], Any, None]]:
         """Execute the NLP pipeline on a batch of texts using spacy pipe.
 
         :param texts: A list of texts to process. if as_tuples is set to True,

--- a/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
@@ -118,9 +118,7 @@ class SpacyNlpEngine(NlpEngine):
         batch_size: int = 1,
         n_process: int = 1,
         as_tuples: bool = False,
-    ) -> Generator[
-        Union[Tuple[Any, NlpArtifacts, Any], Tuple[Any, NlpArtifacts], Any, None]
-    ]:
+    ) -> Generator[Union[Tuple[Any, NlpArtifacts, Any], Tuple[Any, NlpArtifacts]], Any, None]:
         """Execute the NLP pipeline on a batch of texts using spacy pipe.
 
         :param texts: A list of texts to process. if as_tuples is set to True,
@@ -145,7 +143,7 @@ class SpacyNlpEngine(NlpEngine):
                     "When 'as_tuples' is True, "
                     "'texts' must be a list of tuples (text, context)."
                 )
-            texts = [(str(text), context) for text, context in texts]
+            texts = ((str(text), context) for text, context in texts)
         else:
             texts = (str(text) for text in texts)
         batch_output = self.nlp[language].pipe(

--- a/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
@@ -14,6 +14,7 @@ from presidio_analyzer.nlp_engine import (
 
 logger = logging.getLogger("presidio-analyzer")
 
+
 class SpacyNlpEngine(NlpEngine):
     """
     SpacyNlpEngine is an abstraction layer over the nlp module.
@@ -117,7 +118,9 @@ class SpacyNlpEngine(NlpEngine):
         batch_size: int = 1,
         n_process: int = 1,
         as_tuples: bool = False,
-    ) -> Generator[Union[Tuple[Any, NlpArtifacts, Any] , Tuple[Any, NlpArtifacts], Any, None]]:
+    ) -> Generator[
+        Union[Tuple[Any, NlpArtifacts, Any], Tuple[Any, NlpArtifacts], Any, None]
+    ]:
         """Execute the NLP pipeline on a batch of texts using spacy pipe.
 
         :param texts: A list of texts to process. if as_tuples is set to True,
@@ -139,7 +142,8 @@ class SpacyNlpEngine(NlpEngine):
         if as_tuples:
             if not all(isinstance(item, tuple) and len(item) == 2 for item in texts):
                 raise ValueError(
-                    "When 'as_tuples' is True, 'texts' must be a list of tuples (text, context)."
+                    "When 'as_tuples' is True, "
+                    "'texts' must be a list of tuples (text, context)."
                 )
             texts = [(str(text), context) for text, context in texts]
         else:

--- a/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/spacy_nlp_engine.py
@@ -137,6 +137,10 @@ class SpacyNlpEngine(NlpEngine):
             raise ValueError("NLP engine is not loaded. Consider calling .load()")
 
         if as_tuples:
+            if not all(isinstance(item, tuple) and len(item) == 2 for item in texts):
+                raise ValueError(
+                    "When 'as_tuples' is True, 'texts' must be a list of tuples (text, context)."
+                )
             texts = [(str(text), context) for text, context in texts]
         else:
             texts = (str(text) for text in texts)

--- a/presidio-analyzer/tests/test_spacy_nlp_engine.py
+++ b/presidio-analyzer/tests/test_spacy_nlp_engine.py
@@ -81,3 +81,25 @@ def test_get_supported_entities_doesnt_include_ignored():
     assert "A" not in entities
     assert "B" not in entities
     assert "C" in entities
+
+
+@pytest.mark.parametrize("texts, as_tuples", [
+    (["simple text", "simple text"], False),
+    ([("simple text", {"key": "value"})], True),
+])
+def test_batch_processing_with_as_tuples_returns_context(spacy_nlp_engine, texts, as_tuples):
+    nlp_artifacts_batch = spacy_nlp_engine.process_batch(
+        texts, language="en", as_tuples=as_tuples
+    )
+    assert isinstance(nlp_artifacts_batch, Iterator)
+    nlp_artifacts_batch = list(nlp_artifacts_batch)
+
+    if as_tuples:
+        for text, nlp_artifacts, context in nlp_artifacts_batch:
+            assert text == "simple text"
+            assert len(nlp_artifacts.tokens) == 2
+            assert context == {"key": "value"}
+    else:
+        for text, nlp_artifacts in nlp_artifacts_batch:
+            assert text == "simple text"
+            assert len(nlp_artifacts.tokens) == 2

--- a/presidio-analyzer/tests/test_stanza_nlp_engine.py
+++ b/presidio-analyzer/tests/test_stanza_nlp_engine.py
@@ -1,9 +1,8 @@
 """Tests adapted from the spacy_stanza repo"""
 
-from spacy.lang.en import EnglishDefaults, English
+from spacy.lang.en import EnglishDefaults
 
 
-import stanza
 import pytest
 
 from presidio_analyzer.nlp_engine.stanza_nlp_engine import load_pipeline
@@ -16,6 +15,7 @@ def tags_equal(act, exp):
 
 @pytest.fixture(scope="module")
 def stanza_pipeline():
+    import stanza
     lang = "en"
     stanza.download(lang)
     nlp = load_pipeline(lang)


### PR DESCRIPTION
## Change Description

Fixing issue #1574 where as_tuples=True would not work.
Added support for input of type `List[Tuple[str, object]]` where the user might want to add additional context/metatada to the list of texts to process, and get them together with the processed text.

Also fixed an issue with test_stanza_nlp_engine, assuming stanza is always installed.

## Issue reference

This PR fixes issue #1574

## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [X] I have signed the CLA (if required)
- [X] My code includes unit tests
- [X] All unit tests and lint checks pass locally
- [X] My PR contains documentation updates / additions if required
