### PR TITLE
Fix for 1641: Load StanzaRecognizer if StanzaNlpEngine is configured

### DIFF
--- a/presidio-analyzer/Dockerfile.stanza
+++ b/presidio-analyzer/Dockerfile.stanza
@@ -1,0 +1,37 @@
+FROM python:3.12-slim
+
+ARG NAME
+ARG NLP_CONF_FILE=presidio_analyzer/conf/default.yaml
+ARG ANALYZER_CONF_FILE=presidio_analyzer/conf/default_analyzer.yaml
+ARG RECOGNIZER_REGISTRY_CONF_FILE=presidio_analyzer/conf/default_recognizers.yaml
+ENV PIP_NO_CACHE_DIR=1
+
+ENV ANALYZER_CONF_FILE=${ANALYZER_CONF_FILE}
+ENV RECOGNIZER_REGISTRY_CONF_FILE=${RECOGNIZER_REGISTRY_CONF_FILE}
+ENV NLP_CONF_FILE=${NLP_CONF_FILE}
+
+ENV PORT=3000
+ENV WORKERS=1
+
+COPY ${ANALYZER_CONF_FILE} /usr/bin/${NAME}/${ANALYZER_CONF_FILE}
+COPY ${RECOGNIZER_REGISTRY_CONF_FILE} /usr/bin/${NAME}/${RECOGNIZER_REGISTRY_CONF_FILE}
+COPY ${NLP_CONF_FILE} /usr/bin/${NAME}/${NLP_CONF_FILE}
+
+WORKDIR /usr/bin/${NAME}
+
+# Install essential build tools
+RUN apt-get update \
+  && apt-get install -y build-essential
+
+COPY ./pyproject.toml /usr/bin/${NAME}/
+COPY ./README.md /usr/bin/${NAME}/
+
+RUN pip install poetry && poetry install --no-root --only=main -E server -E stanza
+# install nlp models specified in NLP_CONF_FILE
+COPY ./install_nlp_models.py /usr/bin/${NAME}/
+
+RUN poetry run python install_nlp_models.py --conf_file ${NLP_CONF_FILE}
+
+COPY . /usr/bin/${NAME}/
+EXPOSE ${PORT}
+CMD poetry run gunicorn -w $WORKERS -b 0.0.0.0:$PORT 'app:create_app()'

--- a/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizer_registry_provider.py
+++ b/presidio-analyzer/presidio_analyzer/recognizer_registry/recognizer_registry_provider.py
@@ -146,15 +146,18 @@ class RecognizerRegistryProvider:
                 f"NLP recognizer (e.g. SpacyRecognizer, StanzaRecognizer) "
                 f"is not in the list of recognizers "
                 f"for language {language}. "
-                f"Adding the default {SpacyRecognizer.__name__} to the list."
+                f"Adding the default recognizer to the list."
                 f"If you wish to remove the NLP recognizer, "
                 f"define it as `enabled=false`."
             )
             logger.warning(warning_text)
             warnings.warn(warning_text)
             if nlp_engine:
