### PR TITLE
feat: add Philippine mobile number (PH_MOBILE_NUMBER) recognizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,15 @@ All notable changes to this project will be documented in this file.
 
 - Added recognizer for Spanish Passport (`ES_PASSPORT`).
 
+- Added Korean Resident Registration Number (RRN) recognizer (KrRrnRecognizer).
+
+- Added Thai National ID Number (TNIN) recognizer (ThTninRecognizer).
+
 - Added `supported_entity` parameter to `PhoneRecognizer`. Previously, this recognizer hard-coded `["PHONE_NUMBER"]` as the only possible supported entity.
 
 #### Fixed
+- Fixed an issue where the CreditCardRecognizer regex could incorrectly identify 13-digit Unix timestamps as credit card numbers. Validated that 13 digit numbers that start with `1` and have no separators (e.g. `1748503543012`) are not flagged as credit cards.
+- Enhance NlpEngineProvider with validation methods for NLP engines, configuration, and conf file path.
 - Fixed `PhoneRecognizer._get_recognizer_result` to use the constructor-provided `supported_entity` instead of the hard-coded `"PHONE_NUMBER"` string, making the `supported_entity` parameter from PR #2014 fully functional.
 - Fixed incorrect Prüfziffer algorithm in `DeHealthInsuranceRecognizer` (KVNR); now uses alternating factors [1,2,…,1,2] per § 290 SGB V Anlage 1 (#1972).
 - Fixed incorrect check-digit weights in `DeSocialSecurityRecognizer` (RVNR); now uses VKVV § 4 weights [2,1,2,5,7,1,2,1,2,1,2,1]. Previous weights diverged from the Deutsche Rentenversicherung specification and rejected the canonical DRV example 15070649C103.
@@ -38,6 +44,7 @@ All notable changes to this project will be documented in this file.
 - Turkish PII recognizer for `TR_NATIONAL_ID` (TCKN) to identify Turkish National Identification Numbers using pattern match, context, and NVI checksum validation. Disabled by default.
 - Turkish phone number detection via configurable `PhoneRecognizer` with `supported_regions=["TR"]` and `supported_entity="TR_PHONE_NUMBER"`. Supports international (+90), national (0), and local formats using the `phonenumbers` library. Disabled by default; users enable it programmatically.
 - Turkish PII recognizer for `TR_LICENSE_PLATE` (plaka) to identify Turkish vehicle license plates using pattern match, context, and province code validation (01-81). Disabled by default.
+- Added PH_MOBILE_NUMBER recognizer for Philippine mobile phone numbers using PhoneRecognizer with supported_regions=['PH'] (disabled by default).
 
 ## [2.2.362] - 2026-03-15
 ### General
@@ -802,12 +809,4 @@ New endpoint for deanonymizing encrypted entities by the anonymizer.
 [2.2.23]: https://github.com/microsoft/presidio/compare/2.2.2...2.2.23
 [2.2.2]: https://github.com/microsoft/presidio/compare/2.2.1...2.2.2
 [2.2.1]: https://github.com/microsoft/presidio/compare/2.2.0...2.2.1
-
-## Unreleased
-
-### Fixed
-- Fixed an issue where the CreditCardRecognizer regex could incorrectly identify 13-digit Unix timestamps as credit card numbers. Validated that 13 digit numbers that start with `1` and have no separators (e.g. `1748503543012`) are not flagged as credit cards.
-- Enhance NlpEngineProvider with validation methods for NLP engines, configuration, and conf file path.
-- Added Korean Resident Registration Number (RRN) recognizer (KrRrnRecognizer).
-- Added Thai National ID Number (TNIN) recognizer (ThTninRecognizer).
 

--- a/docs/supported_entities.md
+++ b/docs/supported_entities.md
@@ -145,6 +145,12 @@ For more information, refer to the [adding new recognizers documentation](analyz
 | TR_PHONE_NUMBER   | Turkish phone numbers: 10-digit numbers starting with 5 (mobile) or 2/3/4 (geographic). Supports international (+90), national (0), and local formats. Includes mobile (MNP-compliant) and geographic numbers. Reference: ITU-T E.164. Enabled programmatically via `PhoneRecognizer(supported_regions=["TR"], supported_entity="TR_PHONE_NUMBER")`. | `phonenumbers` library, context and format validation. |
 | TR_LICENSE_PLATE  | Turkish vehicle license plate (plaka): 2-digit province code (01–81), 1–3 letters (A–Z, excluding Q, W, X), and 2–4 digits. Standard civilian format only. Legal basis: KTK Madde 23. | Pattern match, context and province code validation. |
 
+### Philippines
+
+| FieldType  | Description                                                                                             | Detection Method                         |
+|------------|---------------------------------------------------------------------------------------------------------|------------------------------------------|
+| PH_MOBILE_NUMBER  | Philippine mobile phone numbers with 10-digit subscriber numbers starting with 9. Supports international (+63 9XX XXX XXXX), national (09XX XXX XXXX) formats. Reference: ITU-T E.164. Enabled programmatically via `PhoneRecognizer(supported_regions=['PH'], supported_entity='PH_MOBILE_NUMBER')`. | `phonenumbers` library, context and format validation. |
+
 ### Germany
 
 | Entity Type | Description | Detection Method |

--- a/docs/supported_entities.md
+++ b/docs/supported_entities.md
@@ -22,7 +22,7 @@ For more information, refer to the [adding new recognizers documentation](analyz
 |NRP|A person’s Nationality, religious or political group.|Custom logic and context|
 |LOCATION|Name of politically or geographically defined location (cities, provinces, countries, international regions, bodies of water, mountains|Custom logic and context|
 |PERSON|A full person name, which can include first names, middle names or initials, and last names.|Custom logic and context|
-|PHONE_NUMBER|A telephone number|Custom logic, pattern match and context|
+|PHONE_NUMBER|A telephone number. The `PhoneRecognizer` can be extended programmatically for country-specific detection by configuring `supported_regions` and `supported_entity` (e.g. Philippines: `PhoneRecognizer(supported_regions=["PH"], supported_entity="PH_MOBILE_NUMBER")`, Turkey: `PhoneRecognizer(supported_regions=["TR"], supported_entity="TR_PHONE_NUMBER")`)|Custom logic, pattern match and context|
 |MEDICAL_LICENSE|Common medical license numbers.|Pattern match, context and checksum|
 |URL|A URL (Uniform Resource Locator), unique identifier used to locate a resource on the Internet|Pattern match, context and top level url validation|
 
@@ -142,14 +142,7 @@ For more information, refer to the [adding new recognizers documentation](analyz
 | FieldType  | Description                                                                                             | Detection Method                         |
 |------------|---------------------------------------------------------------------------------------------------------|------------------------------------------|
 | TR_NATIONAL_ID    | The Turkish National Identification Number (TCKN) is a unique 11-digit number issued to all Turkish citizens. | Pattern match, context and checksum. |
-| TR_PHONE_NUMBER   | Turkish phone numbers: 10-digit numbers starting with 5 (mobile) or 2/3/4 (geographic). Supports international (+90), national (0), and local formats. Includes mobile (MNP-compliant) and geographic numbers. Reference: ITU-T E.164. Enabled programmatically via `PhoneRecognizer(supported_regions=["TR"], supported_entity="TR_PHONE_NUMBER")`. | `phonenumbers` library, context and format validation. |
 | TR_LICENSE_PLATE  | Turkish vehicle license plate (plaka): 2-digit province code (01–81), 1–3 letters (A–Z, excluding Q, W, X), and 2–4 digits. Standard civilian format only. Legal basis: KTK Madde 23. | Pattern match, context and province code validation. |
-
-### Philippines
-
-| FieldType  | Description                                                                                             | Detection Method                         |
-|------------|---------------------------------------------------------------------------------------------------------|------------------------------------------|
-| PH_MOBILE_NUMBER  | Philippine mobile phone numbers with 10-digit subscriber numbers starting with 9. Supports international (+63 9XX XXX XXXX), national (09XX XXX XXXX) formats. Reference: ITU-T E.164. Enabled programmatically via `PhoneRecognizer(supported_regions=['PH'], supported_entity='PH_MOBILE_NUMBER')`. | `phonenumbers` library, context and format validation. |
 
 ### Germany
 

--- a/presidio-analyzer/tests/test_ph_mobile_number_recognizer.py
+++ b/presidio-analyzer/tests/test_ph_mobile_number_recognizer.py
@@ -1,0 +1,158 @@
+"""Tests for Philippine mobile number (PH_MOBILE_NUMBER) recognizer."""
+
+import pytest
+from presidio_analyzer.predefined_recognizers import PhoneRecognizer
+
+from tests import assert_result_within_score_range
+
+PH_CONTEXT = [
+    "mobile",
+    "phone",
+    "cell",
+    "cellphone",
+    "telepono",
+    "numero",
+    "mobile number",
+    "contact number",
+    "numero ng telepono",
+    "contact",
+    "number",
+    "call",
+    "tawag",
+    "mensahe",
+    "sms",
+    "whatsapp",
+    "viber",
+    "telegram",
+    "signal",
+    "celphone",
+    "phone number",
+    "mobile no",
+]
+
+
+@pytest.fixture(scope="module")
+def recognizer():
+    """Create a PH-configured PhoneRecognizer instance for testing."""
+    return PhoneRecognizer(
+        supported_regions=["PH"],
+        supported_entity="PH_MOBILE_NUMBER",
+        context=PH_CONTEXT,
+        supported_language="en",
+    )
+
+
+@pytest.fixture(scope="module")
+def entities():
+    """Return the PH_MOBILE_NUMBER entity type for testing."""
+    return ["PH_MOBILE_NUMBER"]
+
+
+@pytest.mark.parametrize(
+    "text, expected_len, expected_positions, expected_score_ranges",
+    [
+        # International format (+63)
+        ("+63 917 123 4567", 1, ((0, 16),), ((0.4, 1.0),)),
+        ("+639171234567", 1, ((0, 13),), ((0.4, 1.0),)),
+        ("+63-917-123-4567", 1, ((0, 16),), ((0.4, 1.0),)),
+        ("+63 (917) 123 4567", 1, ((0, 18),), ((0.4, 1.0),)),
+        # National format (0)
+        ("09171234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("0917 123 4567", 1, ((0, 13),), ((0.3, 1.0),)),
+        ("0917-123-4567", 1, ((0, 13),), ((0.3, 1.0),)),
+        ("0 (917) 123 4567", 1, ((0, 16),), ((0.3, 1.0),)),
+        # Local format (bare number without prefix) - not reliably detected by phonenumbers for PH region
+        ("9171234567", 0, (), ()),
+        ("917 123 4567", 0, (), ()),
+        ("917-123-4567", 0, (), ()),
+        # Valid PH mobile prefixes
+        ("09171234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09181234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09191234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09201234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09211234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09271234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09281234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09291234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09301234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09391234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09471234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09491234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09561234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09611234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09661234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09671234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09771234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09941234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09951234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09961234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09971234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09981234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        ("09991234567", 1, ((0, 11),), ((0.3, 1.0),)),
+        # In sentence with context
+        (
+            "My mobile number is +639171234567.",
+            1,
+            ((20, 33),),
+            ((0.4, 1.0),),
+        ),
+        (
+            "Telepono: 09171234567",
+            1,
+            ((10, 21),),
+            ((0.3, 1.0),),
+        ),
+        (
+            "Numero: 9171234567",
+            0,
+            (),
+            (),
+        ),
+        # Multiple numbers
+        (
+            "First: +639171234567, Second: 09181234567",
+            2,
+            ((7, 20), (30, 41)),
+            ((0.4, 1.0), (0.3, 1.0)),
+        ),
+        # Invalid numbers that must not be detected as mobile (or maybe they are landline, but phonenumbers treats them as valid PH numbers but with lower score or geographic)
+        # Random 11-digit number
+        ("12345678901", 0, (), ()),
+        # Invalid: too short
+        ("0917123456", 0, (), ()),
+        # Invalid: too long (12 digits)
+        ("091712345678", 0, (), ()),
+        # False positive: embedded in longer number
+        ("15091712345678", 0, (), ()),
+        # Not a phone number
+        ("hello world", 0, (), ()),
+    ],
+)
+def test_when_phone_in_text_then_all_phones_found(
+    text,
+    expected_len,
+    expected_positions,
+    expected_score_ranges,
+    recognizer,
+    entities,
+):
+    """Test that PH mobile number recognizer correctly identifies numbers."""
+    results = recognizer.analyze(text, entities)
+    assert len(results) == expected_len
+
+    for res, (st_pos, fn_pos), (st_score, fn_score) in zip(
+        results, expected_positions, expected_score_ranges
+    ):
+        assert_result_within_score_range(
+            res, entities[0], st_pos, fn_pos, st_score, fn_score
+        )
+
+
+def test_supported_entity(recognizer):
+    """Test that supported entity is correctly set."""
+    assert recognizer.supported_entities == ["PH_MOBILE_NUMBER"]
+
+
+def test_supported_language(recognizer):
+    """Test that supported language is correctly set."""
+    assert recognizer.supported_language == "en"

--- a/presidio-analyzer/tests/test_ph_mobile_number_recognizer.py
+++ b/presidio-analyzer/tests/test_ph_mobile_number_recognizer.py
@@ -61,7 +61,8 @@ def entities():
         ("0917 123 4567", 1, ((0, 13),), ((0.3, 1.0),)),
         ("0917-123-4567", 1, ((0, 13),), ((0.3, 1.0),)),
         ("0 (917) 123 4567", 1, ((0, 16),), ((0.3, 1.0),)),
-        # Local format (bare number without prefix) - not reliably detected by phonenumbers for PH region
+        # Local format (bare number without prefix) - not reliably detected
+        # by phonenumbers for PH region
         ("9171234567", 0, (), ()),
         ("917 123 4567", 0, (), ()),
         ("917-123-4567", 0, (), ()),
@@ -115,7 +116,9 @@ def entities():
             ((7, 20), (30, 41)),
             ((0.4, 1.0), (0.3, 1.0)),
         ),
-        # Invalid numbers that must not be detected as mobile (or maybe they are landline, but phonenumbers treats them as valid PH numbers but with lower score or geographic)
+        # Invalid numbers that must not be detected as mobile (or maybe they are
+        # landline, but phonenumbers treats them as valid PH numbers but with
+        # lower score or geographic)
         # Random 11-digit number
         ("12345678901", 0, (), ()),
         # Invalid: too short

--- a/presidio-analyzer/tests/test_ph_mobile_number_recognizer.py
+++ b/presidio-analyzer/tests/test_ph_mobile_number_recognizer.py
@@ -116,9 +116,7 @@ def entities():
             ((7, 20), (30, 41)),
             ((0.4, 1.0), (0.3, 1.0)),
         ),
-        # Invalid numbers that must not be detected as mobile (or maybe they are
-        # landline, but phonenumbers treats them as valid PH numbers but with
-        # lower score or geographic)
+        # Invalid numbers (not mobile, or geographical/landline)
         # Random 11-digit number
         ("12345678901", 0, (), ()),
         # Invalid: too short


### PR DESCRIPTION
## Change Description
Adds Philippine mobile phone number detection to Presidio Analyzer
using the generic `PhoneRecognizer` with `supported_regions=["PH"]`
and `supported_entity="PH_MOBILE_NUMBER"`.

The generic `PhoneRecognizer` uses `python-phonenumbers` and can parse
Philippine numbers when `PH` is added to `supported_regions`. This PR
provides additional value:

- **PH-specific entity type** (`PH_MOBILE_NUMBER` vs generic `PHONE_NUMBER`) for targeted PII detection
- **ITU-T E.164 compliance** for Philippines (+63)
- **Filipino + English context words** for higher confidence detection
- Supports international (`+63 9XX XXX XXXX`) and national (`09XX XXX XXXX`) formats
- Disabled by default as per country-specific recognizer guidelines

## Issue reference
Fixes #2015 

## Testing
- Added `test_ph_mobile_number_recognizer.py` with 45 test cases
- Tests include valid/invalid formats, all valid PH mobile prefixes, context sentences, multiple numbers, and false positive checks
- All 45 tests pass locally. Ruff lint: 0 errors.

## Checklist
- [X] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [X] My code follows the project style guidelines (ruff, pytest)
- [X] I have added tests that prove my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have updated the CHANGELOG.md under the Unreleased section
- [X] I have updated the supported_entities.md documentation