### PR TITLE
Version 2.2.359

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -48,7 +48,7 @@ jobs:
       env:
         GDN_CHECKOV_SKIPPATH: 'docs/'
       with:
-        tools: bandit, binskim, checkov, eslint, templateanalyzer, terrascan, trivy
+        tools: bandit, checkov, templateanalyzer, terrascan, trivy
 
     - name: Upload results to Security tab
       uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -48,7 +48,7 @@ jobs:
       env:
         GDN_CHECKOV_SKIPPATH: 'docs/'
       with:
-        tools: 'bandit,binskim,checkov,eslint,templateanalyzer,terrascan,trivy,container-mapping'
+        tools: bandit, binskim, checkov, eslint, templateanalyzer, terrascan, trivy, container-mapping'
 
     - name: Upload results to Security tab
       uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -48,6 +48,7 @@ jobs:
       env:
         GDN_CHECKOV_SKIPPATH: 'docs/'
         GDN_ANTIMALWARE_SIGNATUREUPDATEFAILURELOGGERLEVEL: 'Warning'
+        GDN_ANTIMALWARE_SIGNATUREUPDATEUSESMMPC: true
 
     - name: Upload results to Security tab
       uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -48,7 +48,7 @@ jobs:
       env:
         GDN_CHECKOV_SKIPPATH: 'docs/'
       with:
-        tools: bandit, binskim, checkov, eslint, templateanalyzer, terrascan, trivy, container-mapping'
+        tools: bandit, binskim, checkov, eslint, templateanalyzer, terrascan, trivy, container-mapping
 
     - name: Upload results to Security tab
       uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -47,7 +47,8 @@ jobs:
       id: msdo
       env:
         GDN_CHECKOV_SKIPPATH: 'docs/'
-      
+        GDN_ANTIMALWARE_SIGNATUREUPDATEFAILURELOGGERLEVEL: 'Warning'
+
     - name: Upload results to Security tab
       uses: github/codeql-action/upload-sarif@v3
       with:

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -48,7 +48,7 @@ jobs:
       env:
         GDN_CHECKOV_SKIPPATH: 'docs/'
       with:
-        tools: bandit, binskim, checkov, eslint, templateanalyzer, terrascan, trivy, container-mapping
+        tools: bandit, binskim, checkov, eslint, templateanalyzer, terrascan, trivy
 
     - name: Upload results to Security tab
       uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -47,8 +47,8 @@ jobs:
       id: msdo
       env:
         GDN_CHECKOV_SKIPPATH: 'docs/'
-        GDN_ANTIMALWARE_SIGNATUREUPDATEFAILURELOGGERLEVEL: 'Warning'
-        GDN_ANTIMALWARE_SIGNATUREUPDATEUSESMMPC: true
+      with:
+        tools: 'bandit,binskim,checkov,eslint,templateanalyzer,terrascan,trivy,container-mapping'
 
     - name: Upload results to Security tab
       uses: github/codeql-action/upload-sarif@v3

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -100,7 +100,7 @@ Pseudonymization is a de-identification technique in which the real data is repl
 
 ### Does Presidio work on structured/tabular data?
 
