### PR TITLE
Fix Transformers Recognizer return value on REST API

### DIFF
--- a/presidio-analyzer/presidio_analyzer/nlp_engine/transformers_nlp_engine.py
+++ b/presidio-analyzer/presidio_analyzer/nlp_engine/transformers_nlp_engine.py
@@ -131,4 +131,4 @@ class TransformersNlpEngine(SpacyNlpEngine):
         :param doc: SpaCy doc
         """
 
-        return doc.spans[self.entity_key].attrs["scores"]
+        return [float(score) for score in doc.spans[self.entity_key].attrs["scores"]]

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/nlp_engine_recognizers/spacy_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/nlp_engine_recognizers/spacy_recognizer.py
@@ -114,12 +114,12 @@ class SpacyRecognizer(LocalRecognizer):
                 continue
 
             textual_explanation = self.DEFAULT_EXPLANATION.format(ner_entity.label_)
-            explanation = self.build_explanation(float(ner_score), textual_explanation)
+            explanation = self.build_explanation(ner_score, textual_explanation)
             spacy_result = RecognizerResult(
                 entity_type=ner_entity.label_,
                 start=ner_entity.start_char,
                 end=ner_entity.end_char,
-                score=float(ner_score),
+                score=ner_score,
                 analysis_explanation=explanation,
                 recognition_metadata={
                     RecognizerResult.RECOGNIZER_NAME_KEY: self.name,


### PR DESCRIPTION
## Change Description

When using transformers, the recognizer return type for score was numpy float instead of python's float.
When serializing it for Flask return value, an error was thrown:

`Message: "A fatal error occurred during execution of AnalyzerEngine.analyze(). 'numpy.float32' object has no attribute 'to_dict'"
Arguments: (AttributeError("'numpy.float32' object has no attribute 'to_dict'"),)`

While at it, fixed the Dockerfile for transformers which was bad-syntaxed. 

## Issue reference

Fixes #1746

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
