### PR TITLE
 📝 Fix typos in documentation and code comments

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -11,7 +11,7 @@ Steps:
    ```
    Note that these might take some time to build for the first time.
    
-3. Install the e2e-tests framework, preferrably in a virtual environment:
+3. Install the e2e-tests framework, preferably in a virtual environment:
    ```sh
    pip install -r requirements.txt
    ```

--- a/presidio-analyzer/presidio_analyzer/context_aware_enhancers/lemma_context_aware_enhancer.py
+++ b/presidio-analyzer/presidio_analyzer/context_aware_enhancers/lemma_context_aware_enhancer.py
@@ -249,7 +249,7 @@ class LemmaContextAwareEnhancer(ContextAwareEnhancer):
     ) -> int:
         found = False
         # we use the known start index of the original word to find the actual
-        # token at that index, we are not checking for equivilance since the
+        # token at that index, we are not checking for equivalence since the
         # token might be just a substring of that word (e.g. for phone number
         # 555-124564 the first token might be just '555' or for a match like '
         # rocket' the actual token will just be 'rocket' hence the misalignment

--- a/presidio-analyzer/presidio_analyzer/entity_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/entity_recognizer.py
@@ -22,7 +22,7 @@ class EntityRecognizer:
     :param supported_entities: the entities supported by this recognizer
     (for example, phone number, address, etc.)
     :param supported_language: the language supported by this recognizer.
-    The supported langauge code is iso6391Name
+    The supported language code is iso6391Name
     :param name: the name of this recognizer (optional)
     :param version: the recognizer current version
     :param context: a list of words which can help boost confidence score

--- a/presidio-analyzer/tests/test_context_support.py
+++ b/presidio-analyzer/tests/test_context_support.py
@@ -136,7 +136,7 @@ def test_when_text_with_only_additional_context_lemma_based_context_enhancer_the
     in text to support context enhancement.
 
     when passing a word which doesn't appear in the text but is defined as context in
-    the recognizer which recongnized this the recognized entity and there's no other
+    the recognizer which recognized this the recognized entity and there's no other
     word in the text tp support context, the enhancer should
     return that word as supportive_context_word and raise the score.
     """


### PR DESCRIPTION

### Description
🔍 Fixed several spelling mistakes across the codebase:
- `equivilance` → `equivalence`
- `langauge` → `language` 
- `recongnized` → `recognized`
- `preferrably` → `preferably`

