### PR TITLE
Added Korean Resident Registration Number (RRN) recognizer (KrRrnRecognizer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -635,3 +635,4 @@ New endpoint for deanonymizing encrypted entities by the anonymizer.
 ### Fixed
 - Fixed an issue where the CreditCardRecognizer regex could incorrectly identify 13-digit Unix timestamps as credit card numbers. Validated that 13 digit numbers that start with `1` and have no separators (e.g. `1748503543012`) are not flagged as credit cards.
 - Enhance NlpEngineProvider with validation methods for NLP engines, configuration, and conf file path.
+- Added Korean Resident Registration Number (RRN) recognizer (KrRrnRecognizer).

--- a/docs/supported_entities.md
+++ b/docs/supported_entities.md
@@ -95,6 +95,11 @@ For more information, refer to the [adding new recognizers documentation](analyz
 |------------|---------------------------------------------------------------------------------------------------------|------------------------------------------|
 | FI_PERSONAL_IDENTITY_CODE     | The Finnish Personal Identity Code (Henkilötunnus) is a unique 11 character individual identity number. | Pattern match, context and custom logic. |
 
+### Korea
+| FieldType  | Description                                                                                             | Detection Method                         |
+|------------|---------------------------------------------------------------------------------------------------------|------------------------------------------|
+| KR_RRN     | The Korean Resident Registration Number (RRN) is a 13-digit number issued to all Korean residents. | Pattern match, context and custom logic. |
+
 ## Adding a custom PII entity
 
 See [this documentation](analyzer/adding_recognizers.md) for instructions on how to add a new Recognizer for a new type of PII entity.

--- a/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
+++ b/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
@@ -153,6 +153,12 @@ recognizers:
     - pl
     type: predefined
 
+  - name: KrRrnRecognizer
+    supported_languages: 
+    - kr
+    type: predefined
+    enabled: false
+
   - name: CryptoRecognizer
     type: predefined
 

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
@@ -34,6 +34,9 @@ from .country_specific.italy.it_identity_card_recognizer import ItIdentityCardRe
 from .country_specific.italy.it_passport_recognizer import ItPassportRecognizer
 from .country_specific.italy.it_vat_code import ItVatCodeRecognizer
 
+# Korea recognizers
+from .country_specific.korea.kr_rrn_recognizer import KrRrnRecognizer
+
 # Poland recognizers
 from .country_specific.poland.pl_pesel_recognizer import PlPeselRecognizer
 
@@ -142,4 +145,5 @@ __all__ = [
     "EsNieRecognizer",
     "UkNinoRecognizer",
     "AzureHealthDeidRecognizer",
+    "KrRrnRecognizer",
 ]

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/korea/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/korea/__init__.py
@@ -1,0 +1,7 @@
+"""Korea-specific recognizers."""
+
+from .kr_rrn_recognizer import KrRrnRecognizer
+
+__all__ = [
+    "KrRrnRecognizer",
+]

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/korea/kr_rrn_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/korea/kr_rrn_recognizer.py
@@ -1,0 +1,140 @@
+from typing import List, Optional, Tuple
+
+from presidio_analyzer import EntityRecognizer, Pattern, PatternRecognizer
+
+
+class KrRrnRecognizer(PatternRecognizer):
+    """
+    Recognize Korean Resident Registration Number (RRN).
+
+    The Korean Resident Registration Number (RRN) is
+    a 13-digit number issued to all Korean residents.
+
+    The format is YYMMDD-GHIJKLX where:
+    - YYMMDD represents the birth date
+    - G determines gender and century of birth
+
+    For RRNs issued before October 2020:
+    - HIJKL is a serial number assigned by district
+    - X is a check digit calculated using the preceding 12 digits
+
+    For RRNs issued after October 2020:
+    - HIJKLX is a random number
+
+    Reference: https://en.wikipedia.org/wiki/Resident_registration_number
+
+    :param patterns: List of patterns to be used by this recognizer
+    :param context: List of context words to increase confidence in detection
+    :param supported_language: Language this recognizer supports
+    :param supported_entity: The entity this recognizer can detect
+    :param replacement_pairs: List of tuples with potential replacement values
+    for different strings to be used during pattern matching.
+    This can allow a greater variety in input, for example by removing dashes.
+    """
+
+    PATTERNS = [
+        Pattern(
+            "RRN (Medium)",
+            r"\b\d{2}(0[1-9]|1[0-2])(0[1-9]|[1-2][0-9]|3[0-1])(-?)\d{7}\b",
+            0.5,
+        )
+    ]
+
+    CONTEXT = [
+        "Korean RRN",
+        "Korean Resident Registration Number",
+        "Resident Registration Number",
+        "RRN",
+        "rrn",
+        "rrn#",
+    ]
+
+    def __init__(
+        self,
+        patterns: Optional[List[Pattern]] = None,
+        context: Optional[List[str]] = None,
+        supported_language: str = "kr",
+        supported_entity: str = "KR_RRN",
+        replacement_pairs: Optional[List[Tuple[str, str]]] = None,
+    ):
+        self.replacement_pairs = replacement_pairs if replacement_pairs else [("-", "")]
+
+        patterns = patterns if patterns else self.PATTERNS
+        context = context if context else self.CONTEXT
+        super().__init__(
+            supported_entity=supported_entity,
+            patterns=patterns,
+            context=context,
+            supported_language=supported_language,
+        )
+
+    def validate_result(self, pattern_text: str) -> bool | None:
+        """
+        Validate the pattern logic e.g., by running checksum on a detected pattern.
+
+        This validation is only for RRNs issued before October 2020.
+        Therefore, it returns None, not False, at the end of the method.
+
+        :param pattern_text: the text to validated.
+        Only the part in text that was detected by the regex engine
+        :return: A bool or None, indicating whether the validation was successful.
+        """
+        # Pre-processing before validation checks
+        sanitized_value = EntityRecognizer.sanitize_value(
+            pattern_text, self.replacement_pairs
+        )
+
+        # Check if the sanitized value has the correct length (13 digits)
+        if len(sanitized_value) != 13:
+            return False
+
+        # Check if all characters are digits
+        if not sanitized_value.isdigit():
+            return False
+
+        # Validate region code (HI) and checksum (X)
+        region_code = int(sanitized_value[7:9])  # HI
+        if self._validate_region_code(region_code) and self._validate_checksum(
+            sanitized_value
+        ):
+            return True
+
+        return None
+
+    def _validate_region_code(self, region_code: int) -> bool:
+        """
+        Validate the region code of Korean RRN.
+
+        :param region_code: The region code to validate
+        :return: True if region code is valid, False otherwise
+        """
+        return True if 0 <= region_code <= 95 else False
+
+    def _validate_checksum(self, rrn: str) -> bool:
+        """
+        Validate the checksum of Korean RRN.
+
+        The checksum is calculated using the preceding 12 digits.
+        X = (11 - (2A+3B+4C+5D+6E+7F+8G+9H+2I+3J+4K+5L) mod 11) mod 10
+
+        :param rrn: The RRN to validate
+        :return: True if checksum is valid, False otherwise
+        """
+
+        digit_sum = (
+            2 * int(rrn[0])
+            + 3 * int(rrn[1])
+            + 4 * int(rrn[2])
+            + 5 * int(rrn[3])
+            + 6 * int(rrn[4])
+            + 7 * int(rrn[5])
+            + 8 * int(rrn[6])
+            + 9 * int(rrn[7])
+            + 2 * int(rrn[8])
+            + 3 * int(rrn[9])
+            + 4 * int(rrn[10])
+            + 5 * int(rrn[11])
+        )
+        checksum = (11 - (digit_sum % 11)) % 10
+
+        return checksum == int(rrn[12])

--- a/presidio-analyzer/tests/test_kr_rrn_recognizer.py
+++ b/presidio-analyzer/tests/test_kr_rrn_recognizer.py
@@ -1,0 +1,56 @@
+import pytest
+
+from tests import assert_result_within_score_range
+from presidio_analyzer.predefined_recognizers import KrRrnRecognizer
+
+@pytest.fixture(scope="module")
+def recognizer():
+    return KrRrnRecognizer()
+
+@pytest.fixture(scope="module")
+def entities():
+    return ["KR_RRN"]
+
+@pytest.mark.parametrize(
+    "text, expected_len, expected_positions, expected_score_ranges",
+    [
+        # Valid RRNs, but medium match
+        ("960121-1234567", 1, ((0, 14),), ((0.5, 0.5),), ),
+        ("9601211234567", 1, ((0, 13),), ((0.5, 0.5),), ),
+        ("000505-7637892", 1, ((0, 14),), ((0.5, 0.5),), ),
+        ("0005057637892", 1, ((0, 13),), ((0.5, 0.5),), ),
+        ("His Korean RRN is 960121-1234567", 1, ((18, 32),), ((0.5, 0.5),), ),
+        
+        # Valid RRNs, strong match by validate_result()
+        ("960121-1021413", 1, ((0, 14),), ((1.0, 1.0),), ),
+        ("9601211021413", 1, ((0, 13),), ((1.0, 1.0),), ),
+        ("050912-0000008", 1, ((0, 14),), ((1.0, 1.0),), ),
+        ("0509120000008", 1, ((0, 13),), ((1.0, 1.0),), ),
+        ("His RRN is 9601211021413", 1, ((11, 24),), ((1.0, 1.0),), ),
+        
+        # Invalid RRNs 
+        ("001332-1234567", 0, (), (),),
+        ("0013321234567", 0, (), (),),
+        ("960121+1021413", 0, (), (),),
+        ("960121-10214131", 0, (), (),),
+    ],
+)
+def test_when_all_rrns_then_succeed(
+    text,
+    expected_len,
+    expected_positions,
+    expected_score_ranges,
+    recognizer,
+    entities,
+    max_score,
+):
+    results = recognizer.analyze(text, entities)
+    assert len(results) == expected_len
+    for res, (st_pos, fn_pos), (st_score, fn_score) in zip(
+        results, expected_positions, expected_score_ranges
+    ):
+        if fn_score == "max":
+            fn_score = max_score
+        assert_result_within_score_range(
+            res, entities[0], st_pos, fn_pos, st_score, fn_score
+        )


### PR DESCRIPTION
## Change Description

- A medium regex pattern with the score of 0.5 was added.
- RRNs issued prior to October 2020 follow certain rules with checksum, so `validate_result` additionally checks those rules.

## Issue reference

This PR fixes issue #XX

## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [X] I have signed the CLA (if required)
- [X] My code includes unit tests
- [X] All unit tests and lint checks pass locally
- [X] My PR contains documentation updates / additions if required
