### PR TITLE
Add German country-specific PII recognizers

### DIFF
--- a/docs/supported_entities.md
+++ b/docs/supported_entities.md
@@ -93,6 +93,15 @@ For more information, refer to the [adding new recognizers documentation](analyz
 | IN_PASSPORT | Indian Passport Number | Pattern match, Context |
 | IN_GSTIN | The Indian Goods and Services Tax Identification Number (GSTIN) is a 15-character identifier with state code (01-37), PAN, registration number, 'Z', and checksum. | Pattern match, context, and validation |
 
+### Germany
+
+|Entity Type|Description|Detection Method|
+|--- |--- |--- |
+|DE_TAX_ID|The German Tax Identification Number (Steueridentifikationsnummer) is an 11-digit number assigned to every person registered in Germany.|Pattern match, context and checksum|
+|DE_ID_CARD|A German ID card number (Personalausweisnummer), 9-character alphanumeric identifier issued since 2010.|Pattern match and context|
+|DE_PASSPORT|A German passport number (Reisepassnummer), 9-character alphanumeric identifier.|Pattern match and context|
+|DE_DRIVER_LICENSE|A German driver license number (Führerscheinnummer), 11-character alphanumeric identifier.|Pattern match and context|
+
 ### Finland
 | FieldType  | Description                                                                                             | Detection Method                         |
 |------------|---------------------------------------------------------------------------------------------------------|------------------------------------------|

--- a/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
+++ b/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
@@ -194,6 +194,30 @@ recognizers:
     type: predefined
     enabled: false
 
+  - name: DeTaxIdRecognizer
+    supported_languages:
+    - de
+    type: predefined
+    enabled: false
+
+  - name: DeIdCardRecognizer
+    supported_languages:
+    - de
+    type: predefined
+    enabled: false
+
+  - name: DePassportRecognizer
+    supported_languages:
+    - de
+    type: predefined
+    enabled: false
+
+  - name: DeDriverLicenseRecognizer
+    supported_languages:
+    - de
+    type: predefined
+    enabled: false
+
   - name: HuggingFaceNerRecognizer
     supported_languages:
     - en

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
@@ -14,6 +14,15 @@ from .country_specific.australia.au_tfn_recognizer import AuTfnRecognizer
 from .country_specific.finland.fi_personal_identity_code_recognizer import (
     FiPersonalIdentityCodeRecognizer,
 )
+
+# Germany recognizers
+from .country_specific.germany.de_driver_license_recognizer import (
+    DeDriverLicenseRecognizer,
+)
+from .country_specific.germany.de_id_card_recognizer import DeIdCardRecognizer
+from .country_specific.germany.de_passport_recognizer import DePassportRecognizer
+from .country_specific.germany.de_tax_id_recognizer import DeTaxIdRecognizer
+
 from .country_specific.india import (
     InVehicleRegistrationRecognizer,
 )
@@ -175,4 +184,8 @@ __all__ = [
     "AzureOpenAILangExtractRecognizer",
     "BasicLangExtractRecognizer",
     "KrPassportRecognizer",
+    "DeDriverLicenseRecognizer",
+    "DeIdCardRecognizer",
+    "DePassportRecognizer",
+    "DeTaxIdRecognizer",
 ]

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/__init__.py
@@ -1,0 +1,13 @@
+"""Germany-specific recognizers."""
+
+from .de_driver_license_recognizer import DeDriverLicenseRecognizer
+from .de_id_card_recognizer import DeIdCardRecognizer
+from .de_passport_recognizer import DePassportRecognizer
+from .de_tax_id_recognizer import DeTaxIdRecognizer
+
+__all__ = [
+    "DeDriverLicenseRecognizer",
+    "DeIdCardRecognizer",
+    "DePassportRecognizer",
+    "DeTaxIdRecognizer",
+]

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/de_driver_license_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/de_driver_license_recognizer.py
@@ -1,0 +1,57 @@
+from typing import List, Optional
+
+from presidio_analyzer import Pattern, PatternRecognizer
+
+
+class DeDriverLicenseRecognizer(PatternRecognizer):
+    """
+    Recognizes German driver license numbers (Fuhrerscheinnummer).
+
+    The German driver license number is an 11-character alphanumeric
+    string with the pattern: one alphanumeric character, two digits,
+    six alphanumeric characters, one digit, and one alphanumeric character.
+
+    Reference: https://en.wikipedia.org/wiki/European_driving_licence
+
+    :param patterns: List of patterns to be used by this recognizer
+    :param context: List of context words to increase confidence in detection
+    :param supported_language: Language this recognizer supports
+    :param supported_entity: The entity this recognizer can detect
+    """
+
+    PATTERNS = [
+        Pattern(
+            "Driver License (very weak)",
+            r"\b[A-Z0-9]\d{2}[A-Z0-9]{6}\d[A-Z0-9]\b",
+            0.01,
+        ),
+    ]
+
+    CONTEXT = [
+        "fuhrerschein",
+        "fuhrerscheinnummer",
+        "fahrerlaubnis",
+        "driver license",
+        "driving licence",
+        "fahrerlaubnisnummer",
+        "fuhrerscheinklasse",
+        "strassenverkehrsamt",
+    ]
+
+    def __init__(
+        self,
+        patterns: Optional[List[Pattern]] = None,
+        context: Optional[List[str]] = None,
+        supported_language: str = "de",
+        supported_entity: str = "DE_DRIVER_LICENSE",
+        name: Optional[str] = None,
+    ) -> None:
+        patterns = patterns if patterns else self.PATTERNS
+        context = context if context else self.CONTEXT
+        super().__init__(
+            supported_entity=supported_entity,
+            patterns=patterns,
+            context=context,
+            supported_language=supported_language,
+            name=name,
+        )

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/de_id_card_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/de_id_card_recognizer.py
@@ -1,0 +1,59 @@
+from typing import List, Optional
+
+from presidio_analyzer import Pattern, PatternRecognizer
+
+
+class DeIdCardRecognizer(PatternRecognizer):
+    """
+    Recognizes German ID card numbers (Personalausweisnummer).
+
+    The post-2010 German ID card number is a 9-character alphanumeric
+    string. The first character is a letter from the set
+    [L, M, N, P, R, T, V, W, X, Y], followed by 8 alphanumeric
+    characters (digits 0-9 and letters C, F, G, H, J, K,
+    L, M, N, P, R, T, V, W, X, Y — no vowels, no B, D, S, Q, I, O, Z).
+
+    Reference: https://en.wikipedia.org/wiki/German_identity_card
+
+    :param patterns: List of patterns to be used by this recognizer
+    :param context: List of context words to increase confidence in detection
+    :param supported_language: Language this recognizer supports
+    :param supported_entity: The entity this recognizer can detect
+    """
+
+    PATTERNS = [
+        Pattern(
+            "ID Card (very weak)",
+            r"\b[LMNPRTVWXY][CFGHJKLMNPRTVWXY0-9]{8}\b",
+            0.01,
+        ),
+    ]
+
+    CONTEXT = [
+        "personalausweis",
+        "personalausweisnummer",
+        "ausweis",
+        "ausweisnummer",
+        "identity card",
+        "id card",
+        "ausweisdokument",
+        "identitatsnachweis",
+    ]
+
+    def __init__(
+        self,
+        patterns: Optional[List[Pattern]] = None,
+        context: Optional[List[str]] = None,
+        supported_language: str = "de",
+        supported_entity: str = "DE_ID_CARD",
+        name: Optional[str] = None,
+    ):
+        patterns = patterns if patterns else self.PATTERNS
+        context = context if context else self.CONTEXT
+        super().__init__(
+            supported_entity=supported_entity,
+            patterns=patterns,
+            context=context,
+            supported_language=supported_language,
+            name=name,
+        )

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/de_passport_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/de_passport_recognizer.py
@@ -1,0 +1,58 @@
+from typing import List, Optional
+
+from presidio_analyzer import Pattern, PatternRecognizer
+
+
+class DePassportRecognizer(PatternRecognizer):
+    """
+    Recognizes German passport numbers (Reisepassnummer).
+
+    The German passport number is a 9-character alphanumeric string.
+    The first character is a letter from the set [C, F, G, H, J, K]
+    (disjoint from German ID card first letters), followed by
+    8 alphanumeric characters (digits 0-9 and letters C, F, G, H, J, K,
+    L, M, N, P, R, T, V, W, X, Y — no vowels, no B, D, S, Q, I, O, Z).
+
+    Reference: https://en.wikipedia.org/wiki/German_passport
+
+    :param patterns: List of patterns to be used by this recognizer
+    :param context: List of context words to increase confidence in detection
+    :param supported_language: Language this recognizer supports
+    :param supported_entity: The entity this recognizer can detect
+    """
+
+    PATTERNS = [
+        Pattern(
+            "Passport (very weak)",
+            r"\b[CFGHJK][CFGHJKLMNPRTVWXY0-9]{8}\b",
+            0.01,
+        ),
+    ]
+
+    CONTEXT = [
+        "reisepass",
+        "reisepassnummer",
+        "passnummer",
+        "passport",
+        "reisedokument",
+        "grenzubergang",
+        "bundesdruckerei",
+    ]
+
+    def __init__(
+        self,
+        patterns: Optional[List[Pattern]] = None,
+        context: Optional[List[str]] = None,
+        supported_language: str = "de",
+        supported_entity: str = "DE_PASSPORT",
+        name: Optional[str] = None,
+    ):
+        patterns = patterns if patterns else self.PATTERNS
+        context = context if context else self.CONTEXT
+        super().__init__(
+            supported_entity=supported_entity,
+            patterns=patterns,
+            context=context,
+            supported_language=supported_language,
+            name=name,
+        )

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/de_tax_id_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/de_tax_id_recognizer.py
@@ -1,0 +1,120 @@
+from typing import List, Optional, Tuple
+
+from presidio_analyzer import EntityRecognizer, Pattern, PatternRecognizer
+
+
+class DeTaxIdRecognizer(PatternRecognizer):
+    """
+    Recognizes German Tax Identification Numbers (Steueridentifikationsnummer).
+
+    The Steueridentifikationsnummer (Steuer-IdNr) is an 11-digit tax
+    identification number assigned to every person registered in Germany.
+    It uses an ISO 7064 MOD 11,10 check digit and has an occurrence rule:
+    exactly one digit must appear exactly twice (or three times),
+    and one digit must not appear at all (or appear once fewer).
+
+    Reference: https://de.wikipedia.org/wiki/Steuerliche_Identifikationsnummer
+
+    :param patterns: List of patterns to be used by this recognizer
+    :param context: List of context words to increase confidence in detection
+    :param supported_language: Language this recognizer supports
+    :param supported_entity: The entity this recognizer can detect
+    :param replacement_pairs: List of tuples with potential replacement values
+    for different strings to be used during pattern matching.
+    """
+
+    PATTERNS = [
+        Pattern(
+            "Tax ID (Medium)",
+            r"\b\d{2}\s\d{3}\s\d{3}\s\d{3}\b",
+            0.3,
+        ),
+        Pattern(
+            "Tax ID (Low)",
+            r"\b\d{11}\b",
+            0.01,
+        ),
+    ]
+
+    CONTEXT = [
+        "steuer-id",
+        "steueridentifikationsnummer",
+        "steuerliche identifikationsnummer",
+        "steuer-idnr",
+        "steuerid",
+        "idnr",
+        "tax id",
+        "tin",
+        "finanzamt",
+        "identifikationsnummer",
+    ]
+
+    def __init__(
+        self,
+        patterns: Optional[List[Pattern]] = None,
+        context: Optional[List[str]] = None,
+        supported_language: str = "de",
+        supported_entity: str = "DE_TAX_ID",
+        replacement_pairs: Optional[List[Tuple[str, str]]] = None,
+        name: Optional[str] = None,
+    ):
+        self.replacement_pairs = (
+            replacement_pairs if replacement_pairs else [("-", ""), (" ", "")]
+        )
+        patterns = patterns if patterns else self.PATTERNS
+        context = context if context else self.CONTEXT
+        super().__init__(
+            supported_entity=supported_entity,
+            patterns=patterns,
+            context=context,
+            supported_language=supported_language,
+            name=name,
+        )
+
+    def validate_result(self, pattern_text: str) -> bool:
+        """
+        Validate the pattern logic by checking the occurrence rule
+        and ISO 7064 MOD 11,10 check digit.
+
+        :param pattern_text: the text to validate.
+        Only the part in text that was detected by the regex engine
+        :return: A bool indicating whether the validation was successful.
+        """
+        text = EntityRecognizer.sanitize_value(pattern_text, self.replacement_pairs)
+        digits = [int(d) for d in text]
+
+        if len(digits) != 11:
+            return False
+
+        # First digit must not be 0
+        if digits[0] == 0:
+            return False
+
+        # Occurrence rule: in the first 10 digits, exactly one digit
+        # appears two or three times, all others appear zero or one time.
+        first_ten = digits[:10]
+        counts = [0] * 10
+        for d in first_ten:
+            counts[d] += 1
+
+        twos_or_threes = sum(1 for c in counts if c >= 2)
+        if twos_or_threes != 1:
+            return False
+
+        # No digit may appear more than 3 times
+        if any(c > 3 for c in counts):
+            return False
+
+        # ISO 7064 MOD 11,10 check digit
+        product = 10
+        for i in range(10):
+            total = (digits[i] + product) % 10
+            if total == 0:
+                total = 10
+            product = (total * 2) % 11
+
+        check = 11 - product
+        if check == 10:
+            check = 0
+
+        return check == digits[10]

--- a/presidio-analyzer/tests/test_de_driver_license_recognizer.py
+++ b/presidio-analyzer/tests/test_de_driver_license_recognizer.py
@@ -1,0 +1,52 @@
+import pytest
+
+from tests import assert_result_within_score_range
+from presidio_analyzer.predefined_recognizers import DeDriverLicenseRecognizer
+
+
+@pytest.fixture(scope="module")
+def recognizer():
+    return DeDriverLicenseRecognizer()
+
+
+@pytest.fixture(scope="module")
+def entities():
+    return ["DE_DRIVER_LICENSE"]
+
+
+@pytest.mark.parametrize(
+    "text, expected_len, expected_positions, expected_score_ranges",
+    [
+        # fmt: off
+        # Valid driver license numbers: [A-Z0-9]\d{2}[A-Z0-9]{6}\d[A-Z0-9]
+        ("B072RRE2P90", 1, ((0, 11),), ((0.0, 0.05),),),
+        ("Z99AAAAAA0A", 1, ((0, 11),), ((0.0, 0.05),),),
+        ("001AAAAAA0A", 1, ((0, 11),), ((0.0, 0.05),),),
+        # Invalid: wrong structure (missing digit positions)
+        ("BBBRRRE2P90", 0, (), (),),
+        # Invalid: wrong length (too short)
+        ("B072RRE2P9", 0, (), (),),
+        # Invalid: wrong length (too long)
+        ("B072RRE2P900", 0, (), (),),
+        # fmt: on
+    ],
+)
+def test_when_all_de_driver_licenses_then_succeed(
+    text,
+    expected_len,
+    expected_positions,
+    expected_score_ranges,
+    recognizer,
+    entities,
+    max_score,
+):
+    results = recognizer.analyze(text, entities)
+    assert len(results) == expected_len
+    for res, (st_pos, fn_pos), (st_score, fn_score) in zip(
+        results, expected_positions, expected_score_ranges
+    ):
+        if fn_score == "max":
+            fn_score = max_score
+        assert_result_within_score_range(
+            res, entities[0], st_pos, fn_pos, st_score, fn_score
+        )

--- a/presidio-analyzer/tests/test_de_id_card_recognizer.py
+++ b/presidio-analyzer/tests/test_de_id_card_recognizer.py
@@ -1,0 +1,53 @@
+import pytest
+
+from tests import assert_result_within_score_range
+from presidio_analyzer.predefined_recognizers import DeIdCardRecognizer
+
+
+@pytest.fixture(scope="module")
+def recognizer():
+    return DeIdCardRecognizer()
+
+
+@pytest.fixture(scope="module")
+def entities():
+    return ["DE_ID_CARD"]
+
+
+@pytest.mark.parametrize(
+    "text, expected_len, expected_positions, expected_score_ranges",
+    [
+        # fmt: off
+        # Valid ID card numbers (first char in LMNPRTVWXY, 9 chars total)
+        ("L01X00T47", 1, ((0, 9),), ((0.0, 0.05),),),
+        ("T22000129", 1, ((0, 9),), ((0.0, 0.05),),),
+        # Invalid: first char is a vowel
+        ("A01X00T47", 0, (), (),),
+        # Invalid: first char is a digit
+        ("101X00T47", 0, (), (),),
+        # Invalid: body contains vowel
+        ("L01A00T47", 0, (), (),),
+        # Invalid: wrong length (too short)
+        ("L01X00T4", 0, (), (),),
+        # fmt: on
+    ],
+)
+def test_when_all_de_id_cards_then_succeed(
+    text,
+    expected_len,
+    expected_positions,
+    expected_score_ranges,
+    recognizer,
+    entities,
+    max_score,
+):
+    results = recognizer.analyze(text, entities)
+    assert len(results) == expected_len
+    for res, (st_pos, fn_pos), (st_score, fn_score) in zip(
+        results, expected_positions, expected_score_ranges
+    ):
+        if fn_score == "max":
+            fn_score = max_score
+        assert_result_within_score_range(
+            res, entities[0], st_pos, fn_pos, st_score, fn_score
+        )

--- a/presidio-analyzer/tests/test_de_passport_recognizer.py
+++ b/presidio-analyzer/tests/test_de_passport_recognizer.py
@@ -1,0 +1,52 @@
+import pytest
+
+from tests import assert_result_within_score_range
+from presidio_analyzer.predefined_recognizers import DePassportRecognizer
+
+
+@pytest.fixture(scope="module")
+def recognizer():
+    return DePassportRecognizer()
+
+
+@pytest.fixture(scope="module")
+def entities():
+    return ["DE_PASSPORT"]
+
+
+@pytest.mark.parametrize(
+    "text, expected_len, expected_positions, expected_score_ranges",
+    [
+        # fmt: off
+        # Valid passport numbers (first char in CFGHJK, 9 chars total)
+        ("C01X00T47", 1, ((0, 9),), ((0.0, 0.05),),),
+        ("K9988776M", 1, ((0, 9),), ((0.0, 0.05),),),
+        # Invalid: first char not in CFGHJK
+        ("L01X00T47", 0, (), (),),
+        ("A01X00T47", 0, (), (),),
+        # Invalid: body contains vowel
+        ("C01A00T47", 0, (), (),),
+        # Invalid: wrong length (too short)
+        ("C01X00T4", 0, (), (),),
+        # fmt: on
+    ],
+)
+def test_when_all_de_passports_then_succeed(
+    text,
+    expected_len,
+    expected_positions,
+    expected_score_ranges,
+    recognizer,
+    entities,
+    max_score,
+):
+    results = recognizer.analyze(text, entities)
+    assert len(results) == expected_len
+    for res, (st_pos, fn_pos), (st_score, fn_score) in zip(
+        results, expected_positions, expected_score_ranges
+    ):
+        if fn_score == "max":
+            fn_score = max_score
+        assert_result_within_score_range(
+            res, entities[0], st_pos, fn_pos, st_score, fn_score
+        )

--- a/presidio-analyzer/tests/test_de_tax_id_recognizer.py
+++ b/presidio-analyzer/tests/test_de_tax_id_recognizer.py
@@ -1,0 +1,55 @@
+import pytest
+
+from tests import assert_result_within_score_range
+from presidio_analyzer.predefined_recognizers import DeTaxIdRecognizer
+
+
+@pytest.fixture(scope="module")
+def recognizer():
+    return DeTaxIdRecognizer()
+
+
+@pytest.fixture(scope="module")
+def entities():
+    return ["DE_TAX_ID"]
+
+
+@pytest.mark.parametrize(
+    "text, expected_len, expected_positions, expected_score_ranges",
+    [
+        # fmt: off
+        # Valid Tax IDs (pass checksum + occurrence rule)
+        ("65 929 970 489", 1, ((0, 14),), ((1.0, 1.0),),),
+        ("65929970489", 1, ((0, 11),), ((1.0, 1.0),),),
+        ("86 095 742 719", 1, ((0, 14),), ((1.0, 1.0),),),
+        # Invalid: starts with 0
+        ("02 461 357 893", 0, (), (),),
+        # Invalid: bad checksum
+        ("65 929 970 481", 0, (), (),),
+        # Invalid: wrong length
+        ("1234567890", 0, (), (),),
+        ("123456789012", 0, (), (),),
+        # Invalid: occurrence rule violation (all digits unique)
+        ("12 345 678 903", 0, (), (),),
+        # fmt: on
+    ],
+)
+def test_when_all_de_tax_ids_then_succeed(
+    text,
+    expected_len,
+    expected_positions,
+    expected_score_ranges,
+    recognizer,
+    entities,
+    max_score,
+):
+    results = recognizer.analyze(text, entities)
+    assert len(results) == expected_len
+    for res, (st_pos, fn_pos), (st_score, fn_score) in zip(
+        results, expected_positions, expected_score_ranges
+    ):
+        if fn_score == "max":
+            fn_score = max_score
+        assert_result_within_score_range(
+            res, entities[0], st_pos, fn_pos, st_score, fn_score
+        )


### PR DESCRIPTION
## Summary

Hey there! This PR adds four new regex pattern recognizers for German PII, as requested in #1828:

- **DE_TAX_ID** - 11-digit Steueridentifikationsnummer with ISO 7064 MOD 11,10 checksum and occurrence rule validation
- **DE_ID_CARD** - 9-character Personalausweisnummer (post-2010 format, first char in [LMNPRTVWXY])
- **DE_PASSPORT** - 9-character Reisepassnummer (first char in [CFGHJK], disjoint from ID card)
- **DE_DRIVER_LICENSE** - 11-character Führerscheinnummer

All four recognizers follow existing Presidio conventions — they use German context words for confidence boosting, are disabled by default (`enabled: false`), and support the `de` language code.

## What's included

- 5 new files in `presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/`
- 4 test files with 26 test cases covering valid patterns, invalid checksums, wrong lengths, and structural mismatches
- Updated `__init__.py` with imports and `__all__` entries
- Updated `default_recognizers.yaml` with config entries
- Updated `docs/supported_entities.md` with a new Germany section

## Test plan

- [x] All 26 new tests pass (`pytest presidio-analyzer/tests/test_de_*.py -v`)
- [x] Full test suite passes with no regressions (1503 passed, pre-existing failures unrelated)
- [x] Import verification works: `from presidio_analyzer.predefined_recognizers import DeTaxIdRecognizer, DeIdCardRecognizer, DePassportRecognizer, DeDriverLicenseRecognizer`

Closes #1828