### PR TITLE
Fix incorrect PESEL checksum validation in PlPeselRecognizer

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/poland/pl_pesel_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/poland/pl_pesel_recognizer.py
@@ -44,10 +44,15 @@ class PlPeselRecognizer(PatternRecognizer):
         )
 
     def validate_result(self, pattern_text: str) -> bool:  # noqa: D102
+        if len(pattern_text) != 11 or not pattern_text.isdigit():
+            return False
+
         digits = [int(digit) for digit in pattern_text]
         weights = [1, 3, 7, 9, 1, 3, 7, 9, 1, 3]
 
-        checksum = sum(digit * weight for digit, weight in zip(digits[:10], weights))
-        checksum %= 10
+        weighted_sum = sum(d * w for d, w in zip(digits[:10], weights))
+        # PESEL check digit = (10 - weighted_sum % 10) % 10. See
+        # https://en.wikipedia.org/wiki/PESEL#Check_digit
+        check_digit = (10 - weighted_sum % 10) % 10
 
-        return checksum == digits[10]
+        return check_digit == digits[10]

--- a/presidio-analyzer/tests/test_pl_pesel_recognizer.py
+++ b/presidio-analyzer/tests/test_pl_pesel_recognizer.py
@@ -18,12 +18,20 @@ def entities():
     "text, expected_len, expected_positions",
     [
         # fmt: off
-        # valid PESEL scores
-        ("11111111114", 1, ((0, 11),),),
-        ("My pesel is 11111111114.", 1, ((12, 23), )),
-        # invalid PESEL scores
+        # Valid PESEL numbers — these pass both the regex (encoded date of birth)
+        # and the check-digit algorithm: check = (10 - weighted_sum % 10) % 10.
+        # See https://en.wikipedia.org/wiki/PESEL#Check_digit
+        ("44051401458", 1, ((0, 11),),),
+        ("My pesel is 44051401458.", 1, ((12, 23),)),
+        ("02070803628", 1, ((0, 11),),),
+        ("11111111116", 1, ((0, 11),),),
+        # Invalid: check digit does not match the weighted sum
+        ("44051401459", 0, ()),
+        ("85040812345", 0, ()),
+        # Invalid: regex rejects illegal month/day encodings
         ("1111321111", 0, ()),
         ("11110021111", 0, ()),
+        # Invalid: hyphen-separated groups are not a PESEL format
         ("11-11-11-11114", 0, ()),
         # fmt: on
     ],
@@ -35,3 +43,25 @@ def test_when_all_pl_pesels_then_succeed(
     assert len(results) == expected_len
     for res, (st_pos, fn_pos) in zip(results, expected_positions):
         assert_result(res, entities[0], st_pos, fn_pos, max_score)
+
+
+@pytest.mark.parametrize(
+    "pesel, expected",
+    [
+        # Real-world and algorithmically-generated valid PESEL numbers
+        ("44051401458", True),
+        ("02070803628", True),
+        ("11111111116", True),
+        # Wrong check digit
+        ("44051401459", False),
+        ("85040812345", False),
+        # Wrong length
+        ("4405140145", False),
+        ("440514014588", False),
+        # Non-digit characters
+        ("4405140145A", False),
+        ("44-051401458", False),
+    ],
+)
+def test_validate_result_checksum(pesel, expected, recognizer):
+    assert recognizer.validate_result(pesel) is expected


### PR DESCRIPTION
## Change Description

The Polish PESEL check-digit algorithm is `check = (10 - weighted_sum % 10) % 10`
(see https://en.wikipedia.org/wiki/PESEL#Check_digit), but
`PlPeselRecognizer.validate_result` currently compares the raw
`weighted_sum % 10` to the check digit, which rejects real valid PESEL numbers.

Example — `44051401458` is the canonical example used in official Polish
documentation and is algorithmically valid, but today:

```python
>>> from presidio_analyzer.predefined_recognizers import PlPeselRecognizer
>>> PlPeselRecognizer().validate_result("44051401458")
False   # expected True
```

This PR:

- Corrects the check-digit formula.
- Guards against non-11-digit / non-numeric inputs (previously would raise
  `IndexError` on a regex-produced string shorter than 11).
- Replaces the existing test fixtures — which were generated using the buggy
  formula and would not pass real-world PESEL validators — with PESEL numbers
  that are valid under the true algorithm, plus negative cases covering wrong
  check digits, wrong length, and non-digit input.

The previous "valid" fixture `11111111114` has a real check digit of `6`, not
`4`. The updated fixtures (`44051401458`, `02070803628`, `11111111116`) verify
against the actual PESEL standard.

## Issue reference

This completes the work started in #1520 (closed on 2025-06-01 due to missing
tests). Attribution to the original author @BlaiseCz for the analysis.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)   *(will sign when CLA bot prompts)*
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally (`pytest tests/test_pl_pesel_recognizer.py` → 18 passed)
- [ ] My PR contains documentation updates / additions if required