-[Presidio-structured](https://microsoft.github.io/presidio/structured/) is a new capability in Presidio for detecting PII entities in structured/semi-structured data, and is still in alpha. If you have a question, suggestion, or a contribution in this area, please reach out by opening an issue, starting a discussion or reaching us directly at <presidio@microsoft.com>
+[Presidio-structured](https://microsoft.github.io/presidio/structured/) is a capability in Presidio for detecting PII entities in structured/semi-structured data. It scans datasets for PII using Presidio Analyzer, and supports the redaction of text, cells, or columns in a tabular dataset.
 
 ## Improving detection accuracy
 

--- a/docs/structured/index.md
+++ b/docs/structured/index.md
@@ -1,10 +1,5 @@
 # Presidio structured
 
-## Status
-
-!!! warning "Warning"
-    **Alpha**: This package is currently in alpha, meaning it is in its early stages of development. Features and functionality may change as the project evolves.
-
 ## Description
 
 The Presidio structured package is a flexible and customizable framework designed to identify and protect structured sensitive data.

--- a/presidio-analyzer/pyproject.toml
+++ b/presidio-analyzer/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["poetry-core"]
 
 [project]
 name = "presidio_analyzer"
-version = "2.2.358"
+version = "2.2.359"
 description = "Presidio Analyzer package"
 authors = [{name = "Presidio", email = "presidio@microsoft.com"}]
 license = "MIT"

--- a/presidio-anonymizer/pyproject.toml
+++ b/presidio-anonymizer/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["poetry-core"]
 
 [project]
 name = "presidio_anonymizer"
-version = "2.2.358"
+version = "2.2.359"
 description = "Presidio Anonymizer package - replaces analyzed text with desired values."
 authors = [{name = "Presidio", email = "presidio@microsoft.com"}]
 license = "MIT"

--- a/presidio-image-redactor/README.md
+++ b/presidio-image-redactor/README.md
@@ -1,7 +1,5 @@
 # Presidio Image Redactor
 
-***Please notice, this package is still in alpha and not production ready.***
-
 ## Description
 
 The Presidio Image Redactor is a Python based module for detecting and redacting PII text entities in images.

--- a/presidio-image-redactor/pyproject.toml
+++ b/presidio-image-redactor/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 keywords = ["presidio_image_redactor"]
 urls = {Homepage = "https://github.com/Microsoft/presidio"}
 readme = "README.md"
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.9,<3.14"
 
 dependencies = [
     "pillow (>=9.0)",
@@ -31,7 +31,7 @@ dependencies = [
     "azure-ai-formrecognizer (>=3.3.0,<4.0.0)",
     "opencv-python (>=4.0.0,<5.0.0)",
     "python-gdcm (>=3.0.24.1)",
-    "spacy <3.8.4 ; python_version<'3.10'", #Remove once 3.9 is EOL
+    "spacy <3.8.4 ; python_version == '3.9'", #Remove once 3.9 is EOL
     "spacy >=3.8.7,<4.0.0 ; python_version >= '3.13'"
 ]
 

--- a/presidio-image-redactor/pyproject.toml
+++ b/presidio-image-redactor/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "azure-ai-formrecognizer (>=3.3.0,<4.0.0)",
     "opencv-python (>=4.0.0,<5.0.0)",
     "python-gdcm (>=3.0.24.1)",
-    "spacy (<3.8.4) ; python_version<'3.10'" #Remove once 3.9 is EOL
+    "spacy <3.8.4 ; python_version<'3.10'", #Remove once 3.9 is EOL
+    "spacy >=3.8.7,<4.0.0 ; python_version >= '3.13'"
 ]
 
 [project.optional-dependencies]

--- a/presidio-image-redactor/pyproject.toml
+++ b/presidio-image-redactor/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["poetry-core"]
 
 [project]
 name = "presidio-image-redactor"
-version = "0.0.56"
+version = "0.0.57"
 description = "Presidio image redactor package"
 authors = [{name = "Presidio", email = "presidio@microsoft.com"}]
 license = "MIT"

--- a/presidio-image-redactor/pyproject.toml
+++ b/presidio-image-redactor/pyproject.toml
@@ -31,8 +31,8 @@ dependencies = [
     "azure-ai-formrecognizer (>=3.3.0,<4.0.0)",
     "opencv-python (>=4.0.0,<5.0.0)",
     "python-gdcm (>=3.0.24.1)",
-    "spacy (<3.8.4) ; python_version<'3.10'" #Remove once 3.9 is EOL
-]
+    "spacy <3.8.4 ; python_version == '3.9'", #Remove once 3.9 is EOL
+    "spacy >=3.8.7,<4.0.0 ; python_version >= '3.13'"]
 
 [project.optional-dependencies]
 server = [

--- a/presidio-image-redactor/pyproject.toml
+++ b/presidio-image-redactor/pyproject.toml
@@ -31,8 +31,7 @@ dependencies = [
     "azure-ai-formrecognizer (>=3.3.0,<4.0.0)",
     "opencv-python (>=4.0.0,<5.0.0)",
     "python-gdcm (>=3.0.24.1)",
-    "spacy <3.8.4 ; python_version == '3.9'", #Remove once 3.9 is EOL
-    "spacy >=3.8.7,<4.0.0 ; python_version >= '3.13'"
+    "spacy (<3.8.4) ; python_version<'3.10'" #Remove once 3.9 is EOL
 ]
 
 [project.optional-dependencies]

--- a/presidio-structured/README.md
+++ b/presidio-structured/README.md
@@ -1,9 +1,5 @@
 # Presidio structured
 
-## Status
-
-**Alpha**: This package is currently in alpha, meaning it is in its early stages of development. Features and functionality may change as the project evolves.
-
 ## Description
 
 The Presidio structured package is a flexible and customizable framework designed to identify and protect structured sensitive data. This tool extends the capabilities of Presidio, focusing on structured data formats such as tabular formats and semi-structured formats (JSON). It leverages the detection capabilities of Presidio-Analyzer to identify columns or keys containing personally identifiable information (PII), and establishes a mapping between these column/keys names and the detected PII entities. Following the detection, Presidio-Anonymizer is used to apply de-identification techniques to each value in columns identified as containing PII, ensuring the sensitive data is appropriately protected.

--- a/presidio-structured/pyproject.toml
+++ b/presidio-structured/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["poetry-core"]
 
 [project]
 name = "presidio_structured"
-version = "0.0.6-alpha"
+version = "0.0.6"
 description = "Presidio structured package - analyzes and anonymizes structured and semi-structured data."
 authors = [{name = "Presidio", email = "presidio@microsoft.com"}]
 license = "MIT"

--- a/presidio-structured/pyproject.toml
+++ b/presidio-structured/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["poetry-core"]
 
 [project]
 name = "presidio_structured"
-version = "0.0.5-alpha"
+version = "0.0.6-alpha"
 description = "Presidio structured package - analyzes and anonymizes structured and semi-structured data."
 authors = [{name = "Presidio", email = "presidio@microsoft.com"}]
 license = "MIT"


### PR DESCRIPTION
## Version 2.2.359 - July 2025
This version includes periodic bug fixes and enhancements. For the full changelog: [CHANGELOG](https://github.com/microsoft/presidio/blob/main/CHANGELOG.md#22359---2025-07-06)


### Changes in Presidio's behavior
One notable change in behavior is how country-specific recognizers are loaded (PR #1586):

Most country specific recognizers that expect English were put as optional to avoid false positives, and would not work out-of-the-box. Specifically:
    - SgFinRecognizer
    - AuAbnRecognizer
    - AuAcnRecognizer
    - AuTfnRecognizer
    - AuMedicareRecognizer
    - InPanRecognizer
    - InAadhaarRecognizer
    - InVehicleRegistrationRecognizer
    - InPassportRecognizer
    - EsNifRecognizer
    - InVoterRecognizer

  To re-enable them, either change the [default YAML](https://github.com/microsoft/presidio/blob/main/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml) to have them as `enabled: true`, or via code, add them to the recognizer registry manually.
    - Yaml based: see more here: [YAML based configuration](https://microsoft.github.io/presidio/analyzer/analyzer_engine_provider/).
    - Code based:
      
```py
from presidio_analyzer import AnalyzerEngine
from presidio_analyzer.predefined_recognizers import AuAbnRecognizer

# Initialize an analyzer engine with the recognizer registry
analyzer = AnalyzerEngine()

# Create an instance of the AuAbnRecognizer
au_abn_recognizer = AuAbnRecognizer()


# Add the recognizer to the registry
analyzer.registry.add_recognizer(au_abn_recognizer)
```