### PR TITLE
Update CI to temporarily drop Python 3.13 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12']
+        # python-version: ['3.10', '3.11', '3.12', '3.13'] # Temporarily dropped 3.13 until resolution of https://github.com/pytorch/pytorch/issues/165448 
         component: 
           - name: 'Analyzer'
             path: 'presidio-analyzer'


### PR DESCRIPTION
## Change Description

Temporarily removed Python 3.13 from CI matrix due to compatibility issues.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
