### PR TITLE
Fix Typos in Docstrings and Comments

### DIFF
--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizers_loader_utils.py
@@ -261,7 +261,7 @@ class RecognizerListLoader:
 
 
 class RecognizerConfigurationLoader:
-    """A utility class that initializes recognizer registry configuraton."""
+    """A utility class that initializes recognizer registry configuration."""
 
     mandatory_keys = [
         "supported_languages",

--- a/presidio-analyzer/tests/test_context_support.py
+++ b/presidio-analyzer/tests/test_context_support.py
@@ -99,7 +99,7 @@ def test_when_text_with_aditional_context_lemma_based_context_enhancer_then_anal
     word from analyze input as if it was in the text itself.
 
     when passing a word which doesn't apear in the text but is defined as context in
-    the recognizer which recongnized this the recognized entity, the enhancer should
+    the recognizer which recognized this the recognized entity, the enhancer should
     return that word as supportive_context_word instead of other recognizer context word
     """
     text = "John Smith license is AC432223"


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in the codebase. Specifically, it fixes the spelling of "configuration" in a docstring within `recognizers_loader_utils.py` and changes "recognized" to "recognized" in a comment within `test_context_support.py`. These changes improve code readability and maintain consistency in documentation and comments. No functional code changes are included.