### PR TITLE
fix: Preserve GLiNER config fields through Pydantic validation

### DIFF
--- a/presidio-analyzer/presidio_analyzer/input_validation/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/input_validation/__init__.py
@@ -5,6 +5,8 @@ from .schemas import ConfigurationValidator
 from .yaml_recognizer_models import (
     BaseRecognizerConfig,
     CustomRecognizerConfig,
+    GLiNERRecognizerConfig,
+    HuggingFaceRecognizerConfig,
     LanguageContextConfig,
     PredefinedRecognizerConfig,
     RecognizerRegistryConfig,
@@ -15,6 +17,8 @@ __all__ = [
     "ConfigurationValidator",
     "BaseRecognizerConfig",
     "CustomRecognizerConfig",
+    "GLiNERRecognizerConfig",
+    "HuggingFaceRecognizerConfig",
     "LanguageContextConfig",
     "PredefinedRecognizerConfig",
     "RecognizerRegistryConfig",

--- a/presidio-analyzer/presidio_analyzer/input_validation/yaml_recognizer_models.py
+++ b/presidio-analyzer/presidio_analyzer/input_validation/yaml_recognizer_models.py
@@ -175,6 +175,16 @@ class HuggingFaceRecognizerConfig(PredefinedRecognizerConfig):
         default=None, description="Prefixes to strip from labels (e.g. B-, I-)"
     )
 
+    def model_dump(self, *args, **kwargs) -> Dict[str, Any]:
+        """Serialize the config without None values by default.
+
+        HuggingFace recognizer kwargs are passed directly to the recognizer constructor.
+        Excluding None values preserves constructor defaults for omitted YAML fields
+        instead of overriding them with explicit None.
+        """
+        kwargs.setdefault("exclude_none", True)
+        return super().model_dump(*args, **kwargs)
+
 
 class GLiNERRecognizerConfig(PredefinedRecognizerConfig):
     """Configuration specifically for GLiNER models."""

--- a/presidio-analyzer/presidio_analyzer/input_validation/yaml_recognizer_models.py
+++ b/presidio-analyzer/presidio_analyzer/input_validation/yaml_recognizer_models.py
@@ -157,7 +157,7 @@ class PredefinedRecognizerConfig(BaseRecognizerConfig):
 class HuggingFaceRecognizerConfig(PredefinedRecognizerConfig):
     """Configuration specifically for HuggingFace NER models."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="allow")
 
     model_name: Optional[str] = Field(None, description="HuggingFace model name")
     tokenizer_name: Optional[str] = Field(
@@ -189,7 +189,7 @@ class HuggingFaceRecognizerConfig(PredefinedRecognizerConfig):
 class GLiNERRecognizerConfig(PredefinedRecognizerConfig):
     """Configuration specifically for GLiNER models."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="allow")
 
     model_name: Optional[str] = Field(None, description="GLiNER model name")
     flat_ner: Optional[bool] = Field(None, description="Use flat NER")

--- a/presidio-analyzer/presidio_analyzer/input_validation/yaml_recognizer_models.py
+++ b/presidio-analyzer/presidio_analyzer/input_validation/yaml_recognizer_models.py
@@ -176,6 +176,23 @@ class HuggingFaceRecognizerConfig(PredefinedRecognizerConfig):
     )
 
 
