### PR TITLE
feat: add Turkish National ID (TR_NATIONAL_ID) recognizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 
 - Added recognizer for Swedish Organisationsnummer, ID number for all Swedish oragnisations.
 
+- Turkish PII recognizer for `TR_NATIONAL_ID` (TCKN) to identify Turkish National Identification Numbers using pattern match, context, and NVI checksum validation. Disabled by default.
+
 ## [2.2.362] - 2026-03-15
 ### General
 #### Added

--- a/docs/supported_entities.md
+++ b/docs/supported_entities.md
@@ -136,6 +136,12 @@ For more information, refer to the [adding new recognizers documentation](analyz
 |------------|---------------------------------------------------------------------------------------------------------|------------------------------------------|
 | TH_TNIN    | The Thai National ID Number (TNIN) is a unique 13-digit number issued to all Thai residents. | Pattern match, context and custom logic. |
 
+### Turkey
+
+| FieldType  | Description                                                                                             | Detection Method                         |
+|------------|---------------------------------------------------------------------------------------------------------|------------------------------------------|
+| TR_NATIONAL_ID    | The Turkish National Identification Number (TCKN) is a unique 11-digit number issued to all Turkish citizens. | Pattern match, context and checksum. |
+
 ### Germany
 
 | Entity Type | Description | Detection Method |

--- a/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
+++ b/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
@@ -254,6 +254,12 @@ recognizers:
     type: predefined
     enabled: false
 
+  - name: TrNationalIdRecognizer
+    supported_languages:
+    - tr
+    type: predefined
+    enabled: false
+
   - name: HuggingFaceNerRecognizer
     supported_languages:
     - en

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
@@ -95,6 +95,11 @@ from .country_specific.sweden.se_personnummer_recognizer import SePersonnummerRe
 # Thai recognizers
 from .country_specific.thai.th_tnin_recognizer import ThTninRecognizer
 
+# Turkey recognizers
+from .country_specific.turkey.tr_national_id_recognizer import (
+    TrNationalIdRecognizer,
+)
+
 # UK recognizers
 from .country_specific.uk.uk_driving_licence_recognizer import (
     UkDrivingLicenceRecognizer,
@@ -226,6 +231,7 @@ __all__ = [
     "KrFrnRecognizer",
     "SeOrganisationsnummerRecognizer",
     "ThTninRecognizer",
+    "TrNationalIdRecognizer",
     "SePersonnummerRecognizer",
     "LangExtractRecognizer",
     "AzureOpenAILangExtractRecognizer",

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/turkey/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/turkey/__init__.py
@@ -1,0 +1,7 @@
+"""Turkey-specific recognizers."""
+
+from .tr_national_id_recognizer import TrNationalIdRecognizer
+
+__all__ = [
+    "TrNationalIdRecognizer",
+]

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/turkey/tr_national_id_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/turkey/tr_national_id_recognizer.py
@@ -1,0 +1,107 @@
+from typing import List, Optional, Tuple, Union
+
+from presidio_analyzer import EntityRecognizer, Pattern, PatternRecognizer
+
+
+class TrNationalIdRecognizer(PatternRecognizer):
+    """
+    Recognize Turkish National Identification Number (TC Kimlik No / TCKN).
+
+    The Turkish National ID is an 11-digit number where:
+    - First digit cannot be 0
+    - 10th digit = (sum_of_odd_positions * 7 - sum_of_even_positions) % 10
+    - 11th digit = (sum of first 10 digits) % 10
+
+    Checksum validation based on the official Nüfus ve Vatandaşlık İşleri
+    Genel Müdürlüğü (NVI) algorithm, referenced in KVKK compliance guidelines.
+
+    :param patterns: List of patterns to be used by this recognizer
+    :param context: List of context words to increase confidence in detection
+    :param supported_language: Language this recognizer supports
+    :param supported_entity: The entity this recognizer can detect
+    :param replacement_pairs: List of tuples with potential replacement values
+    for different strings to be used during pattern matching.
+    """
+
+    PATTERNS = [
+        Pattern(
+            "TR_NATIONAL_ID",
+            r"\b[1-9][0-9]{10}\b",
+            0.3,
+        ),
+    ]
+
+    CONTEXT = [
+        "tc kimlik",
+        "kimlik no",
+        "kimlik numarası",
+        "tckn",
+        "tc no",
+        "nüfus cüzdanı",
+        "national id",
+        "turkish id",
+        "türk kimlik",
+    ]
+
+    def __init__(
+        self,
+        patterns: Optional[List[Pattern]] = None,
+        context: Optional[List[str]] = None,
+        supported_language: str = "tr",
+        supported_entity: str = "TR_NATIONAL_ID",
+        replacement_pairs: Optional[List[Tuple[str, str]]] = None,
+        name: Optional[str] = None,
+    ):
+        self.replacement_pairs = replacement_pairs if replacement_pairs else []
+
+        patterns = patterns if patterns else self.PATTERNS
+        context = context if context else self.CONTEXT
+        super().__init__(
+            supported_entity=supported_entity,
+            patterns=patterns,
+            context=context,
+            supported_language=supported_language,
+            name=name,
+        )
+
+    def validate_result(self, pattern_text: str) -> Union[bool, None]:
+        """
+        Validate the pattern logic by running checksum on a detected pattern.
+
+        :param pattern_text: the text to validated.
+        Only the part in text that was detected by the regex engine
+        :return: A bool or None, indicating whether the validation was successful.
+        """
+        sanitized_value = EntityRecognizer.sanitize_value(
+            pattern_text, self.replacement_pairs
+        )
+
+        if len(sanitized_value) != 11 or not sanitized_value.isdigit():
+            return False
+
+        if sanitized_value[0] == "0":
+            return False
+
+        return self._validate_checksum(sanitized_value)
+
+    def _validate_checksum(self, tckn: str) -> bool:
+        """
+        Validate Turkish National ID using the official NVI checksum algorithm.
+
+        :param tckn: The TCKN to validate
+        :return: True if checksum is valid, False otherwise
+        """
+        digits = [int(d) for d in tckn]
+
+        odd_sum = sum(digits[i] for i in range(0, 9, 2))
+        even_sum = sum(digits[i] for i in range(1, 8, 2))
+
+        tenth = (odd_sum * 7 - even_sum) % 10
+        if tenth != digits[9]:
+            return False
+
+        eleventh = sum(digits[:10]) % 10
+        if eleventh != digits[10]:
+            return False
+
+        return True

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/turkey/tr_national_id_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/turkey/tr_national_id_recognizer.py
@@ -14,6 +14,7 @@ class TrNationalIdRecognizer(PatternRecognizer):
 
     Checksum validation based on the official Nüfus ve Vatandaşlık İşleri
     Genel Müdürlüğü (NVI) algorithm, referenced in KVKK compliance guidelines.
+    See: https://tckimlik.nvi.gov.tr/ (NVİ official service portal)
 
     :param patterns: List of patterns to be used by this recognizer
     :param context: List of context words to increase confidence in detection

--- a/presidio-analyzer/tests/test_tr_national_id_recognizer.py
+++ b/presidio-analyzer/tests/test_tr_national_id_recognizer.py
@@ -1,0 +1,171 @@
+"""Tests for Turkish National ID (TCKN) recognizer."""
+
+import pytest
+from presidio_analyzer.predefined_recognizers import TrNationalIdRecognizer
+
+from tests import assert_result_within_score_range
+
+
+@pytest.fixture(scope="module")
+def recognizer():
+    """Create a Turkish TCKN recognizer instance for testing."""
+    return TrNationalIdRecognizer()
+
+
+@pytest.fixture(scope="module")
+def entities():
+    """Return the Turkish TCKN entity type for testing."""
+    return ["TR_NATIONAL_ID"]
+
+
+@pytest.mark.parametrize(
+    "text, expected_len, expected_positions, expected_score_ranges",
+    [
+        # Valid TCKNs with correct checksum
+        ("10000000146", 1, ((0, 11),), ((0.5, 1.0),),),
+        ("76543210794", 1, ((0, 11),), ((0.5, 1.0),),),
+        ("36493665440", 1, ((0, 11),), ((0.5, 1.0),),),
+        ("53857632436", 1, ((0, 11),), ((0.5, 1.0),),),
+        ("94357219628", 1, ((0, 11),), ((0.5, 1.0),),),
+        ("79059236630", 1, ((0, 11),), ((0.5, 1.0),),),
+        ("64625294480", 1, ((0, 11),), ((0.5, 1.0),),),
+        # Valid TCKNs in sentences
+        (
+            "TC Kimlik No: 10000000146",
+            1,
+            ((14, 25),),
+            ((0.5, 1.0),),
+        ),
+        (
+            "Başvuru sahibinin TCKN numarası 10000000146 olarak tescil edilmiştir.",
+            1,
+            ((32, 43),),
+            ((0.5, 1.0),),
+        ),
+        # Multiple valid TCKNs
+        (
+            "Birinci kişi: 10000000146, ikinci kişi: 76543210794",
+            2,
+            ((14, 25), (40, 51),),
+            ((0.5, 1.0), (0.5, 1.0),),
+        ),
+        # Invalid TCKNs - first digit is 0
+        ("00000000000", 0, (), (),),
+        ("02531814694", 0, (), (),),  # first digit 0, rest mathematically plausible
+        # Invalid TCKNs - wrong 10th digit checksum
+        ("12345678900", 0, (), (),),
+        ("76543210780", 0, (), (),),
+        ("83219500748", 0, (), (),),  # 10th digit wrong, single-digit mismatch
+        ("11798724308", 0, (), (),),  # random entry, both 10th and 11th wrong
+        # Invalid TCKNs - correct 10th digit but wrong 11th digit
+        ("10000000145", 0, (), (),),
+        ("62286775983", 0, (), (),),  # 10th correct, 11th wrong
+        ("97485249605", 0, (), (),),  # OCR/typo scenario, single digit off
+        # Invalid TCKNs - wrong length
+        ("1234567890", 0, (), (),),
+        ("123456789012", 0, (), (),),
+        # Invalid TCKNs - non-digits
+        ("abcdefghijk", 0, (), (),),
+        # Context enhancement
+        (
+            "Turkish ID 10000000146",
+            1,
+            ((11, 22),),
+            ((0.5, 1.0),),
+        ),
+        (
+            "Türk kimlik numarası 36493665440",
+            1,
+            ((21, 32),),
+            ((0.5, 1.0),),
+        ),
+    ],
+)
+def test_when_tckn_in_text_then_all_tckns_found(
+    text,
+    expected_len,
+    expected_positions,
+    expected_score_ranges,
+    recognizer,
+    entities,
+    max_score,
+):
+    """Test that Turkish TCKN recognizer correctly identifies TCKNs."""
+    results = recognizer.analyze(text, entities)
+    assert len(results) == expected_len
+
+    for res, (st_pos, fn_pos), (st_score, fn_score) in zip(
+        results, expected_positions, expected_score_ranges
+    ):
+        if fn_score == "max":
+            fn_score = max_score
+        assert_result_within_score_range(
+            res, entities[0], st_pos, fn_pos, st_score, fn_score
+        )
+
+
+def test_validate_result_with_valid_tckn(recognizer):
+    """Test validate_result method with valid TCKNs."""
+    assert recognizer.validate_result("10000000146") is True
+    assert recognizer.validate_result("76543210794") is True
+    assert recognizer.validate_result("36493665440") is True
+    assert recognizer.validate_result("53857632436") is True
+    assert recognizer.validate_result("94357219628") is True
+    assert recognizer.validate_result("79059236630") is True
+    assert recognizer.validate_result("64625294480") is True
+
+
+def test_validate_result_with_invalid_first_digit(recognizer):
+    """Test validate_result method with TCKNs starting with 0."""
+    assert recognizer.validate_result("00000000000") is False
+    assert recognizer.validate_result("02531814694") is False
+
+
+def test_validate_result_with_wrong_checksum(recognizer):
+    """Test validate_result method with wrong checksum."""
+    # 10th digit wrong
+    assert recognizer.validate_result("12345678900") is False
+    assert recognizer.validate_result("76543210780") is False
+    assert recognizer.validate_result("83219500748") is False
+    assert recognizer.validate_result("11798724308") is False
+    # 10th digit correct but 11th digit wrong
+    assert recognizer.validate_result("10000000145") is False
+    assert recognizer.validate_result("62286775983") is False
+    assert recognizer.validate_result("97485249605") is False
+
+
+def test_validate_result_with_wrong_length(recognizer):
+    """Test validate_result method with wrong length."""
+    assert recognizer.validate_result("1234567890") is False
+    assert recognizer.validate_result("123456789012") is False
+
+
+def test_validate_result_with_non_digits(recognizer):
+    """Test validate_result method with non-digit characters."""
+    assert recognizer.validate_result("abcdefghijk") is False
+
+
+def test_context_words(recognizer):
+    """Test that context words are properly set."""
+    expected_context = [
+        "tc kimlik",
+        "kimlik no",
+        "kimlik numarası",
+        "tckn",
+        "tc no",
+        "nüfus cüzdanı",
+        "national id",
+        "turkish id",
+        "türk kimlik",
+    ]
+    assert recognizer.context == expected_context
+
+
+def test_supported_entity(recognizer):
+    """Test that supported entity is correctly set."""
+    assert recognizer.supported_entities == ["TR_NATIONAL_ID"]
+
+
+def test_supported_language(recognizer):
+    """Test that supported language is correctly set."""
+    assert recognizer.supported_language == "tr"


### PR DESCRIPTION
Adds Turkish National ID (TCKN / TC Kimlik Numarası) recognizer to Presidio Analyzer.

The TCKN is an 11-digit identification number issued to Turkish citizens and foreign residents. It is the primary PII under Turkish KVKK (Personal Data Protection Law).

**Features:**
- Pattern recognition for 11-digit numbers starting with 1-9
- Algorithmic validation of 10th and 11th digits per official NVI specification
- Context words for higher confidence detection (TC Kimlik, TCKN, etc.)
- Disabled by default as per country-specific recognizer guidelines

## Issue reference
Part of #1973

## Testing
- Added `test_tr_national_id_recognizer.py` with >=90% coverage on changed lines
- Tests include valid checksums, invalid checksums, and false positive checks (short/long inputs, non-digits)
- All existing tests continue to pass

## Checklist
- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] My code follows the project style guidelines (ruff, pytest)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the CHANGELOG.md under the Unreleased section
- [x] I have updated the supported_entities.md documentation
- [x] I have added my recognizer to `default_recognizers.yaml` with `enabled: false`
- [x] I have added my recognizer to `__init__.py` and `__all__`
