### PR TITLE
fix release-docs workflow credentials

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -19,15 +19,17 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Fetch all history for proper gh-pages deployment
-          persist-credentials: false
+          persist-credentials: true  # So that the token is available for pushing
       
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install -r docs/requirements-docs.txt
       
       - name: Deploy docs
         run: |
-          set -eux  # fail on error
-          pip install -r docs/requirements-docs.txt
           mkdocs gh-deploy


### PR DESCRIPTION
## Change Description

mkdocs needs credentials to push to the pages branch. One method is to persist the GitHub token from the checkout step (which we remove everywhere else).

## Checklist

- [ ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
