### PR TITLE
Fix Typos in Documentation and Test Descriptions

### DIFF
--- a/docs/samples/python/transformers_recognizer/index.md
+++ b/docs/samples/python/transformers_recognizer/index.md
@@ -16,7 +16,7 @@ When initializing the `TransformersRecognizer`, choose from the following option
 3. Provide the path to your own local custom trained model.
 
 !!! note "Note"
-    For each combination of model & dataset, it is recommended to create a configuration object which includes setting necessary parameters for getting the correct results. Please reference this [configuraion.py](https://github.cim/microsoft/presidio/blob/miN/configuration.py) file for examples.
+    For each combination of model & dataset, it is recommended to create a configuration object which includes setting necessary parameters for getting the correct results. Please reference this [configuration.py](https://github.cim/microsoft/presidio/blob/miN/configuration.py) file for examples.
 
 ## Example Code
 

--- a/docs/samples/python/transformers_recognizer/index.md
+++ b/docs/samples/python/transformers_recognizer/index.md
@@ -16,7 +16,7 @@ When initializing the `TransformersRecognizer`, choose from the following option
 3. Provide the path to your own local custom trained model.
 
 !!! note "Note"
-    For each combination of model & dataset, it is recommended to create a configuration object which includes setting necessary parameters for getting the correct results. Please reference this [configuration.py](https://github.cim/microsoft/presidio/blob/miN/configuration.py) file for examples.
+    For each combination of model & dataset, it is recommended to create a configuration object which includes setting necessary parameters for getting the correct results. Please reference this [configuration.py](https://github.com/microsoft/presidio/blob/main/configuration.py) file for examples.
 
 ## Example Code
 

--- a/presidio-analyzer/tests/test_context_support.py
+++ b/presidio-analyzer/tests/test_context_support.py
@@ -133,7 +133,7 @@ def test_when_text_with_only_additional_context_lemma_based_context_enhancer_the
 ):
     """This test checks that LemmaContextAwareEnhancer uses supportive context
     word from analyze input as if it was in the text itself but no other words apear
-    in text to support context enhancment.
+    in text to support context enhancement.
 
     when passing a word which doesn't apear in the text but is defined as context in
     the recognizer which recongnized this the recognized entity and there's no other


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in the documentation and test files:
- Fixed a typo in the link reference from [configuruaion.py] to [configuration.py] in the Transformers Recognizer documentation.
- Corrected the spelling of "enhancement" in the context support test docstring.

These changes improve clarity and maintain consistency in the codebase documentation and comments. No functional code changes are included.