### PR TITLE
Add dependency groups for Docker and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -151,7 +151,10 @@ updates:
       # Allow only patch/micro and digest updates for python; block major and minor version bumps
       - dependency-name: "python"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      
+    groups:
+      docker-deps:
+        patterns: ["*"]
+
   - package-ecosystem: "docker"
     directory: "/presidio-anonymizer"
     schedule:
@@ -164,7 +167,10 @@ updates:
       # Allow only patch/micro and digest updates for python; block major and minor version bumps
       - dependency-name: "python"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      
+    groups:
+      docker-deps:
+        patterns: ["*"]
+
   - package-ecosystem: "docker"
     directory: "/presidio-image-redactor"
     schedule:
@@ -177,7 +183,10 @@ updates:
       # Allow only patch/micro and digest updates for python; block major and minor version bumps
       - dependency-name: "python"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      
+    groups:
+      docker-deps:
+        patterns: ["*"]
+
   - package-ecosystem: "docker-compose"
     directory: "/"
     schedule:
@@ -195,3 +204,6 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      actions-deps:
+        patterns: ["*"]


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to introduce dependency grouping for Docker, Docker Compose, and GitHub Actions dependencies. Grouping dependencies allows Dependabot to batch related updates into a single pull request, making dependency management more streamlined and reducing noise from individual PRs.

