### PR TITLE
fix(analyzer): preserve recognizer-specific config dumps

### DIFF
--- a/presidio-analyzer/presidio_analyzer/input_validation/schemas.py
+++ b/presidio-analyzer/presidio_analyzer/input_validation/schemas.py
@@ -97,7 +97,7 @@ class ConfigurationValidator:
         dumped_config["recognizers"] = [
             recognizer
             if isinstance(recognizer, str)
-            else recognizer.model_dump(exclude_unset=False)
+            else recognizer.model_dump()
             for recognizer in validated_config.recognizers
         ]
         return dumped_config

--- a/presidio-analyzer/presidio_analyzer/input_validation/schemas.py
+++ b/presidio-analyzer/presidio_analyzer/input_validation/schemas.py
@@ -80,10 +80,27 @@ class ConfigurationValidator:
         try:
             # Use Pydantic model for validation
             validated_config = RecognizerRegistryConfig(**config)
-            # Use model_dump() without exclude_unset to include default values
-            return validated_config.model_dump(exclude_unset=False)
+            return ConfigurationValidator._dump_recognizer_registry_configuration(
+                validated_config
+            )
         except ValidationError as e:
             raise ValueError("Invalid recognizer registry configuration") from e
+
+    @staticmethod
+    def _dump_recognizer_registry_configuration(
+        validated_config: RecognizerRegistryConfig,
+    ) -> Dict[str, Any]:
+        """Dump registry config while preserving recognizer-specific dump rules."""
+        dumped_config = validated_config.model_dump(
+            exclude_unset=False, exclude={"recognizers"}
+        )
+        dumped_config["recognizers"] = [
+            recognizer
+            if isinstance(recognizer, str)
+            else recognizer.model_dump(exclude_unset=False)
+            for recognizer in validated_config.recognizers
+        ]
+        return dumped_config
 
     @staticmethod
     def validate_analyzer_configuration(config: Dict[str, Any]) -> Dict[str, Any]:

--- a/presidio-analyzer/tests/test_yaml_recognizer_models.py
+++ b/presidio-analyzer/tests/test_yaml_recognizer_models.py
@@ -254,6 +254,58 @@ def test_recognizer_registry_config_preserves_custom_country_code_on_dump():
     assert config.model_dump()["recognizers"][0]["country_code"] == "am"
 
 
+def test_configuration_validator_uses_recognizer_specific_dump_rules():
+    """Validated YAML should preserve recognizer-specific model_dump behavior."""
+    from presidio_analyzer.input_validation.schemas import ConfigurationValidator
+
+    raw_config = {
+        "supported_languages": ["en"],
+        "recognizers": [
+            {
+                "name": "HuggingFaceNerRecognizer",
+                "type": "predefined",
+                "supported_language": "en",
+                "supported_entities": ["PERSON"],
+                "model_name": "custom/ner-model",
+                "aggregation_strategy": "simple",
+                "device": "cpu",
+            },
+            {
+                "name": "GLiNERRecognizer",
+                "type": "predefined",
+                "supported_language": "en",
+                "model_name": "custom/gliner-model",
+            },
+            {
+                "name": "CreditCardRecognizer",
+                "type": "predefined",
+            },
+        ],
+    }
+
+    validated = ConfigurationValidator.validate_recognizer_registry_configuration(
+        raw_config
+    )
+    hf_recognizer = validated["recognizers"][0]
+    gliner_recognizer = validated["recognizers"][1]
+    predefined_recognizer = validated["recognizers"][2]
+
+    assert validated["global_regex_flags"] == 26
+    assert hf_recognizer["enabled"] is True
+    assert hf_recognizer["model_name"] == "custom/ner-model"
+    assert "threshold" not in hf_recognizer
+    assert "chunk_size" not in hf_recognizer
+    assert "chunk_overlap" not in hf_recognizer
+    assert "tokenizer_name" not in hf_recognizer
+    assert gliner_recognizer["enabled"] is True
+    assert gliner_recognizer["model_name"] == "custom/gliner-model"
+    assert "threshold" not in gliner_recognizer
+    assert "flat_ner" not in gliner_recognizer
+    assert "entity_mapping" not in gliner_recognizer
+    assert predefined_recognizer["name"] == "CreditCardRecognizer"
+    assert predefined_recognizer["supported_language"] is None
+
+
 def test_custom_recognizer_config_with_deny_list():
     """Test custom recognizer with deny list only."""
     config = CustomRecognizerConfig(


### PR DESCRIPTION
# fix(analyzer): preserve recognizer-specific YAML config dumps

## Change Description

This PR preserves recognizer-specific config dump behavior during recognizer
registry YAML validation.

This affects recognizer-specific config models such as
`HuggingFaceRecognizerConfig` and `GLiNERRecognizerConfig`. Without this,
omitted optional fields can be serialized as explicit `None` values and passed
as recognizer kwargs.

Changes:

- Keep registry defaults while preserving each recognizer config's own handling
  of omitted fields.
- Add a test covering Hugging Face, GLiNER, and a normal predefined recognizer.

## Issue reference

Fixes #2080

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
