### PR TITLE
Remove poetry cache from docker images

### DIFF
--- a/presidio-analyzer/Dockerfile
+++ b/presidio-analyzer/Dockerfile
@@ -26,7 +26,10 @@ RUN apt-get update \
 
 COPY ./pyproject.toml /app/
 
-RUN pip install poetry && poetry install --no-root --only=main -E server
+RUN pip install poetry \
+    && poetry install --no-root --only=main -E server \
+    && rm -rf $(poetry config cache-dir)
+    
 # install nlp models specified in NLP_CONF_FILE
 COPY ./install_nlp_models.py /app/
 

--- a/presidio-anonymizer/Dockerfile
+++ b/presidio-anonymizer/Dockerfile
@@ -12,7 +12,9 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 COPY ./pyproject.toml /app/
-RUN pip install poetry && poetry install --no-root --only=main -E server
+RUN pip install poetry \
+    && poetry install --no-root --only=main -E server \
+    && rm -rf $(poetry config cache-dir)
 
 COPY . /app/
 

--- a/presidio-image-redactor/Dockerfile
+++ b/presidio-image-redactor/Dockerfile
@@ -25,7 +25,9 @@ RUN apt-get update \
   && tesseract -v
 
 COPY ./pyproject.toml /app/
-RUN pip install poetry && poetry install --no-root --only=main -E server
+RUN pip install poetry \
+    && poetry install --no-root --only=main -E server\
+    && rm -rf $(poetry config cache-dir)
 
 # Install spaCy model during build (as root) so it's available to non-root user at runtime
 RUN python -m spacy download en_core_web_lg


### PR DESCRIPTION
## Change Description

Poetry keeps a cache directory with things not needed for runtime so removing the cache reduces the docker images.
Analyzer was 2.15GB and is now 1.99GB
Anonymizer was 388MB and is now 375MB

## Checklist

- [ ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
