### PR TITLE
fix(analyzer): remove erroneous anchor in Italian driver license regex

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/italy/it_driver_license_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/italy/it_driver_license_recognizer.py
@@ -18,7 +18,7 @@ class ItDriverLicenseRecognizer(PatternRecognizer):
             "Driver License",
             (
                 r"\b(?i)(([A-Z]{2}\d{7}[A-Z])"
-                r"|(^[U]1[BCDEFGHLJKMNPRSTUWYXZ0-9]{7}[A-Z]))\b"
+                r"|(U1[BCDEFGHLJKMNPRSTUWYXZ0-9]{7}[A-Z]))\b"
             ),
             0.2,
         ),

--- a/presidio-analyzer/tests/test_it_driver_license_recognizer.py
+++ b/presidio-analyzer/tests/test_it_driver_license_recognizer.py
@@ -31,6 +31,10 @@ def entities() -> list[str]:
         ("U1H00A000B", 0, (), (),),
         # Test with invalid Driver License
         ("990123456B", 0, (), (),),
+        # Test with JK letters in license (issue #1555)
+        ("U1K711J11M", 1, ((0, 10),), ((0.1, 0.4),),),
+        # Test with JK letters not at start of string
+        ("license U1K711J11M here", 1, ((8, 18),), ((0.1, 0.4),),),
         # fmt: on
     ],
 )


### PR DESCRIPTION
Fixes #1555

## Change Description

Fixed the regex pattern in `ItDriverLicenseRecognizer` by removing an erroneous `^` anchor that prevented matching Italian driver license numbers (U1 format) when they appeared anywhere other than the start of a string.

The regex for U1-format licenses incorrectly had `^[U]1` which only matched at the beginning of a line. This has been corrected to `U1` so licenses like `U1K711J11M` are now correctly recognized regardless of their position in the text.

## Issue reference

Fixes #1555

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [x] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required

## Changes

- `presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/italy/it_driver_license_recognizer.py`: Removed erroneous `^` anchor from the U1-format regex pattern
- `presidio-analyzer/tests/test_it_driver_license_recognizer.py`: Added test cases for license numbers containing J/K letters and for licenses not at the start of text

```
 presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/italy/it_driver_license_recognizer.py | 2 +-
 presidio-analyzer/tests/test_it_driver_license_recognizer.py                     | 4 ++++
 2 files changed, 5 insertions(+), 1 deletion(-)
```