### PR TITLE
Revert to python 3.12 in analyzer Dockerfile

### DIFF
--- a/presidio-analyzer/Dockerfile
+++ b/presidio-analyzer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.12-slim
 
 ARG NAME
 ARG NLP_CONF_FILE=presidio_analyzer/conf/default.yaml


### PR DESCRIPTION
## Change Description

Revert python version to 3.12 in Analyzer Dockerfiles 