### PR TITLE
Test for yaml config for custom recognizers

### DIFF
--- a/presidio-analyzer/tests/conf/custom_recognizer_yaml.yaml
+++ b/presidio-analyzer/tests/conf/custom_recognizer_yaml.yaml
@@ -1,0 +1,19 @@
+recognizer_registry:
+  global_regex_flags: 26
+  recognizers:
+    - name: "Zip code Recognizer"
+      supported_language: "en"
+      patterns:
+        - name: "zip code (weak)"
+          regex: "(\\b\\d{5}(?:\\-\\d{4})?\\b)"
+          score: 0.01
+      context:
+        - zip
+        - code
+      supported_entity: "ZIP"
+    - name: "SpacyRecognizer"
+      enabled: false
+
+supported_languages:
+  - en
+default_score_threshold: 0.0

--- a/presidio-analyzer/tests/test_analyzer_engine_provider.py
+++ b/presidio-analyzer/tests/test_analyzer_engine_provider.py
@@ -2,7 +2,7 @@ import re
 from pathlib import Path
 from typing import List
 
-from presidio_analyzer import AnalyzerEngineProvider, RecognizerResult
+from presidio_analyzer import AnalyzerEngineProvider, RecognizerResult, PatternRecognizer
 from presidio_analyzer.nlp_engine import SpacyNlpEngine, NlpArtifacts
 
 
@@ -199,6 +199,7 @@ def test_analyzer_engine_provider_with_ahds():
     analyzer_yaml, _, _ = get_full_paths(
         "conf/test_ahds_reco.yaml",
     )
+    from presidio_analyzer.predefined_recognizers import AzureHealthDeidRecognizer
 
     class MockAHDSDeidRecognizer(AzureHealthDeidRecognizer):
         def analyze(
@@ -339,3 +340,14 @@ def test_analyzer_engine_stanza_without_recognizer_creates_recognizer():
         nlp_recognizers[1].supported_language,
     }
     assert supported_languages == {"en", "es"}
+
+def test_analyzer_engine_provider_one_custom_recognizer():
+    analyzer_yaml, _, _ = get_full_paths(
+        "conf/custom_recognizer_yaml.yaml",
+    )
+    provider = AnalyzerEngineProvider(analyzer_engine_conf_file=analyzer_yaml)
+
+    analyzer_engine = provider.create_engine()
+    assert len(analyzer_engine.get_recognizers()) == 1
+    assert analyzer_engine.analyze("My zip code is 12345", language="en")[0].score == pytest.approx(0.4)
+


### PR DESCRIPTION
## Change Description

Testing that custom recognizers can be successfully defined in YAML through the `AnalyzerEngineProvider`

## Issue reference

Fixes #1696 

## Checklist

- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [X] I have signed the CLA (if required)
- [X] My code includes unit tests
- [X] All unit tests and lint checks pass locally
- [X] My PR contains documentation updates / additions if required
