### PR TITLE
Phonenumber configurable entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 
 - Added recognizer for Swedish Organisationsnummer, ID number for all Swedish oragnisations.
 
+- Added `supported_entity` parameter to `PhoneRecognizer`. Previously, this recognizer hard-coded `["PHONE_NUMBER"]` as the only possible supported entity.
+
 #### Fixed
 - Fixed incorrect Prüfziffer algorithm in `DeHealthInsuranceRecognizer` (KVNR); now uses alternating factors [1,2,…,1,2] per § 290 SGB V Anlage 1 (#1972).
 - Fixed incorrect check-digit weights in `DeSocialSecurityRecognizer` (RVNR); now uses VKVV § 4 weights [2,1,2,5,7,1,2,1,2,1,2,1]. Previous weights diverged from the Deutsche Rentenversicherung specification and rejected the canonical DRV example 15070649C103.

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/generic/phone_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/generic/phone_recognizer.py
@@ -31,6 +31,7 @@ class PhoneRecognizer(LocalRecognizer):
         self,
         context: Optional[List[str]] = None,
         supported_language: str = "en",
+        supported_entity: str = "PHONE_NUMBER",
         # For all regions, use phonenumbers.SUPPORTED_REGIONS
         supported_regions=DEFAULT_SUPPORTED_REGIONS,
         leniency: Optional[int] = 1,
@@ -40,7 +41,7 @@ class PhoneRecognizer(LocalRecognizer):
         self.supported_regions = supported_regions
         self.leniency = leniency
         super().__init__(
-            supported_entities=self.get_supported_entities(),
+            supported_entities=[supported_entity],
             supported_language=supported_language,
             context=context,
             name=name,
@@ -48,9 +49,6 @@ class PhoneRecognizer(LocalRecognizer):
 
     def load(self) -> None:  # noqa: D102
         pass
-
-    def get_supported_entities(self):  # noqa: D102
-        return ["PHONE_NUMBER"]
 
     def analyze(
         self, text: str, entities: List[str], nlp_artifacts: NlpArtifacts = None

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/generic/phone_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/generic/phone_recognizer.py
@@ -18,6 +18,7 @@ class PhoneRecognizer(LocalRecognizer):
      Using python-phonenumbers, along with fixed and regional context words.
     :param context: Base context words for enhancing the assurance scores.
     :param supported_language: Language this recognizer supports
+    :param supported_entity: The entity this recognizer can detect
     :param supported_regions: The regions for phone number matching and validation
     :param leniency: The strictness level of phone number formats.
     Accepts values from 0 to 3, where 0 is the lenient and 3 is the most strictest.

--- a/presidio-analyzer/tests/test_phone_recognizer.py
+++ b/presidio-analyzer/tests/test_phone_recognizer.py
@@ -144,3 +144,13 @@ def test_get_analysis_explanation():
     test_region = "US"
     explanation = phone_recognizer._get_analysis_explanation(test_region)
     assert explanation.recognizer == "PhoneRecognizer"
+
+def test_get_supported_entities():
+    default_phone_recognizer = PhoneRecognizer()
+    default_supported_entities = default_phone_recognizer.get_supported_entities()
+    assert default_supported_entities == ["PHONE_NUMBER"]
+
+    entity_name = "TELEPHONE_OR_FAX"
+    configured_phone_recognizer = PhoneRecognizer(supported_entity=entity_name)
+    configured_supported_entities = configured_phone_recognizer.get_supported_entities()
+    assert configured_supported_entities == [entity_name]


### PR DESCRIPTION
## Change Description

Make `supported_entity` a configurable parameter for the `PhoneNumber` recognizer to mirror the pattern used in `PatternRecognizer`. Previously, this recognizer hard-coded `"PHONE_NUMBER"` as the supported entity.

## Issue reference

I checked issues referencing the `PhoneNumber` recognizer and did not find any related to this change.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
