### PR TITLE
docs: remove duplicate zip code pattern in recognizer registry example

### DIFF
--- a/docs/analyzer/recognizer_registry_provider.md
+++ b/docs/analyzer/recognizer_registry_provider.md
@@ -70,9 +70,6 @@ The recognizer list comprises of both the predefined and custom recognizers, for
     - name: "zip code (weak)"
       regex: "(\\b\\d{5}(?:\\-\\d{4})?\\b)"
       score: 0.01
-    - name: "zip code (weak)"
-      regex: "(\\b\\d{5}(?:\\-\\d{4})?\\b)"
-      score: 0.01
     supported_languages:
     - language: en
       context: [zip, code]


### PR DESCRIPTION

## Change Description

The example YAML for `ExampleCustomRecognizer` on the [recognizer registry provider docs page](https://microsoft.github.io/presidio/analyzer/recognizer_registry_provider/) contains a duplicated `zip code (weak)` pattern entry (identical name, regex, and score). Removing the duplicate so the example matches the structure of the real `example_recognizers.yaml` in the repo.


