### PR TITLE
Fix: Anonymizer should sort analyzer results input by start and end for whitespace merging to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
   
 ### Anonymizer
 - Fix mutation of input analyzer results object in Anonymizer by creating a copy first
+- Fix whitespace merging not occurring for unsorted (by start, end) analyzer results input by sorting it first
   
 ### Image Redactor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Analyzer
   
 ### Anonymizer
+- Fix mutation of input analyzer results object in Anonymizer by creating a copy first
   
 ### Image Redactor
 

--- a/presidio-anonymizer/presidio_anonymizer/anonymizer_engine.py
+++ b/presidio-anonymizer/presidio_anonymizer/anonymizer_engine.py
@@ -88,6 +88,10 @@ class AnonymizerEngine(EngineBase):
         # modified
         analyzer_results = copy.deepcopy(analyzer_results)
 
+        # Sort because downstream processors like whitespace merging expect input to
+        # be sorted by start, end to work correctly
+        analyzer_results.sort(key=lambda x: (x.start, x.end))
+
         analyzer_results = self._remove_conflicts_and_get_text_manipulation_data(
             analyzer_results, conflict_resolution
         )

--- a/presidio-anonymizer/presidio_anonymizer/anonymizer_engine.py
+++ b/presidio-anonymizer/presidio_anonymizer/anonymizer_engine.py
@@ -1,5 +1,6 @@
 """Handles the entire logic of the Presidio-anonymizer and text anonymizing."""
 
+import copy
 import logging
 import re
 from typing import Dict, List, Optional, Type
@@ -83,6 +84,10 @@ class AnonymizerEngine(EngineBase):
 
 
         """
+        # We do this to make sure the original analyzer_results object is not
+        # modified
+        analyzer_results = copy.deepcopy(analyzer_results)
+
         analyzer_results = self._remove_conflicts_and_get_text_manipulation_data(
             analyzer_results, conflict_resolution
         )

--- a/presidio-anonymizer/tests/test_anonymizer_engine.py
+++ b/presidio-anonymizer/tests/test_anonymizer_engine.py
@@ -261,6 +261,23 @@ def test_given_analyzer_result_input_then_it_is_not_mutated():
     ):
         assert_analyzer_results_eq(original_result, copy_result)
 
+def test_given_unsorted_input_then_merged_correctly():
+    engine = AnonymizerEngine()
+    text = "Jane Doe is a person"
+    # Let's say the analyzer has detected 'Jane' and 'Doe' as separate people,
+    # and the results are not sorted by start, end.
+    original_analyzer_results = [
+        RecognizerResult(start=5, end=8, entity_type="PERSON", score=1.0),
+        RecognizerResult(start=0, end=4, entity_type="PERSON", score=1.0),
+    ]
+    # The whitespace merger should correctly merge the separate entities during the
+    # anonymization process.
+    anonymizer_result = engine.anonymize(
+        text,
+        original_analyzer_results
+    )
+    assert anonymizer_result.text == "<PERSON> is a person"
+
 
 def _operate(
     text: str,

--- a/presidio-anonymizer/tests/test_anonymizer_engine.py
+++ b/presidio-anonymizer/tests/test_anonymizer_engine.py
@@ -236,12 +236,12 @@ def test_given_sorted_analyzer_results_merge_entities_separated_by_white_space(
     assert result.text == expected.text
     assert sorted(result.items) == sorted(expected.items)
 
-def test_given_analyzer_result_then_it_is_not_modified_inplace():
+def test_given_analyzer_result_input_then_it_is_not_mutated():
     def assert_analyzer_results_eq(res1, res2):
         assert res1.start == res2.start
         assert res1.end == res2.end
         assert res1.entity_type == res2.entity_type
-        assert res1.score == res2.score    # The original analyzer object's values should not be modified by the anonymizer
+        assert res1.score == res2.score
 
     engine = AnonymizerEngine()
     text = "Jane Doe is a person"
@@ -254,8 +254,11 @@ def test_given_analyzer_result_then_it_is_not_modified_inplace():
         text,
         original_analyzer_results
     )
+    # Compare length of the lists first and then values of contained objects
     assert len(original_analyzer_results) == len(copy_analyzer_results)
-    for original_result, copy_result in zip(original_analyzer_results, copy_analyzer_results):
+    for original_result, copy_result in zip(
+        original_analyzer_results, copy_analyzer_results
+    ):
         assert_analyzer_results_eq(original_result, copy_result)
 
 


### PR DESCRIPTION
## Change Description

- Sort the input `List[RecognizerResult]` object by `RecognizerResult.start` and `RecognizerResult.end`
- Without this, for unsorted input, the expected merging of two entities of the same type separated by whitespace will not occur
- Ideally I think the analyzer should also have this check, and always return results sorted by start and end

## Issue reference

- This PR fixes the main issue described in #1573

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
