### PR TITLE
Fixing checkov CKV_DOCKER_2 error

### DIFF
--- a/docs/samples/python/streamlit/Dockerfile
+++ b/docs/samples/python/streamlit/Dockerfile
@@ -27,6 +27,6 @@ WORKDIR $HOME/app
 
 COPY --chown=user . $HOME/app
 
-HEALTHCHECK CMD curl --fail http://localhost:7860/_stcore/health
+HEALTHCHECK CMD curl --fail http://localhost:7860/_stcore/health || exit 1
 
 CMD python -m streamlit run presidio_streamlit.py --server.port=7860 --server.address=0.0.0.0

--- a/presidio-analyzer/Dockerfile.dev
+++ b/presidio-analyzer/Dockerfile.dev
@@ -17,4 +17,5 @@ ENV POETRY_EXTRAS=${POETRY_EXTRAS}
 RUN apt-get update \
   && apt-get install -y build-essential
 
-RUN pip install poetry
+RUN pip install poetry \ 
+&& pip install -U checkov

--- a/presidio-anonymizer/Dockerfile.dev
+++ b/presidio-anonymizer/Dockerfile.dev
@@ -4,4 +4,5 @@ FROM python:3.12-slim
 RUN apt-get update \
   && apt-get install -y build-essential
 
-RUN pip install poetry
+RUN pip install poetry \ 
+&& pip install -U checkov

--- a/presidio-image-redactor/Dockerfile.dev
+++ b/presidio-image-redactor/Dockerfile.dev
@@ -13,4 +13,6 @@ RUN apt-get update \
 RUN apt-get update  \
 && apt-get install ffmpeg libsm6 libxext6  -y
 
-RUN pip install poetry
+RUN pip install poetry \ 
+&& pip install -U checkov
+


### PR DESCRIPTION
Fixing error: "Ensure that HEALTHCHECK instructions have been added to container images"

## Change Description

1. Add || exit 1 to ensure a proper non-zero exit code on failure.
2. Add Checkov run inside the container.
## Issue reference

This PR fixes issue #XX
Ensure that HEALTHCHECK instructions have been added to container images

## Checklist

- [ ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
