### PR TITLE
Add Docker HEALTHCHECK to all Dockerfiles

### DIFF
--- a/presidio-analyzer/Dockerfile
+++ b/presidio-analyzer/Dockerfile
@@ -18,9 +18,9 @@ COPY ${NLP_CONF_FILE} /app/${NLP_CONF_FILE}
 
 WORKDIR /app
 
-# Install essential build tools
+# Install essential build tools and curl for health checks
 RUN apt-get update \
-  && apt-get install build-essential --no-install-recommends -y \
+  && apt-get install build-essential curl --no-install-recommends -y \
   && rm -rf /var/lib/apt/lists/*
 
 COPY ./pyproject.toml /app/
@@ -33,4 +33,6 @@ RUN poetry run python install_nlp_models.py --conf_file ${NLP_CONF_FILE}
 
 COPY . /app/
 EXPOSE ${PORT}
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:${PORT}/health || exit 1
 CMD ["./entrypoint.sh"]

--- a/presidio-analyzer/Dockerfile.stanza
+++ b/presidio-analyzer/Dockerfile.stanza
@@ -18,9 +18,9 @@ COPY ${NLP_CONF_FILE} /app/${NLP_CONF_FILE}
 
 WORKDIR /app
 
-# Install essential build tools
+# Install essential build tools and curl for health checks
 RUN apt-get update \
-  && apt-get install -y build-essential
+  && apt-get install -y build-essential curl
 
 COPY ./pyproject.toml /app/
 
@@ -32,4 +32,6 @@ RUN poetry run python install_nlp_models.py --conf_file ${NLP_CONF_FILE}
 
 COPY . /app/
 EXPOSE ${PORT}
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:${PORT}/health || exit 1
 CMD ["./entrypoint.sh"]

--- a/presidio-analyzer/Dockerfile.transformers
+++ b/presidio-analyzer/Dockerfile.transformers
@@ -14,6 +14,9 @@ COPY ${ANALYZER_CONF_FILE} /app/${ANALYZER_CONF_FILE}
 COPY ${RECOGNIZER_REGISTRY_CONF_FILE} /app/${RECOGNIZER_REGISTRY_CONF_FILE}
 COPY ${NLP_CONF_FILE} /app/${NLP_CONF_FILE}
 
+# Install curl for health checks
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 COPY ./pyproject.toml /app/
 RUN pip install poetry && poetry install -E server -E transformers
 
@@ -26,4 +29,6 @@ RUN poetry run python install_nlp_models.py --conf_file ${NLP_CONF_FILE}
 
 COPY . /app/
 EXPOSE ${PORT}
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:${PORT}/health || exit 1
 CMD ["./entrypoint.sh"]

--- a/presidio-analyzer/Dockerfile.windows
+++ b/presidio-analyzer/Dockerfile.windows
@@ -34,4 +34,6 @@ RUN poetry run python install_nlp_models.py --conf_file $Env:NLP_CONF_FILE
 COPY . .
 EXPOSE ${PORT}
 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+    CMD powershell -Command "try { Invoke-WebRequest -Uri http://localhost:$env:PORT/health -UseBasicParsing | Out-Null; exit 0 } catch { exit 1 }"
 CMD ["powershell", "-Command", "poetry run waitress-serve --port=$env:PORT app:create_app"]

--- a/presidio-anonymizer/Dockerfile
+++ b/presidio-anonymizer/Dockerfile
@@ -7,10 +7,15 @@ ENV WORKERS=1
 
 WORKDIR /app
 
+# Install curl for health checks
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 COPY ./pyproject.toml /app/
 RUN pip install poetry && poetry install --no-root --only=main -E server
 
 COPY . /app/
 
 EXPOSE ${PORT}
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:${PORT}/health || exit 1
 CMD ["./entrypoint.sh"]

--- a/presidio-anonymizer/Dockerfile.windows
+++ b/presidio-anonymizer/Dockerfile.windows
@@ -11,4 +11,6 @@ RUN python.exe -m pip install --upgrade pip; pip install poetry; poetry install 
 COPY . /app/
 
 EXPOSE ${PORT}
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+    CMD powershell -Command "try { Invoke-WebRequest -Uri http://localhost:$env:PORT/health -UseBasicParsing | Out-Null; exit 0 } catch { exit 1 }"
 CMD ["powershell", "-Command", "poetry run waitress-serve --port=$env:PORT app:create_app"]

--- a/presidio-image-redactor/Dockerfile
+++ b/presidio-image-redactor/Dockerfile
@@ -19,7 +19,7 @@ COPY ${NLP_CONF_FILE} /app/${NLP_CONF_FILE}
 WORKDIR /app
 
 RUN apt-get update \
-  && apt-get install build-essential tesseract-ocr ffmpeg libsm6 libxext6 --no-install-recommends -y \
+  && apt-get install build-essential tesseract-ocr ffmpeg libsm6 libxext6 curl --no-install-recommends -y \
   && rm -rf /var/lib/apt/lists/* \
   && tesseract -v
 
@@ -28,4 +28,6 @@ RUN pip install poetry && poetry install --no-root --only=main -E server
 
 COPY . /app/
 EXPOSE ${PORT}
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:${PORT}/health || exit 1
 CMD ["./entrypoint.sh"]


### PR DESCRIPTION
## Summary
This PR adds Docker `HEALTHCHECK` directives to all production Dockerfiles across the Presidio repository to enable proper container health monitoring.

## Changes
- Added `HEALTHCHECK` configuration to 7 Dockerfiles:
  - `presidio-anonymizer/Dockerfile`
  - `presidio-anonymizer/Dockerfile.windows`
  - `presidio-analyzer/Dockerfile`
  - `presidio-analyzer/Dockerfile.stanza`
  - `presidio-analyzer/Dockerfile.transformers`
  - `presidio-analyzer/Dockerfile.windows`
  - `presidio-image-redactor/Dockerfile`

- Installed `curl` in Linux-based images for health checks
- Used PowerShell `Invoke-WebRequest` for Windows containers

## Health Check Configuration
- **Interval**: 30 seconds
- **Timeout**: 3 seconds  
- **Start Period**: 30 seconds
- **Retries**: 3

All health checks use the existing `/health` endpoint available in each service.

## Testing
- Built and tested `presidio-anonymizer` Docker image
- Verified container health status shows as "healthy"
- Confirmed health endpoint responds correctly