### PR TITLE
Update analyzer_engine_provider.md

### DIFF
--- a/docs/analyzer/analyzer_engine_provider.md
+++ b/docs/analyzer/analyzer_engine_provider.md
@@ -133,7 +133,7 @@ from presidio_analyzer import AnalyzerEngine, AnalyzerEngineProvider
 
 provider = AnalyzerEngineProvider().create_engine()
 
-results = analyzer.analyze(text="My name is Morris", language="en")
+results = provider.analyze(text="My name is Morris", language="en")
 print(results)
 ```
 


### PR DESCRIPTION
## Change Description

In the doc: https://microsoft.github.io/presidio/analyzer/analyzer_engine_provider/
Inside the sub-heading: "Using the default configuration"
In the sample code, referring "analyzer" is not correct. It needs to be replaced with "provider".  

## Issue reference

This PR fixes issue #XX

## Checklist

- [ ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
