### PR TITLE
Fix mutation of analyzer results input by Anonymizer by creating a copy

### DIFF
--- a/presidio-anonymizer/presidio_anonymizer/anonymizer_engine.py
+++ b/presidio-anonymizer/presidio_anonymizer/anonymizer_engine.py
@@ -1,5 +1,6 @@
 """Handles the entire logic of the Presidio-anonymizer and text anonymizing."""
 
+import copy
 import logging
 import re
 from typing import Dict, List, Optional, Type
@@ -83,6 +84,10 @@ class AnonymizerEngine(EngineBase):
 
 
         """
+        # We do this to make sure the original analyzer_results object is not
+        # modified
+        analyzer_results = copy.deepcopy(analyzer_results)
+
         analyzer_results = self._remove_conflicts_and_get_text_manipulation_data(
             analyzer_results, conflict_resolution
         )


### PR DESCRIPTION
## Change Description
Fixes issue #1573, where the analyzer results object is mutated by the Anonymizer (in the `_merge_entities_with_whitespace_between` method). This is an unexpected side-effect -- when we run anonymization, we don't expect the original input (the analyzer results object) to be modified. Also, other services could possibly also operate on the same object, and mutation is clearly undesirable here.

### Change

Make a deep copy of `List[RecognizerResult]` before running any other methods within the `anonymize` method. Any subsequent operations only work with this copy and do not mutate the original object. A deep copy is required because the input is a nested object, using the normal copy would just create a new list referring to the same `RecognizerResult` objects.

## Issue reference

This PR fixes one out of two mentioned issues in #1573 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
