### PR TITLE
Fix coverage job to use component path for SUBPROJECT_ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           MINIMUM_GREEN: 85
           MINIMUM_ORANGE: 70
           COVERAGE_DATA_BRANCH: coverage-data
-          SUBPROJECT_ID: ${{ matrix.component.name }}
+          SUBPROJECT_ID: ${{ matrix.component.path }}
           COVERAGE_PATH: ${{ matrix.component.path }}
 
       - name: Build wheel package


### PR DESCRIPTION
## Change Description

Ive used the component name which include space inside it which cause branch creating failure.
changed it to the componenet.path.

## Issue reference

Fixes #XX

## Checklist

- [ ] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required
