### PR TITLE
Fix anonymization typos in OpenAI deployment sample

### DIFF
--- a/docs/samples/deployments/openai-anonymaztion-and-deanonymaztion-best-practices/docs/sample_for_presidio_pr/anonymization_toolkit_sample.md
+++ b/docs/samples/deployments/openai-anonymaztion-and-deanonymaztion-best-practices/docs/sample_for_presidio_pr/anonymization_toolkit_sample.md
@@ -15,7 +15,7 @@ The toolkit serves enterprises that: Require PII to remain internal while levera
 
 ## Workflow Example
 
-The following is the desired output. We can input PII data annoymized to the LLM input and return the replaced entities back to the original in the response back to the user.
+The following is the desired output. We can input PII data anonymized to the LLM input and return the replaced entities back to the original in the response back to the user.
 
 - User Input: "Hello world, my name is Jane Doe. My number is: 034453334"
 - Anonymized LLM Input: "Hello world, my name is [PERSON]. My number is: [PHONE_NUMBER]"
@@ -36,7 +36,7 @@ TODO complete this section
 
 ### Anonymization
 
-First we need to setup our `Presidio` engines to aid with analysis, anonoymization and deanonymization.
+First we need to setup our `Presidio` engines to aid with analysis, anonymization and deanonymization.
 The following code can exist as part of a service available to the appropriate api endpoints.
 
 ```python

--- a/docs/samples/deployments/openai-anonymaztion-and-deanonymaztion-best-practices/index.md
+++ b/docs/samples/deployments/openai-anonymaztion-and-deanonymaztion-best-practices/index.md
@@ -26,7 +26,7 @@ The following sections will describe the required infrastructure and code to ach
 
 ### Workflow Example
 
-The following is the desired output. We can input PII data annoymized to the LLM input and return the replaced entities back to the original in the response back to the user.
+The following is the desired output. We can input PII data anonymized to the LLM input and return the replaced entities back to the original in the response back to the user.
 
 - User Input: "Hello world, my name is Jane Doe. My number is: 034453334"
 - Anonymized LLM Input: "Hello world, my name is [PERSON]. My number is: [PHONE_NUMBER]"
@@ -56,7 +56,7 @@ The solution consists of the following components:
 
 ### Anonymization
 
-First we need to setup our `Presidio` engines to aid with analysis, anonoymization and deanonymization.
+First we need to setup our `Presidio` engines to aid with analysis, anonymization and deanonymization.
 The following code can exist as part of a service available to the appropriate api endpoints.
 
 ```python


### PR DESCRIPTION
## Change

Fixes two spelling typos in the OpenAI anonymization/deanonymization deployment sample docs:

- `annoymized` -> `anonymized`
- `anonoymization` -> `anonymization`

The same sample content appears in both the sample docs page and its copied PR sample doc, so both files are updated consistently.

## Validation

- Ran a targeted Python assertion to confirm the misspellings no longer appear in the changed sample docs.
- Inspected the git diff for the two changed Markdown files.
