### PR TITLE
Fix(DICOM): handle both names and patient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [unreleased]
+### Image Redactor
+#### Changed
+- DICOM: use_metadata will now use both is_patient and is_name to generate the PHI list of words via change to _make_phi_list.
 
 ## [2.2.360] - 2025-09-09
 ### Analyzer

--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
@@ -681,7 +681,11 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         is_name: List[bool],
         is_patient: List[bool],
     ) -> list:
-        """Make the list of PHI to use in Presidio ad-hoc recognizer.
+        """
+        Build a stable list of PHI strings to seed the ad-hoc recognizer without
+        mutating inputs while iterating. Combines names and patient-related names,
+        adds generic PHI, flattens nested collections, stringifies, trims empties,
+        and de-duplicates while preserving order of first appearance.
 
         :param original_metadata: List of all the instance's element values
         (excluding pixel data).
@@ -691,26 +695,38 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
 
         :return: List of PHI (str) to use with Presidio ad-hoc recognizer.
         """
-        # Process names
-        phi_list = cls._process_names(original_metadata, is_name)
+        # 1) Base PHI via existing helpers
+        phi: list = []
+        phi.extend(cls._process_names(original_metadata, is_name))
+        phi.extend(cls._process_names(original_metadata, is_patient))
+        phi = cls._add_known_generic_phi(phi)
 
-        # Add known potential phi values
-        phi_list = cls._add_known_generic_phi(phi_list)
+        # 2) Flatten safely (MultiValue/list/tuple) and stringify
+        from pydicom.multival import MultiValue
+        flattened: list = []
+        for val in phi:
+            if isinstance(val, (MultiValue, list, tuple)):
+                for item in val:
+                    if item is None:
+                        continue
+                    s = str(item).strip()
+                    if s:
+                        flattened.append(s)
+            else:
+                if val is None:
+                    continue
+                s = str(val).strip()
+                if s:
+                    flattened.append(s)
 
-        # Flatten any nested lists
-        for phi in phi_list:
-            if type(phi) in [pydicom.multival.MultiValue, list, tuple]:
-                for item in phi:
-                    phi_list.append(item)
-                phi_list.remove(phi)
-
-        # Convert all items to strings
-        phi_str_list = [str(phi) for phi in phi_list]
-
-        # Remove duplicates
-        phi_str_list = list(set(phi_str_list))
-
-        return phi_str_list
+        # 3) Stable de-duplication
+        seen = set()
+        out: list = []
+        for s in flattened:
+            if s not in seen:
+                seen.add(s)
+                out.append(s)
+        return out
 
     @classmethod
     def _set_bbox_color(

--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
@@ -681,8 +681,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         is_name: List[bool],
         is_patient: List[bool],
     ) -> list:
-        """
-        Build a stable list of PHI strings to seed the ad-hoc recognizer without
+        """Build a stable list of PHI strings to seed the ad-hoc recognizer without
         mutating inputs while iterating. Combines names and patient-related names,
         adds generic PHI, flattens nested collections, stringifies, trims empties,
         and de-duplicates while preserving order of first appearance.

--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
@@ -681,10 +681,11 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         is_name: List[bool],
         is_patient: List[bool],
     ) -> list:
-        """Build a stable list of PHI strings to seed the ad-hoc recognizer without
-        mutating inputs while iterating. Combines names and patient-related names,
-        adds generic PHI, flattens nested collections, stringifies, trims empties,
-        and de-duplicates while preserving order of first appearance.
+        """Build a list of PHI strings for the ad-hoc recognizer.
+
+        Combines names and patient-related fields, adds generic PHI, flattens nested
+        collections, stringifies, trims empties, and de-duplicates while preserving
+        order of first appearance.
 
         :param original_metadata: List of all the instance's element values
         (excluding pixel data).

--- a/presidio-image-redactor/tests/test_dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/tests/test_dicom_image_redactor_engine.py
@@ -836,7 +836,8 @@ def test_make_phi_list_happy_path(
     test_phi_str_list = mock_engine._make_phi_list(original_metadata, [], [])
 
     # Assert
-    assert mock_process_names.call_count == 1
+    # _make_phi_list calls _process_names twice: once for is_name and once for is_patient
+    assert mock_process_names.call_count == 2
     assert mock_add_known_generic_phi.call_count == 1
     assert set(test_phi_str_list) == set(expected_return_list)
 

--- a/presidio-image-redactor/tests/test_phi_list.py
+++ b/presidio-image-redactor/tests/test_phi_list.py
@@ -1,0 +1,32 @@
+import pydicom
+from pydicom.multival import MultiValue
+
+from presidio_image_redactor.dicom_image_redactor_engine import DicomImageRedactorEngine
+
+
+def test_make_phi_list_flattens_trims_and_dedupes_without_mutation():
+    # Simulate mixed metadata (strings, list, MultiValue, empty/None)
+    meta = [
+        "John Doe",
+        ["Jane", "Doe", ""],
+        MultiValue(str, ["X", "X", "Y"]),
+        "",
+        None,
+    ]
+    # Only first entry is_name, second is_patient (typical split across tags)
+    is_name =    [True,  False, False, False, False]
+    is_patient = [False, True,  False, False, False]
+
+    out = DicomImageRedactorEngine._make_phi_list(meta, is_name, is_patient)
+
+    # Should be flattened, trimmed and stably de-duplicated
+    # (allow for case/variant expansions produced by augment_word)
+    required = {"John Doe", "Jane", "Doe", "X", "Y"}
+    assert required.issubset(set(out))
+
+    # No exact duplicates (stable dedupe)
+    assert len(out) == len(set(out))
+
+    # Ensure original metadata unchanged
+    assert meta[1] == ["Jane", "Doe", ""]
+    assert list(meta[2]) == ["X", "X", "Y"]


### PR DESCRIPTION
## Change Description

Currently make_phi_list only looks at is_name and ignores is_patient so misses metadata words very relevant to PHI
removal. This change makes it use both is_name and is_patient to generate the list of PHI words.

## Checklist

- [X ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required) - not needed
- [X ] My code includes unit tests
- [ X] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required - not needed
