### PR TITLE
Move poetry cache directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
             path: 'presidio-structured'
             extras: ''
             spacy-models: ''
+    env:
+      POETRY_CACHE_DIR: /mnt/poetry_cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -102,6 +104,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
+
+      - name: Setup Poetry Cache Directory
+        run: |
+          sudo mkdir -p $POETRY_CACHE_DIR
+          sudo chown -R runner $POETRY_CACHE_DIR    
 
       - name: Install system dependencies for Image Redactor
         if: matrix.component.name == 'Image Redactor'


### PR DESCRIPTION
## Change Description

The GH Actions agent has a limited disk space in the home folder which is becoming too small to support everything presidio is using, especially for the analyzer that started to fail in the unit-test phase.

This PR moved poetry's cache directory into the host's temp disk which is located in "/mnt". This frees up ~7GB in the home directory.

## Checklist

- [ ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