+class GLiNERRecognizerConfig(PredefinedRecognizerConfig):
+    """Configuration specifically for GLiNER models."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model_name: Optional[str] = Field(None, description="GLiNER model name")
+    flat_ner: Optional[bool] = Field(None, description="Use flat NER")
+    multi_label: Optional[bool] = Field(
+        None, description="Use multi-label classification"
+    )
+    threshold: Optional[float] = Field(None, description="Confidence threshold")
+    map_location: Optional[str] = Field(None, description="Device (cpu/gpu/etc.)")
+    load_onnx_model: Optional[bool] = Field(None, description="Load ONNX model")
+    onnx_model_file: Optional[str] = Field(None, description="ONNX model file name")
+    entity_mapping: Optional[Dict[str, str]] = Field(None, description="Entity mapping")
+
+
 class CustomRecognizerConfig(BaseRecognizerConfig):
     """Configuration for custom pattern-based recognizers."""
 
@@ -463,4 +480,5 @@ class RecognizerRegistryConfig(BaseModel):
 # This allows for modular expansion without polluting the base config
 CONFIG_MODEL_MAP: Dict[str, Type[BaseModel]] = {
     "HuggingFaceNerRecognizer": HuggingFaceRecognizerConfig,
+    "GLiNERRecognizer": GLiNERRecognizerConfig,
 }

--- a/presidio-analyzer/presidio_analyzer/input_validation/yaml_recognizer_models.py
+++ b/presidio-analyzer/presidio_analyzer/input_validation/yaml_recognizer_models.py
@@ -192,6 +192,27 @@ class GLiNERRecognizerConfig(PredefinedRecognizerConfig):
     onnx_model_file: Optional[str] = Field(None, description="ONNX model file name")
     entity_mapping: Optional[Dict[str, str]] = Field(None, description="Entity mapping")
 
+    @model_validator(mode="after")
+    def validate_entity_mapping_and_supported_entities(self):
+        """Validate that entity_mapping and supported_entities are not both set."""
+        if self.entity_mapping is not None and self.supported_entities is not None:
+            raise ValueError(
+                "GLiNER recognizer configuration cannot define both "
+                "'entity_mapping' and 'supported_entities'; these fields are "
+                "mutually exclusive."
+            )
+        return self
+
+    def model_dump(self, *args, **kwargs) -> Dict[str, Any]:
+        """Serialize the config without None values by default.
+
+        GLiNER recognizer kwargs are passed directly to the recognizer constructor.
+        Excluding None values preserves constructor defaults for omitted YAML fields
+        instead of overriding them with explicit None.
+        """
+        kwargs.setdefault("exclude_none", True)
+        return super().model_dump(*args, **kwargs)
+
 
 class CustomRecognizerConfig(BaseRecognizerConfig):
     """Configuration for custom pattern-based recognizers."""

--- a/presidio-analyzer/tests/test_yaml_recognizer_models.py
+++ b/presidio-analyzer/tests/test_yaml_recognizer_models.py
@@ -696,6 +696,26 @@ def test_gliner_recognizer_config_entity_mapping_and_supported_entities_mutually
         )
 
 
+def test_huggingface_recognizer_config_model_dump_excludes_none():
+    """Test that HuggingFaceRecognizerConfig.model_dump excludes None fields by default."""
+    from presidio_analyzer.input_validation.yaml_recognizer_models import (
+        HuggingFaceRecognizerConfig,
+    )
+
+    config = HuggingFaceRecognizerConfig(
+        name="HuggingFaceNerRecognizer",
+        supported_language="en",
+        model_name="custom/ner-model",
+    )
+    dumped = config.model_dump()
+    assert "model_name" in dumped
+    assert dumped["model_name"] == "custom/ner-model"
+    # Fields not provided should be excluded, not set to None
+    assert "tokenizer_name" not in dumped
+    assert "threshold" not in dumped
+    assert "label_mapping" not in dumped
+
+
 def test_config_model_map_fallback_to_predefined():
     """Test CONFIG_MODEL_MAP falls back to Predefined for unknown class_name."""
     from presidio_analyzer.input_validation.yaml_recognizer_models import (

--- a/presidio-analyzer/tests/test_yaml_recognizer_models.py
+++ b/presidio-analyzer/tests/test_yaml_recognizer_models.py
@@ -658,6 +658,44 @@ def test_gliner_recognizer_config_model_name():
     assert recognizer.multi_label is True
 
 
+def test_gliner_recognizer_config_model_dump_excludes_none():
+    """Test that GLiNERRecognizerConfig.model_dump excludes None fields by default."""
+    from presidio_analyzer.input_validation.yaml_recognizer_models import (
+        GLiNERRecognizerConfig,
+    )
+
+    config = GLiNERRecognizerConfig(
+        name="GLiNERRecognizer",
+        supported_language="en",
+        model_name="custom/gliner-model",
+    )
+    dumped = config.model_dump()
+    assert "model_name" in dumped
+    assert dumped["model_name"] == "custom/gliner-model"
+    # Fields not provided should be excluded, not set to None
+    assert "flat_ner" not in dumped
+    assert "threshold" not in dumped
+    assert "entity_mapping" not in dumped
+
+
+def test_gliner_recognizer_config_entity_mapping_and_supported_entities_mutually_exclusive():
+    """Test that entity_mapping and supported_entities cannot both be set."""
+    import pytest
+    from pydantic import ValidationError
+
+    from presidio_analyzer.input_validation.yaml_recognizer_models import (
+        GLiNERRecognizerConfig,
+    )
+
+    with pytest.raises(ValidationError, match="mutually exclusive"):
+        GLiNERRecognizerConfig(
+            name="GLiNERRecognizer",
+            supported_language="en",
+            entity_mapping={"person": "PERSON"},
+            supported_entities=["PERSON"],
+        )
+
+
 def test_config_model_map_fallback_to_predefined():
     """Test CONFIG_MODEL_MAP falls back to Predefined for unknown class_name."""
     from presidio_analyzer.input_validation.yaml_recognizer_models import (

--- a/presidio-analyzer/tests/test_yaml_recognizer_models.py
+++ b/presidio-analyzer/tests/test_yaml_recognizer_models.py
@@ -627,6 +627,37 @@ def test_recognizer_registry_config_custom_name_with_hf_class():
     assert recognizer.model_name == "TestModel/Ner"
 
 
+def test_gliner_recognizer_config_model_name():
+    """Test that GLiNERRecognizer model_name is preserved through config validation."""
+    from presidio_analyzer.input_validation.yaml_recognizer_models import (
+        GLiNERRecognizerConfig,
+        RecognizerRegistryConfig,
+    )
+
+    registry_config = {
+        "recognizers": [
+            {
+                "name": "GLiNERRecognizer",
+                "type": "predefined",
+                "supported_language": "en",
+                "model_name": "custom/gliner-model",
+                "threshold": 0.5,
+                "flat_ner": False,
+                "multi_label": True,
+            }
+        ]
+    }
+
+    config = RecognizerRegistryConfig(**registry_config)
+    recognizer = config.recognizers[0]
+
+    assert isinstance(recognizer, GLiNERRecognizerConfig)
+    assert recognizer.model_name == "custom/gliner-model"
+    assert recognizer.threshold == 0.5
+    assert recognizer.flat_ner is False
+    assert recognizer.multi_label is True
+
+
 def test_config_model_map_fallback_to_predefined():
     """Test CONFIG_MODEL_MAP falls back to Predefined for unknown class_name."""
     from presidio_analyzer.input_validation.yaml_recognizer_models import (


### PR DESCRIPTION
## Change Description

Add GLiNERRecognizerConfig to the YAML recognizer config model and register it in `CONFIG_MODEL_MAP`, so that model_name and other GLiNER-specific fields (`flat_ner`, `threshold`, `multi_label`, `map_location`, `load_onnx_model`, `onnx_model_file`, `entity_mapping`) are preserved through Pydantic validation when loading recognizer configuration from YAML.                                            
                                                                                                                                    
**Root cause**: When parsing a GLiNERRecognizer entry from YAML, parse_recognizers looked up "GLiNERRecognizer" in `CONFIG_MODEL_MAP` and found nothing, falling back to PredefinedRecognizerConfig. Since that class has no model_name field and Pydantic's default is to ignore extra fields, `model_name` (and all other GLiNER params) were silently dropped. The recognizer would then always load the hardcoded default model (`urchade/gliner_multi_pii-v1`) regardless of what was specified in config.  HuggingFaceNerRecognizer already had this handled correctly via HuggingFaceRecognizerConfig.

## Issue reference

Fixes #XX

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
