### PR TITLE
Fix/kvnr checksum 1972

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to this project will be documented in this file.
 
 - Added recognizer for Swedish Organisationsnummer, ID number for all Swedish oragnisations.
 
+#### Fixed
+- Fixed incorrect Prüfziffer algorithm in `DeHealthInsuranceRecognizer` (KVNR); now uses alternating factors [1,2,…,1,2] per § 290 SGB V Anlage 1 (#1972).
+
 ## [2.2.362] - 2026-03-15
 ### General
 #### Added

--- a/docs/recipes/german-language-support/README.md
+++ b/docs/recipes/german-language-support/README.md
@@ -31,7 +31,7 @@ python -m spacy download de_core_news_md
 sample_text = """
 Sehr geehrter Herr Müller,
 
-Ihre Krankenversicherungsnummer (KVNR): A123456787
+Ihre Krankenversicherungsnummer (KVNR): A123456780
 Steuer-IdNr.: 86095742719
 Arztnummer (LANR): 123456901
 Betriebsstättennummer (BSNR): 021234568

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/de_health_insurance_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/de_health_insurance_recognizer.py
@@ -25,17 +25,17 @@ class DeHealthInsuranceRecognizer(PatternRecognizer):
         Pos 2–9:  8 digits (birth date encoded + serial)
         Pos 10:   Prüfziffer (check digit, 0–9)
 
-    Example (fictitious): A123456787
+    Example: A000500015 (from § 290 SGB V Anlage 1, Stand 02.01.2023)
 
-    Check digit algorithm (GKV-Spitzenverband specification):
+    Check digit algorithm (§ 290 SGB V Anlage 1, GKV-Spitzenverband):
         1. Convert the letter at position 1 to its 2-digit ordinal value
-           (A=01, B=02, …, Z=26), yielding an effective 11-digit string.
-        2. Apply weights [2, 9, 8, 7, 6, 5, 4, 3, 2, 1] to the first 10
-           effective digits (before the check digit at effective position 11).
-           Note: the check digit is the last digit of the original 10-char string
-           (position 10), which maps to effective position 11.
-        3. For each product ≥ 10, replace it with the sum of its digits.
-        4. Sum all 10 values, compute sum mod 10.
+           (A=01, B=02, …, Z=26). Concatenated with the 8 data digits at
+           positions 2–9, this yields 10 effective digits.
+        2. Apply alternating factors [1, 2, 1, 2, 1, 2, 1, 2, 1, 2] to those
+           10 effective digits.
+        3. For each product ≥ 10, replace it with the cross-sum of its digits
+           (Quersumme).
+        4. Sum the 10 values; compute sum mod 10.
         5. The result must equal the check digit at position 10.
 
     :param patterns: List of patterns to be used by this recognizer
@@ -118,16 +118,15 @@ class DeHealthInsuranceRecognizer(PatternRecognizer):
         letter = pattern_text[0]
         letter_val = str(ord(letter) - ord("A") + 1).zfill(2)
 
-        # Effective 11-digit string: 2 (from letter) + 8 data digits + 1 check digit
-        # We apply weights to the first 10 effective positions (before check digit)
-        effective = letter_val + pattern_text[1:9]  # 2 + 8 = 10 digits
+        # Letter expanded to 2 digits + 8 data digits = 10 effective digits
+        effective = letter_val + pattern_text[1:9]
 
         check_digit = int(pattern_text[9])
-        weights = [2, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+        factors = [1, 2, 1, 2, 1, 2, 1, 2, 1, 2]
 
         total = 0
-        for digit_char, weight in zip(effective, weights):
-            product = int(digit_char) * weight
+        for digit_char, factor in zip(effective, factors):
+            product = int(digit_char) * factor
             if product >= 10:
                 product = (product // 10) + (product % 10)
             total += product

--- a/presidio-analyzer/tests/test_de_health_insurance_recognizer.py
+++ b/presidio-analyzer/tests/test_de_health_insurance_recognizer.py
@@ -4,16 +4,21 @@ Tests for DeHealthInsuranceRecognizer (Krankenversicherungsnummer / KVNR).
 Format: 10 characters – 1 uppercase letter (birth surname initial) +
 8 digits (birth date + serial) + 1 check digit.
 
-Valid numbers are generated with the GKV-Spitzenverband checksum algorithm
-(letter expanded to 2-digit ordinal, weights [2,9,8,7,6,5,4,3,2,1],
-products digit-summed if ≥ 10, sum mod 10).
+Valid numbers are generated with the GKV-Spitzenverband Prüfziffer algorithm
+per § 290 SGB V Anlage 1 (Stand 02.01.2023): letter expanded to 2-digit
+ordinal, alternating factors [1,2,1,2,1,2,1,2,1,2], products digit-summed
+if ≥ 10 (Quersumme), sum mod 10.
 
 Legal basis: § 290 SGB V.  DSGVO Art. 9 (Gesundheitsdaten).
 
-Pre-calculated valid examples (fictitious):
-  A123456787  – letter A (=01), data 12345678, check = 7
-  M123456789  – letter M (=13), data 12345678, check = 9
-  B123456787  – letter B (=02), data 12345678, check = 7
+Pre-calculated valid examples:
+  A000500015  – from § 290 SGB V Anlage 1 (Hauptversicherter, PZ=5)
+  C000500021  – from § 290 SGB V Anlage 1 (Familienversicherter IK part, PZ=1)
+  A123456780  – letter A (=01), data 12345678, check = 0
+  B123456782  – letter B (=02), data 12345678, check = 2
+  M123456785  – letter M (=13), data 12345678, check = 5
+  Z000000005  – letter Z (=26), exercises upper-bound letter ordinal
+  Z999999997  – letter Z with all-9 data, exercises Quersumme on 7 of 10 products
 """
 import pytest
 
@@ -36,19 +41,24 @@ def entities():
     [
         # fmt: off
         # Valid KVNR – checksum passes → result at MAX_SCORE
-        ("A123456787", 1, ((0, 10),)),
-        ("M123456789", 1, ((0, 10),)),
-        ("B123456787", 1, ((0, 10),)),
-        ("Krankenkasse KVNR: A123456787", 1, ((19, 29),)),
-        ("eGK-Nummer M123456789 bitte angeben.", 1, ((11, 21),)),
+        ("A000500015", 1, ((0, 10),)),
+        ("C000500021", 1, ((0, 10),)),
+        ("A123456780", 1, ((0, 10),)),
+        ("M123456785", 1, ((0, 10),)),
+        ("B123456782", 1, ((0, 10),)),
+        # Edge: letter Z (upper bound of ordinal) and worst-case Quersumme density
+        ("Z000000005", 1, ((0, 10),)),
+        ("Z999999997", 1, ((0, 10),)),
+        ("Krankenkasse KVNR: A123456780", 1, ((19, 29),)),
+        ("eGK-Nummer M123456785 bitte angeben.", 1, ((11, 21),)),
         # Invalid: wrong check digit
-        ("A123456780", 0, ()),
-        ("M123456781", 0, ()),
+        ("A123456787", 0, ()),
+        ("M123456789", 0, ()),
         # Invalid: starts with digit instead of letter
-        ("1123456787", 0, ()),
+        ("1123456780", 0, ()),
         # Lowercase: Presidio uses global IGNORECASE; validate_result calls .upper()
         # so a valid lowercase KVNR is matched and validated correctly
-        ("a123456787", 1, ((0, 10),)),
+        ("a123456780", 1, ((0, 10),)),
         # Too short (9 chars)
         ("A12345678",  0, ()),
         # Too long (11 chars)
@@ -68,20 +78,28 @@ def test_when_all_de_health_insurance_numbers_then_succeed(
 @pytest.mark.parametrize(
     "number, expected",
     [
-        # Valid
-        ("A123456787", True),
-        ("M123456789", True),
-        ("B123456787", True),
+        # Valid – official § 290 SGB V Anlage 1 samples
+        ("A000500015", True),
+        ("C000500021", True),
+        # Valid – pre-computed fixtures
+        ("A123456780", True),
+        ("M123456785", True),
+        ("B123456782", True),
+        # Edge: letter Z (=26) exercises upper-bound ordinal; all-9 data
+        # forces Quersumme on 7 of 10 products
+        ("Z000000005", True),
+        ("Z999999997", True),
         # Wrong check digit
-        ("A123456780", False),
-        ("M123456781", False),
+        ("A123456787", False),
+        ("M123456789", False),
+        ("A000500010", False),
         # Starts with digit (after .upper() it's still a digit → re.match fails)
-        ("1123456787", False),
+        ("1123456780", False),
         # Wrong length
         ("A12345678",  False),
         ("A1234567890", False),
         # Lowercase: .upper() converts to valid → True (IGNORECASE is global)
-        ("a123456787", True),
+        ("a123456780", True),
     ],
 )
 def test_when_de_health_insurance_validated_then_checksum_result_is_correct(


### PR DESCRIPTION
## Change Description
                                                                                                                                                 
Corrects the KVNR (`DE_HEALTH_INSURANCE`) Prüfziffer algorithm introduced in #1909. The previous implementation applied weights `[2,9,8,7,6,5,4,3,2,1]`, which is not the algorithm defined in § 290 SGB V Anlage 1 (GKV-Spitzenverband, Stand 02.01.2023). The spec uses alternating factors `[1,2,1,2,1,2,1,2,1,2]` on the 10 effective digits (2-digit letter ordinal + 8 data digits), takes the Quersumme of any product ≥ 10, and compares `sum mod 10` against the check digit at position 10.                                                                  
                                                                                                                                                 
Worked examples from Anlage 1 (both now in the fixtures):                                                                                        
- `A000500015` → A=01, expanded `0100050001`, products `0,2,0,0,0,10,0,0,0,2`, cross-sums `0,2,0,0,0,1,0,0,0,2` = 5 → PZ 5 ✓
- `C000500021` → C=03, expanded `0300050002`, products `0,6,0,0,0,10,0,0,0,4`, cross-sums `0,6,0,0,0,1,0,0,0,4` = 11 → 11 mod 10 = 1 → PZ 1 ✓

The three previous "valid" fixtures (`A123456787`, `M123456789`, `B123456787`) were generated with the wrong algorithm and never satisfied the spec; they are moved to the negative-case set and replaced with the two Anlage 1 samples plus three recomputed fixtures (`A123456780`, `B123456782`, `M123456785`) and two edge-case fixtures (`Z000000005` for the upper-bound letter ordinal, `Z999999997` for worst-case Quersumme density).

Files changed:
- `presidio-analyzer/.../germany/de_health_insurance_recognizer.py` — algorithm + docstring
- `presidio-analyzer/tests/test_de_health_insurance_recognizer.py` — fixtures + 4 new edge-case parameters
- `docs/recipes/german-language-support/README.md` — sample text updated to a valid KVNR
- `CHANGELOG.md` — entry under `[unreleased] → Analyzer → Fixed`

### Verification
- `ruff check .` clean
- `poetry run pytest` in `presidio-analyzer` (Python 3.13, all extras): **1952 passed, 12 skipped, 0 failed**
- `tests/test_de_health_insurance_recognizer.py`: **29/29 pass** (all branches of `validate_result` covered, plus Z-letter upper bound and worst-case Quersumme density)
- Sibling DE recognizers (`test_de_*.py`): 158/158 pass, unaffected

### Reference

§ 290 SGB V Anlage 1 (Stand 02.01.2023): https://www.gkv-datenaustausch.de/media/dokumente/kvnr/Anlage_1_20230102_Pruefziffernberechnung-KVNR.pdf

## Issue reference

Fixes #1972

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required