+                nlp_recognizer_cls = RecognizerRegistry.get_nlp_recognizer(
+                    nlp_engine=nlp_engine
+                )
                 recognizers.append(
-                    SpacyRecognizer(
+                    nlp_recognizer_cls(
                         supported_language=language,
                         supported_entities=nlp_engine.get_supported_entities(),
                     )

--- a/presidio-analyzer/tests/conf/test_stanza_without_recognizer.yaml
+++ b/presidio-analyzer/tests/conf/test_stanza_without_recognizer.yaml
@@ -1,0 +1,23 @@
+recognizer_registry:
+  global_regex_flags: 26
+  recognizers: 
+    - name: CreditCardRecognizer
+      supported_languages: 
+      - en
+      type: predefined
+
+
+supported_languages: 
+  - es
+  - en
+default_score_threshold: 0.7
+
+nlp_configuration:
+  nlp_engine_name: stanza
+  models:
+    -
+      lang_code: en
+      model_name: en
+    -
+      lang_code: es
+      model_name: es

--- a/presidio-analyzer/tests/test_analyzer_engine_provider.py
+++ b/presidio-analyzer/tests/test_analyzer_engine_provider.py
@@ -2,14 +2,18 @@ import re
 from pathlib import Path
 from typing import List
 
-import pytest
-
 from presidio_analyzer import AnalyzerEngineProvider, RecognizerResult
 from presidio_analyzer.nlp_engine import SpacyNlpEngine, NlpArtifacts
 
-from presidio_analyzer.predefined_recognizers import AzureAILanguageRecognizer, CreditCardRecognizer, SpacyRecognizer
+from presidio_analyzer.predefined_recognizers import (
+    AzureAILanguageRecognizer,
+    CreditCardRecognizer,
+    SpacyRecognizer,
+    StanzaRecognizer,
+)
 
 import pytest
+
 
 def get_full_paths(analyzer_yaml, nlp_engine_yaml=None, recognizer_registry_yaml=None):
     this_path = Path(__file__).parent.absolute()
@@ -157,7 +161,10 @@ def test_analyzer_engine_provider_with_files_per_provider():
     assert len(recognizer_registry.recognizers) == 6
     assert recognizer_registry.supported_languages == ["en", "es"]
 
-@pytest.mark.skipif(pytest.importorskip("azure"), reason="Optional dependency not installed") # noqa: E501
+
+@pytest.mark.skipif(
+    pytest.importorskip("azure"), reason="Optional dependency not installed"
+)  # noqa: E501
 def test_analyzer_engine_provider_with_azure_ai_language():
     analyzer_yaml, _, _ = get_full_paths(
         "conf/test_azure_ai_language_reco.yaml",
@@ -212,9 +219,12 @@ def test_analyzer_engine_provider_no_nlp_recognizer_is_added():
     analyzer_engine = provider.create_engine()
 
     assert len(analyzer_engine.get_recognizers()) == 2
-    nlp_recognizer = [rec for rec in analyzer_engine.get_recognizers() if isinstance(rec, SpacyRecognizer)]
+    nlp_recognizer = [
+        rec
+        for rec in analyzer_engine.get_recognizers()
+        if isinstance(rec, SpacyRecognizer)
+    ]
     assert len(nlp_recognizer) == 1
-
 
 
 def test_analyzer_engine_provider_no_nlp_recognizer_is_added_per_language():
@@ -226,8 +236,12 @@ def test_analyzer_engine_provider_no_nlp_recognizer_is_added_per_language():
     analyzer_engine = provider.create_engine()
 
     assert len(analyzer_engine.get_recognizers()) == 4 # Two CreditCardRecognizers and two SpacyRecognizers
-    nlp_recognizers = [rec for rec in analyzer_engine.get_recognizers() if isinstance(rec, SpacyRecognizer)]
-    assert len(nlp_recognizers) == 2 # one per language
+    nlp_recognizers = [
+        rec
+        for rec in analyzer_engine.get_recognizers()
+        if isinstance(rec, SpacyRecognizer)
+    ]
+    assert len(nlp_recognizers) == 2  # one per language
     assert set([rec.supported_language for rec in nlp_recognizers]) == {"en", "es"}
 
 
@@ -240,15 +254,19 @@ def test_analyzer_engine_provider_mismatch_between_nlp_engine_and_nlp_recognizer
         provider = AnalyzerEngineProvider(analyzer_engine_conf_file=analyzer_yaml)
         analyzer_engine = provider.create_engine()
 
+
 def test_analyzer_engine_provider_multiple_nlp_recognizers_raises_exception():
     analyzer_yaml, _, _ = get_full_paths(
         "conf/test_multiple_nlp_recognizers.yaml",
     )
 
-    with pytest.raises(ValueError, match = f"Multiple NLP recognizers for language en found in the configuration. "
+    with pytest.raises(
+        ValueError,
+        match=f"Multiple NLP recognizers for language en found in the configuration. "
                 f"Please remove the duplicates."):
         provider = AnalyzerEngineProvider(analyzer_engine_conf_file=analyzer_yaml)
         analyzer_engine = provider.create_engine()
+
 
 def test_analyzer_engine_provider_no_nlp_engine_or_provider_results_in_default_nlp_recognizer():
     analyzer_yaml, _, _ = get_full_paths(
@@ -259,5 +277,34 @@ def test_analyzer_engine_provider_no_nlp_engine_or_provider_results_in_default_n
     analyzer_engine = provider.create_engine()
 
     assert len(analyzer_engine.get_recognizers()) == 2 # SpacyRecognizer, CreditCardRecognizer
-    nlp_recognizer = [rec for rec in analyzer_engine.get_recognizers() if isinstance(rec, SpacyRecognizer)]
+    nlp_recognizer = [
+        rec
+        for rec in analyzer_engine.get_recognizers()
+        if isinstance(rec, SpacyRecognizer)
+    ]
     assert len(nlp_recognizer) == 1
+
+
+@pytest.mark.skip_engine("stanza_en")
+def test_analyzer_engine_stanza_without_recognizer_creates_recognizer():
+    analyzer_yaml, _, _ = get_full_paths(
+        "conf/test_stanza_without_recognizer.yaml",
+    )
+    provider = AnalyzerEngineProvider(analyzer_engine_conf_file=analyzer_yaml)
+
+    analyzer_engine = provider.create_engine()
+
+    assert (
+        len(analyzer_engine.get_recognizers()) == 3
+    )  # StanzaRecognizer en, StanzaRecognizer es, CreditCardRecognizer
+    nlp_recognizers = [
+        rec
+        for rec in analyzer_engine.get_recognizers()
+        if isinstance(rec, StanzaRecognizer)
+    ]
+    assert len(nlp_recognizers) == 2
+    supported_languages = {
+        nlp_recognizers[0].supported_language,
+        nlp_recognizers[1].supported_language,
+    }
+    assert supported_languages == {"en", "es"}


### PR DESCRIPTION
## Change Description

Allowing stanza to load even if not in the recognizer registry list, if the nlp engine is stanza, instead of the default spacy recognizer
## Issue reference

This PR fixes issue #1641

## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [X] I have signed the CLA (if required)
- [X] My code includes unit tests
- [X] All unit tests and lint checks pass locally
- [X] My PR contains documentation updates / additions if required
