### PR TITLE
fix(analyzer): stop quadratic backtracking in in_pan low pattern

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/india/in_pan_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/india/in_pan_recognizer.py
@@ -38,7 +38,7 @@ class InPanRecognizer(PatternRecognizer):
         ),
         Pattern(
             "PAN (Low)",
-            r"\b((?=.*?[a-zA-Z])(?=.*?[0-9]{4})[\w@#$%^?~-]{10})\b",
+            r"\b((?=[\w@#$%^?~-]*?[a-zA-Z])(?=[\w@#$%^?~-]*?[0-9]{4})[\w@#$%^?~-]{10})\b",
             0.01,
         ),
     ]

--- a/presidio-analyzer/tests/test_in_pan_recognizer.py
+++ b/presidio-analyzer/tests/test_in_pan_recognizer.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from tests import assert_result
@@ -47,3 +49,25 @@ def test_when_pan_in_text_then_all_pans_found(
             expected_position[1],
             expected_score,
         )
+
+
+def test_low_confidence_pan_with_embedded_digits_still_detected(recognizer, entities):
+    # The low-confidence pattern keeps matching a 10-char token that carries a
+    # letter and a four-digit run; scoping the lookaheads to the token class
+    # leaves this detection unchanged.
+    results = recognizer.analyze("A1111DFSFS", entities)
+    assert len(results) == 1
+    assert_result(results[0], entities[0], 0, 10, 0.01)
+
+
+def test_low_confidence_pattern_does_not_backtrack(recognizer, entities):
+    # The low-confidence pattern used `.*?` lookaheads that rescanned the whole
+    # remaining text at every word boundary, so a long boundary-rich string with
+    # no four-digit run cost time quadratic in its length. Matching must now be
+    # linear and finish well within the regex timeout.
+    text = "a " * 50000
+    start = time.time()
+    results = recognizer.analyze(text, entities)
+    elapsed = time.time() - start
+    assert results == []
+    assert elapsed < 10

--- a/presidio-analyzer/tests/test_in_pan_recognizer.py
+++ b/presidio-analyzer/tests/test_in_pan_recognizer.py
@@ -66,8 +66,8 @@ def test_low_confidence_pattern_does_not_backtrack(recognizer, entities):
     # no four-digit run cost time quadratic in its length. Matching must now be
     # linear and finish well within the regex timeout.
     text = "a " * 50000
-    start = time.time()
+    start = time.perf_counter()
     results = recognizer.analyze(text, entities)
-    elapsed = time.time() - start
+    elapsed = time.perf_counter() - start
     assert results == []
     assert elapsed < 10


### PR DESCRIPTION
## Change Description

`in_pan_recognizer.py`, PAN (Low) pattern, matched against a boundary-rich string with no four-digit run:

    in_pan PAN (Low) regex, input = "a " repeated:
      length  25,000  ->   2.0 s
      length  50,000  ->   8.1 s
      length 100,000  ->  32.4 s   (larger input reaches REGEX_TIMEOUT_SECONDS)

Both lookaheads use `.*?`, so each one rescans the rest of the text at every word boundary and match time is quadratic in input length. IN_PAN is enabled by default for English, so this sits on the analyze path for any analyzed text.

Before: `(?=.*?[a-zA-Z])(?=.*?[0-9]{4})[\w@#$%^?~-]{10}`. `.` walks across non-token characters, so the lookahead scan is unbounded.

After: `(?=[\w@#$%^?~-]*?[a-zA-Z])(?=[\w@#$%^?~-]*?[0-9]{4})[\w@#$%^?~-]{10}`. The lookaheads only traverse the PAN token's own character class, so each stops at the first non-token character. Matching is linear (100 KB now ~9 ms) and every valid PAN whose four digits sit inside the token still matches at the same span and score.

Tradeoff: scoping the lookaheads also drops one previous match. A ten-letter token is no longer reported as a PAN when four digits happen to appear later in the text; a PAN's digits live inside the number, so that case was a false positive.

## Issue reference

N/A

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required