### PR TITLE
Issue 1632: Update Indian Aadhaar recognizer to include regex for contextual delimiters

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/india/in_aadhaar_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/india/in_aadhaar_recognizer.py
@@ -24,6 +24,7 @@ class InAadhaarRecognizer(PatternRecognizer):
             r"\b[0-9]{12}\b",
             0.01,
         ),
+        Pattern("AADHAR (Very Weak)", r"\b[0-9]{4}[- :][0-9]{4}[- :][0-9]{4}\b", 0.01),
     ]
 
     CONTEXT = [
@@ -40,7 +41,7 @@ class InAadhaarRecognizer(PatternRecognizer):
         supported_language: str = "en",
         supported_entity: str = "IN_AADHAAR",
         replacement_pairs: Optional[List[Tuple[str, str]]] = None,
-    ):
+    ) -> None:
         self.replacement_pairs = (
             replacement_pairs
             if replacement_pairs
@@ -75,7 +76,7 @@ class InAadhaarRecognizer(PatternRecognizer):
         return is_valid_aadhaar
 
     @staticmethod
-    def _is_palindrome(text: str, case_insensitive: bool = False):
+    def _is_palindrome(text: str, case_insensitive: bool = False) -> bool:
         """
         Validate if input text is a true palindrome.
 
@@ -89,7 +90,7 @@ class InAadhaarRecognizer(PatternRecognizer):
         return palindrome_text == palindrome_text[::-1]
 
     @staticmethod
-    def _is_verhoeff_number(input_number: int):
+    def _is_verhoeff_number(input_number: int) -> bool:
         """
         Check if the input number is a true verhoeff number.
 

--- a/presidio-analyzer/tests/test_in_aadhaar_recognizer.py
+++ b/presidio-analyzer/tests/test_in_aadhaar_recognizer.py
@@ -5,12 +5,12 @@ from presidio_analyzer.predefined_recognizers import InAadhaarRecognizer
 
 
 @pytest.fixture(scope="module")
-def recognizer():
+def recognizer() -> InAadhaarRecognizer:
     return InAadhaarRecognizer()
 
 
 @pytest.fixture(scope="module")
-def entities():
+def entities() -> list[str]:
     return ["IN_AADHAAR"]
 
 
@@ -21,6 +21,15 @@ def entities():
         ("123456789012", 0, (0,12), 0),
         ("312345678909", 1, (0, 12), 1),
         ("399876543211", 1, (0, 12), 1),
+        ("1234 5678 9012", 0, (0,14), 0),
+        ("3123 4567 8909", 1, (0, 14), 1),
+        ("3998 7654 3211", 1, (0, 14), 1),
+        ("1234-5678-9012", 0, (0,14), 0),
+        ("3123-4567-8909", 1, (0, 14), 1),
+        ("3998-7654-3211", 1, (0, 14), 1),
+        ("1234:5678:9012", 0, (0,14), 0),
+        ("3123:4567:8909", 1, (0, 14), 1),
+        ("3998:7654:3211", 1, (0, 14), 1),
         ("My Aadhaar number is 400123456787 with a lot of text beyond it", 1, (21,33), 1),
         # fmt: on
     ],
@@ -32,7 +41,7 @@ def test_when_aadhaar_in_text_then_all_aadhaars_found(
     expected_score,
     recognizer,
     entities,
-):
+) -> None:
     results = recognizer.analyze(text, entities)
     print(results)
 
@@ -80,7 +89,7 @@ verhoeff_test_set = [
 ]
 
 @pytest.mark.parametrize("input_number, is_verhoeff", verhoeff_test_set)
-def test_is_verhoeff(input_number, is_verhoeff):
+def test_is_verhoeff(input_number, is_verhoeff) -> None:
     """
     Test to assert verhoeff number validation based on checksum from base class.
 


### PR DESCRIPTION
## Change Description

This PR adds regular expressions for the detection of Aadhaar numbers with common contextual separators along with associated test cases. Separators such as '-', ':' and ' ' have already been defined and used to sanitize values, but the recognizer does not have the appropriate regular expressions to identify Aadhaar numbers using such separators.

## Issue reference

This PR fixes issue https://github.com/microsoft/presidio/issues/1632

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
