### PR TITLE
test(ip-recognizer): add regression tests for IPv6 double-colon bugs (#1476)

### DIFF
--- a/presidio-analyzer/tests/test_ip_recognizer.py
+++ b/presidio-analyzer/tests/test_ip_recognizer.py
@@ -81,6 +81,8 @@ def test_when_all_ips_then_succeed(
         ("2001:db8:85a3::8a2e:370", 1, ((0, 23),), ((0.6, 0.81),),),
         ("2001:db8::1", 1, ((0, 11),), ((0.6, 0.81),),),
         ("fe80::1%eth0", 1, ((0, 12),), ((0.6, 0.81),),),
+        # Regression for issue #1476: 1 group before :: must match fully
+        ("A099::09C0:876A:130B", 1, ((0, 20),), ((0.6, 0.81),),),
         # fmt: on
     ],
 )
@@ -326,6 +328,8 @@ def test_when_ip_at_boundary_then_correct_span(
         ("300.168.1.1", 0, (), (),),
         ("12345:db8::1", 0, (), (),),
         ("2001::db8::1", 0, (), (),),
+        # Regression for issue #1476: multiple :: in an address must not match
+        ("2001::25de::cade", 0, (), (),),
         # Zone suffixes are not valid for IPv4
         # IPv4 address substring is valid and should still be matched
         ("192.168.2.1@eth0", 1, ((0, 11),), ((0.6, 0.81),),),


### PR DESCRIPTION
## Summary

Issue #1476 reported two bugs in the `IpRecognizer` IPv6 pattern:

1. **Valid address with single `::`** — `A099::09C0:876A:130B` was matched as `A099::` instead of the full address (the `{1,7}::` alternative fired before the `{1}::{1,6}` one).
2. **Invalid address with multiple `::`** — `2001::25de::cade` produced two spurious matches (`2001::` and `25de::`) instead of none, because `\b` treats `:` as a non-word character.

Both bugs have since been fixed in the regex (the lookbehind/lookahead guards were updated), but the specific test cases from the issue were never added to the test suite, leaving the door open for silent regressions.

This PR adds the two exact examples from the issue report as explicit parametrized test cases:

- `A099::09C0:876A:130B` → 1 match at `(0, 20)` in `test_when_ipv6_compression_then_succeed`
- `2001::25de::cade` → 0 matches in `test_when_invalid_ip_then_no_match`

## Test plan

- [x] Run `pytest presidio-analyzer/tests/test_ip_recognizer.py` — all **115 tests pass** (113 pre-existing + 2 new)
- [x] New tests specifically exercise the two failure modes described in #1476
- [x] No production code changed; change is test-only