### PR TITLE
fix(image-redactor): remove double bbox formatting in eval_dicom_instance

### DIFF
--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_pii_verify_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_pii_verify_engine.py
@@ -164,20 +164,15 @@ class DicomImagePiiVerifyEngine(ImagePiiVerifyEngine, DicomImageRedactorEngine):
         :return: Evaluation comparing redactor engine results vs ground truth.
         """
         # Verify detected PHI
-        verify_image, ocr_results, analyzer_results = self.verify_dicom_instance(
+        # verify_dicom_instance already returns formatted ocr bboxes and analyzer bboxes
+        verify_image, formatted_ocr_results, detected_phi = self.verify_dicom_instance(
             instance,
             padding_width,
             display_image,
-            use_metadata,
+            use_metadata=use_metadata,
             ocr_kwargs=ocr_kwargs,
             ad_hoc_recognizers=ad_hoc_recognizers,
             **text_analyzer_kwargs,
-        )
-        formatted_ocr_results = self.bbox_processor.get_bboxes_from_ocr_results(
-            ocr_results
-        )
-        detected_phi = self.bbox_processor.get_bboxes_from_analyzer_results(
-            analyzer_results
         )
 
         # Remove duplicate entities in results

--- a/presidio-image-redactor/tests/test_dicom_image_pii_verify_engine.py
+++ b/presidio-image-redactor/tests/test_dicom_image_pii_verify_engine.py
@@ -149,12 +149,6 @@ def test_eval_dicom_instance_happy_path(
         "verify_dicom_instance",
         return_value=[None, None, None],
     )
-    mock_get_ocr_bboxes = mocker.patch.object(BboxProcessor, "get_bboxes_from_ocr_results", return_value=None)
-    mock_get_analyzer_bboxes = mocker.patch.object(
-        BboxProcessor,
-        "get_bboxes_from_analyzer_results",
-        return_value=None,
-    )
     mock_remove_dups = mocker.patch.object(DicomImagePiiVerifyEngine, "_remove_duplicate_entities", return_value=None)
     mock_label_positives = mocker.patch.object(DicomImagePiiVerifyEngine, "_label_all_positives", return_value=None)
     mock_precision = mocker.patch.object(DicomImagePiiVerifyEngine, "calculate_precision", return_value=None)
@@ -168,8 +162,6 @@ def test_eval_dicom_instance_happy_path(
     # Assert
     assert type(test_eval_results) == dict
     assert mock_verify_instance.call_count == 1
-    assert mock_get_ocr_bboxes.call_count == 1
-    assert mock_get_analyzer_bboxes.call_count == 1
     assert mock_remove_dups.call_count == 1
     assert mock_label_positives.call_count == 1
     assert mock_precision.call_count == 1


### PR DESCRIPTION
## Summary

- `verify_dicom_instance` already calls `get_bboxes_from_ocr_results` and `get_bboxes_from_analyzer_results` internally and returns the formatted bbox lists. However, `eval_dicom_instance` was calling both formatters a second time on the already-formatted results, causing a `TypeError: list indices must be integers or slices, not str` whenever the evaluation notebook or `eval_dicom_instance` was used.
- Fixed by consuming the return values of `verify_dicom_instance` directly (they are already formatted bboxes, not raw OCR results).
- Also fixed a positional argument mismatch: `use_metadata` was passed as the 4th positional argument to `verify_dicom_instance`, but the 4th parameter there is `show_text_annotation`. Changed to a keyword argument.
- Updated the unit test for `eval_dicom_instance` to reflect the correct behavior (no longer expecting calls to `get_bboxes_from_ocr_results` / `get_bboxes_from_analyzer_results` inside `eval_dicom_instance`).

Closes #1251

## Test plan

- [x] Ran `presidio-image-redactor/tests/test_dicom_image_pii_verify_engine.py` — all 29 tests pass
- [x] The `eval_dicom_instance` unit test now correctly verifies that `verify_dicom_instance` is called once and its formatted results are used directly