### PR TITLE
Update checkov skip-path

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -48,7 +48,7 @@ jobs:
       uses: microsoft/security-devops-action@latest
       id: msdo
       env:
-        GDN_CHECKOV_SKIPPATH: 'docs/'
+        GDN_CHECKOV_SKIPPATH: 'docs'
       with:
         tools: bandit, checkov, templateanalyzer, trivy
 


### PR DESCRIPTION
## Change Description

Checkov is configured to skip the `docs` path but it doesn't take hold due to the ending slash. 
A run with the original setting: https://github.com/microsoft/presidio/actions/runs/18757303717/job/53512462521
A run with the new setting showing checkov doesn't scan the docs folder: https://github.com/microsoft/presidio/actions/runs/18805027597/job/53657835858

## Checklist

- [ ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
