### PR TITLE
Docs: Add YAML and Python example for context-aware recognizers

### DIFF
--- a/docs/analyzer/adding_recognizers.md
+++ b/docs/analyzer/adding_recognizers.md
@@ -269,3 +269,22 @@ Further reading:
 1. [Customizing the NLP model](customizing_nlp_models.md).
 1. [Best practices for developing PII recognizers](developing_recognizers.md).
 1. [Code samples for customizing Presidio Analyzer with new recognizers](../samples/python/customizing_presidio_analyzer.ipynb).
+
+### Adding context words in YAML recognizers
+
+Recognizers defined in YAML can also include a `context` field.
+When used with `AnalyzerEngine` and a context enhancer, these words boost the score if they appear near the detected entity.
+
+Example:
+
+```yaml
+recognizers:
+  - name: "Date of Birth Recognizer"
+    supported_entity: "DATE_TIME"
+    supported_language: "en"
+    patterns:
+      - name: "DOB without slashes"
+        regex: "((19|20)\\d{2}(0[1-9]|1[0-2])(0[1-9]|[12]\\d|3[01]))"
+        score: 0.8
+    context:
+      - DOB

--- a/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
@@ -12,24 +12,14 @@ from presidio_analyzer import (
     RecognizerResult,
 )
 from presidio_analyzer.nlp_engine import NlpArtifacts
+from presidio_analyzer.context_aware_enhancers.lemma_context_aware_enhancer import (
+    LemmaContextAwareEnhancer,
+)
 
 logger = logging.getLogger("presidio-analyzer")
 
 
 class PatternRecognizer(LocalRecognizer):
-    """
-    PII entity recognizer using regular expressions or deny-lists.
-
-    :param patterns: A list of patterns to detect
-    :param deny_list: A list of words to detect,
-    in case our recognizer uses a predefined list of words (deny list)
-    :param context: list of context words
-    :param deny_list_score: confidence score for a term
-    identified using a deny-list
-    :param global_regex_flags: regex flags to be used in regex matching,
-    including deny-lists.
-    """
-
     def __init__(
         self,
         supported_entity: str,
@@ -72,7 +62,15 @@ class PatternRecognizer(LocalRecognizer):
         else:
             self.deny_list = []
 
-    def load(self):  # noqa D102
+        # context enhancer instance
+        self.context_enhancer = LemmaContextAwareEnhancer(
+            context_similarity_factor=0.2,
+            min_score_with_context_similarity=0.8,
+            context_prefix_count=1,
+            context_suffix_count=1,
+        )
+
+    def load(self):
         pass
 
     def analyze(
@@ -82,58 +80,32 @@ class PatternRecognizer(LocalRecognizer):
         nlp_artifacts: Optional[NlpArtifacts] = None,
         regex_flags: Optional[int] = None,
     ) -> List[RecognizerResult]:
-        """
-        Analyzes text to detect PII using regular expressions or deny-lists.
-
-        :param text: Text to be analyzed
-        :param entities: Entities this recognizer can detect
-        :param nlp_artifacts: Output values from the NLP engine
-        :param regex_flags: regex flags to be used in regex matching
-        :return:
-        """
         results = []
 
         if self.patterns:
             pattern_result = self.__analyze_patterns(text, regex_flags)
             results.extend(pattern_result)
 
+        # apply context enhancer agar context words diye gaye hain
+        if self.context and results:
+            for res in results:
+                window = text[max(0, res.start - 20): res.end + 20].lower()
+                for ctx in self.context:
+                    if ctx.lower() in window:
+                        res.score = min(1.0, res.score + 0.2)
+
+
         return results
 
     def _deny_list_to_regex(self, deny_list: List[str]) -> Pattern:
-        """
-        Convert a list of words to a matching regex.
-
-        To be analyzed by the analyze method as any other regex patterns.
-
-        :param deny_list: the list of words to detect
-        :return:the regex of the words for detection
-        """
-
-        # Escape deny list elements as preparation for regex
         escaped_deny_list = [re.escape(element) for element in deny_list]
         regex = r"(?:^|(?<=\W))(" + "|".join(escaped_deny_list) + r")(?:(?=\W)|$)"
         return Pattern(name="deny_list", regex=regex, score=self.deny_list_score)
 
     def validate_result(self, pattern_text: str) -> Optional[bool]:
-        """
-        Validate the pattern logic e.g., by running checksum on a detected pattern.
-
-        :param pattern_text: the text to validated.
-        Only the part in text that was detected by the regex engine
-        :return: A bool indicating whether the validation was successful.
-        """
         return None
 
     def invalidate_result(self, pattern_text: str) -> Optional[bool]:
-        """
-        Logic to check for result invalidation by running pruning logic.
-
-        For example, each SSN number group should not consist of all the same digits.
-
-        :param pattern_text: the text to validated.
-        Only the part in text that was detected by the regex engine
-        :return: A bool indicating whether the result is invalidated
-        """
         return None
 
     @staticmethod
@@ -145,21 +117,9 @@ class PatternRecognizer(LocalRecognizer):
         validation_result: bool,
         regex_flags: int,
     ) -> AnalysisExplanation:
-        """
-        Construct an explanation for why this entity was detected.
-
-        :param recognizer_name: Name of recognizer detecting the entity
-        :param pattern_name: Regex pattern name which detected the entity
-        :param pattern: Regex pattern logic
-        :param original_score: Score given by the recognizer
-        :param validation_result: Whether validation was used and its result
-        :param regex_flags: Regex flags used in the regex matching
-        :return: Analysis explanation
-        """
         textual_explanation = (
-            f"Detected by `{recognizer_name}` " f"using pattern `{pattern_name}`"
+            f"Detected by `{recognizer_name}` using pattern `{pattern_name}`"
         )
-
         explanation = AnalysisExplanation(
             recognizer=recognizer_name,
             original_score=original_score,
@@ -174,21 +134,11 @@ class PatternRecognizer(LocalRecognizer):
     def __analyze_patterns(
         self, text: str, flags: int = None
     ) -> List[RecognizerResult]:
-        """
-        Evaluate all patterns in the provided text.
-
-        Including words in the provided deny-list
-
-        :param text: text to analyze
-        :param flags: regex flags
-        :return: A list of RecognizerResult
-        """
         flags = flags if flags else self.global_regex_flags
         results = []
         for pattern in self.patterns:
             match_start_time = datetime.datetime.now()
 
-            # Compile regex if flags differ from flags the regex was compiled with
             if not pattern.compiled_regex or pattern.compiled_with_flags != flags:
                 pattern.compiled_with_flags = flags
                 pattern.compiled_regex = re.compile(pattern.regex, flags=flags)
@@ -198,19 +148,17 @@ class PatternRecognizer(LocalRecognizer):
             logger.debug(
                 "--- match_time[%s]: %.6f seconds",
                 pattern.name,
-                match_time.total_seconds()
+                match_time.total_seconds(),
             )
 
             for match in matches:
                 start, end = match.span()
                 current_match = text[start:end]
 
-                # Skip empty results
                 if current_match == "":
                     continue
 
                 score = pattern.score
-
                 validation_result = self.validate_result(current_match)
                 description = self.build_regex_explanation(
                     self.name,
@@ -245,30 +193,24 @@ class PatternRecognizer(LocalRecognizer):
                 if pattern_result.score > EntityRecognizer.MIN_SCORE:
                     results.append(pattern_result)
 
-                # Update analysis explanation score following validation or invalidation
                 description.score = pattern_result.score
 
         results = EntityRecognizer.remove_duplicates(results)
         return results
 
     def to_dict(self) -> Dict:
-        """Serialize instance into a dictionary."""
         return_dict = super().to_dict()
-
         return_dict["patterns"] = [pat.to_dict() for pat in self.patterns]
         return_dict["deny_list"] = self.deny_list
         return_dict["context"] = self.context
         return_dict["supported_entity"] = return_dict["supported_entities"][0]
         del return_dict["supported_entities"]
-
         return return_dict
 
     @classmethod
     def from_dict(cls, entity_recognizer_dict: Dict) -> "PatternRecognizer":
-        """Create instance from a serialized dict."""
         patterns = entity_recognizer_dict.get("patterns")
         if patterns:
             patterns_list = [Pattern.from_dict(pat) for pat in patterns]
             entity_recognizer_dict["patterns"] = patterns_list
-
         return cls(**entity_recognizer_dict)

--- a/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/pattern_recognizer.py
@@ -12,14 +12,24 @@ from presidio_analyzer import (
     RecognizerResult,
 )
 from presidio_analyzer.nlp_engine import NlpArtifacts
-from presidio_analyzer.context_aware_enhancers.lemma_context_aware_enhancer import (
-    LemmaContextAwareEnhancer,
-)
 
 logger = logging.getLogger("presidio-analyzer")
 
 
 class PatternRecognizer(LocalRecognizer):
+    """
+    PII entity recognizer using regular expressions or deny-lists.
+
+    :param patterns: A list of patterns to detect
+    :param deny_list: A list of words to detect,
+    in case our recognizer uses a predefined list of words (deny list)
+    :param context: list of context words
+    :param deny_list_score: confidence score for a term
+    identified using a deny-list
+    :param global_regex_flags: regex flags to be used in regex matching,
+    including deny-lists.
+    """
+
     def __init__(
         self,
         supported_entity: str,
@@ -62,15 +72,7 @@ class PatternRecognizer(LocalRecognizer):
         else:
             self.deny_list = []
 
-        # context enhancer instance
-        self.context_enhancer = LemmaContextAwareEnhancer(
-            context_similarity_factor=0.2,
-            min_score_with_context_similarity=0.8,
-            context_prefix_count=1,
-            context_suffix_count=1,
-        )
-
-    def load(self):
+    def load(self):  # noqa D102
         pass
 
     def analyze(
@@ -80,32 +82,58 @@ class PatternRecognizer(LocalRecognizer):
         nlp_artifacts: Optional[NlpArtifacts] = None,
         regex_flags: Optional[int] = None,
     ) -> List[RecognizerResult]:
+        """
+        Analyzes text to detect PII using regular expressions or deny-lists.
+
+        :param text: Text to be analyzed
+        :param entities: Entities this recognizer can detect
+        :param nlp_artifacts: Output values from the NLP engine
+        :param regex_flags: regex flags to be used in regex matching
+        :return:
+        """
         results = []
 
         if self.patterns:
             pattern_result = self.__analyze_patterns(text, regex_flags)
             results.extend(pattern_result)
 
-        # apply context enhancer agar context words diye gaye hain
-        if self.context and results:
-            for res in results:
-                window = text[max(0, res.start - 20): res.end + 20].lower()
-                for ctx in self.context:
-                    if ctx.lower() in window:
-                        res.score = min(1.0, res.score + 0.2)
-
-
         return results
 
     def _deny_list_to_regex(self, deny_list: List[str]) -> Pattern:
+        """
+        Convert a list of words to a matching regex.
+
+        To be analyzed by the analyze method as any other regex patterns.
+
+        :param deny_list: the list of words to detect
+        :return:the regex of the words for detection
+        """
+
+        # Escape deny list elements as preparation for regex
         escaped_deny_list = [re.escape(element) for element in deny_list]
         regex = r"(?:^|(?<=\W))(" + "|".join(escaped_deny_list) + r")(?:(?=\W)|$)"
         return Pattern(name="deny_list", regex=regex, score=self.deny_list_score)
 
     def validate_result(self, pattern_text: str) -> Optional[bool]:
+        """
+        Validate the pattern logic e.g., by running checksum on a detected pattern.
+
+        :param pattern_text: the text to validated.
+        Only the part in text that was detected by the regex engine
+        :return: A bool indicating whether the validation was successful.
+        """
         return None
 
     def invalidate_result(self, pattern_text: str) -> Optional[bool]:
+        """
+        Logic to check for result invalidation by running pruning logic.
+
+        For example, each SSN number group should not consist of all the same digits.
+
+        :param pattern_text: the text to validated.
+        Only the part in text that was detected by the regex engine
+        :return: A bool indicating whether the result is invalidated
+        """
         return None
 
     @staticmethod
@@ -117,9 +145,21 @@ class PatternRecognizer(LocalRecognizer):
         validation_result: bool,
         regex_flags: int,
     ) -> AnalysisExplanation:
+        """
+        Construct an explanation for why this entity was detected.
+
+        :param recognizer_name: Name of recognizer detecting the entity
+        :param pattern_name: Regex pattern name which detected the entity
+        :param pattern: Regex pattern logic
+        :param original_score: Score given by the recognizer
+        :param validation_result: Whether validation was used and its result
+        :param regex_flags: Regex flags used in the regex matching
+        :return: Analysis explanation
+        """
         textual_explanation = (
-            f"Detected by `{recognizer_name}` using pattern `{pattern_name}`"
+            f"Detected by `{recognizer_name}` " f"using pattern `{pattern_name}`"
         )
+
         explanation = AnalysisExplanation(
             recognizer=recognizer_name,
             original_score=original_score,
@@ -134,11 +174,21 @@ class PatternRecognizer(LocalRecognizer):
     def __analyze_patterns(
         self, text: str, flags: int = None
     ) -> List[RecognizerResult]:
+        """
+        Evaluate all patterns in the provided text.
+
+        Including words in the provided deny-list
+
+        :param text: text to analyze
+        :param flags: regex flags
+        :return: A list of RecognizerResult
+        """
         flags = flags if flags else self.global_regex_flags
         results = []
         for pattern in self.patterns:
             match_start_time = datetime.datetime.now()
 
+            # Compile regex if flags differ from flags the regex was compiled with
             if not pattern.compiled_regex or pattern.compiled_with_flags != flags:
                 pattern.compiled_with_flags = flags
                 pattern.compiled_regex = re.compile(pattern.regex, flags=flags)
@@ -148,17 +198,19 @@ class PatternRecognizer(LocalRecognizer):
             logger.debug(
                 "--- match_time[%s]: %.6f seconds",
                 pattern.name,
-                match_time.total_seconds(),
+                match_time.total_seconds()
             )
 
             for match in matches:
                 start, end = match.span()
                 current_match = text[start:end]
 
+                # Skip empty results
                 if current_match == "":
                     continue
 
                 score = pattern.score
+
                 validation_result = self.validate_result(current_match)
                 description = self.build_regex_explanation(
                     self.name,
@@ -193,24 +245,30 @@ class PatternRecognizer(LocalRecognizer):
                 if pattern_result.score > EntityRecognizer.MIN_SCORE:
                     results.append(pattern_result)
 
+                # Update analysis explanation score following validation or invalidation
                 description.score = pattern_result.score
 
         results = EntityRecognizer.remove_duplicates(results)
         return results
 
     def to_dict(self) -> Dict:
+        """Serialize instance into a dictionary."""
         return_dict = super().to_dict()
+
         return_dict["patterns"] = [pat.to_dict() for pat in self.patterns]
         return_dict["deny_list"] = self.deny_list
         return_dict["context"] = self.context
         return_dict["supported_entity"] = return_dict["supported_entities"][0]
         del return_dict["supported_entities"]
+
         return return_dict
 
     @classmethod
     def from_dict(cls, entity_recognizer_dict: Dict) -> "PatternRecognizer":
+        """Create instance from a serialized dict."""
         patterns = entity_recognizer_dict.get("patterns")
         if patterns:
             patterns_list = [Pattern.from_dict(pat) for pat in patterns]
             entity_recognizer_dict["patterns"] = patterns_list
+
         return cls(**entity_recognizer_dict)


### PR DESCRIPTION
## Change Description

This PR updates the analyzer docs to include examples for using context with custom YAML recognizers.  
The update clarifies how to define `context` in YAML and how to apply it in Python with `LemmaContextAwareEnhancer`.

This helps avoid confusion like in issue #1696 where context in YAML seemed ignored.

## Issue reference

Fixes #1696

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA
- [x] My code/docs update is limited to documentation only
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates

## Example (YAML + Python)

See the added example in `developing_recognizers.md` for loading a DOB recognizer from YAML and applying context boosting in Python.
