### PR TITLE
Fix CI for PR flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
     name: Build ${{ matrix.image }} (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     needs: [lint]
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+    if: github.ref == 'refs/heads/main'
     permissions:
       id-token: write
       contents: read
@@ -187,7 +187,7 @@ jobs:
     name: Create Multi-Platform Manifests
     runs-on: ubuntu-latest
     needs: build-platform-images
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+    if: github.ref == 'refs/heads/main'
     permissions:
       id-token: write
       contents: read
@@ -224,7 +224,7 @@ jobs:
     name: E2E Tests (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     needs: create-manifests
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+    if: github.ref == 'refs/heads/main'
     permissions:
       id-token: write
       contents: read
@@ -313,10 +313,17 @@ jobs:
 
   # Local build and test jobs for external contributors (no secrets required) 
   local-build-and-test:
-    name: Local Build and E2E Tests
-    runs-on: ubuntu-latest
+    name: Local Build and E2E Tests (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     needs: [lint]
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    if: github.ref != 'refs/heads/main'
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -354,9 +361,9 @@ jobs:
           path: |
             ~/.cache/pip
             e2e-tests/env
-          key: ${{ runner.os }}-local-e2e-${{ hashFiles('e2e-tests/requirements.txt') }}
+          key: ${{ runner.os }}-${{ matrix.platform }}-local-e2e-${{ hashFiles('e2e-tests/requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-local-e2e-
+            ${{ runner.os }}-${{ matrix.platform }}-local-e2e-
 
       - name: Install E2E test dependencies
         working-directory: e2e-tests


### PR DESCRIPTION
## Change Description

Fix the CI workflow to support contributions from people or entities (dependabot) that don't have access to secrets.

1. Jobs that use the secrets are now conditionally run when in the main branch
2. Run local build/e2e on both platforms.

## Checklist

- [ ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
