### PR TITLE
Fix: Correct typos in documentation

### DIFF
--- a/presidio-cli/README.md
+++ b/presidio-cli/README.md
@@ -8,7 +8,7 @@
 
 CLI tool that analyzes text for PII Entities using Presidio Analyzer.
 
-## Prerequisities
+## Prerequisites
 
 `Python` version: 3.9, 3.10, 3.11
 

--- a/presidio-image-redactor/README.md
+++ b/presidio-image-redactor/README.md
@@ -155,7 +155,7 @@ See the example notebook for more details and visual confirmation of the output:
 
 ### Side note for Windows
 
-If you are using a Windows machine, you may run into issues if file paths are too long. Unfortunatley, this is not rare when working with DICOM images that are often nested in directories with descriptive names.
+If you are using a Windows machine, you may run into issues if file paths are too long. Unfortunately, this is not rare when working with DICOM images that are often nested in directories with descriptive names.
 
 To avoid errors where the code may not recognize a path as existing due to the length of the characters in the file path, please [enable long paths on your system](https://learn.microsoft.com/en-us/answers/questions/293227/longpathsenabled.html).
 


### PR DESCRIPTION


**Description:**

This pull request addresses two minor typographical errors in the project's documentation.

- Corrected "Prerequisities" to "Prerequisites" in `presidio-cli/README.md`.
- Corrected "Unfortunatley" to "Unfortunately" in `presidio-image-redactor/README.md`.
