### PR TITLE
fix(image-redactor): fix duplicate entity sorting discard in DICOM verification engine

### DIFF
--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_pii_verify_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_pii_verify_engine.py
@@ -212,7 +212,7 @@ class DicomImagePiiVerifyEngine(ImagePiiVerifyEngine, DicomImageRedactorEngine):
         :return: Detected PHI with no duplicate entities.
         """
         dups = []
-        sorted(results, key=lambda x: x["score"], reverse=True)
+        results = sorted(results, key=lambda x: x["score"], reverse=True)
         results_no_dups = []
         dims = ["left", "top", "width", "height"]
 

--- a/presidio-image-redactor/tests/test_dicom_image_pii_verify_engine.py
+++ b/presidio-image-redactor/tests/test_dicom_image_pii_verify_engine.py
@@ -389,7 +389,7 @@ def test_remove_duplicate_entities_happy_path(
     test_results_no_dups = mock_engine._remove_duplicate_entities(results, tolerance)
 
     # Assert
-    assert test_results_no_dups == expected_results
+    assert sorted(test_results_no_dups, key=lambda x: str(x)) == sorted(expected_results, key=lambda x: str(x))
 
 
 # ------------------------------------------------------
@@ -574,7 +574,7 @@ def test_label_all_positives_happy_path(
     test_all_pos = mock_engine._label_all_positives(mock_gt_single, ocr_results, analyzer_results, tolerance)
 
     # Assert
-    assert test_all_pos == expected_results
+    assert sorted(test_all_pos, key=lambda x: str(x)) == sorted(expected_results, key=lambda x: str(x))
 
 
 # ------------------------------------------------------
@@ -708,3 +708,16 @@ def test_calculate_recall_happy_path(
 
     # Assert
     assert test_recall == expected_result
+
+def test_remove_duplicate_entities_keeps_highest_score():
+    from presidio_image_redactor import DicomImagePiiVerifyEngine
+
+    engine = DicomImagePiiVerifyEngine()
+    results = [
+        {"entity_type": "DATE_TIME", "score": 0.4, "left": 10, "top": 10, "width": 100, "height": 30},
+        {"entity_type": "PERSON",    "score": 1.0, "left": 10, "top": 10, "width": 100, "height": 30},
+    ]
+    
+    deduped = engine._remove_duplicate_entities(results, dup_pix_tolerance=5)
+    assert len(deduped) == 1
+    assert deduped[0]["entity_type"] == "PERSON"

--- a/presidio-image-redactor/tests/test_dicom_image_pii_verify_engine.py
+++ b/presidio-image-redactor/tests/test_dicom_image_pii_verify_engine.py
@@ -389,7 +389,7 @@ def test_remove_duplicate_entities_happy_path(
     test_results_no_dups = mock_engine._remove_duplicate_entities(results, tolerance)
 
     # Assert
-    assert sorted(test_results_no_dups, key=lambda x: str(x)) == sorted(expected_results, key=lambda x: str(x))
+    assert sorted(map(lambda d: tuple(sorted(d.items())), test_results_no_dups)) == sorted(map(lambda d: tuple(sorted(d.items())), expected_results))
 
 
 # ------------------------------------------------------
@@ -574,7 +574,7 @@ def test_label_all_positives_happy_path(
     test_all_pos = mock_engine._label_all_positives(mock_gt_single, ocr_results, analyzer_results, tolerance)
 
     # Assert
-    assert sorted(test_all_pos, key=lambda x: str(x)) == sorted(expected_results, key=lambda x: str(x))
+    assert sorted(map(lambda d: tuple(sorted(d.items())), test_all_pos)) == sorted(map(lambda d: tuple(sorted(d.items())), expected_results))
 
 
 # ------------------------------------------------------
@@ -710,14 +710,11 @@ def test_calculate_recall_happy_path(
     assert test_recall == expected_result
 
 def test_remove_duplicate_entities_keeps_highest_score():
-    from presidio_image_redactor import DicomImagePiiVerifyEngine
-
-    engine = DicomImagePiiVerifyEngine()
     results = [
         {"entity_type": "DATE_TIME", "score": 0.4, "left": 10, "top": 10, "width": 100, "height": 30},
         {"entity_type": "PERSON",    "score": 1.0, "left": 10, "top": 10, "width": 100, "height": 30},
     ]
     
-    deduped = engine._remove_duplicate_entities(results, dup_pix_tolerance=5)
+    deduped = DicomImagePiiVerifyEngine._remove_duplicate_entities(results, dup_pix_tolerance=5)
     assert len(deduped) == 1
     assert deduped[0]["entity_type"] == "PERSON"


### PR DESCRIPTION
## Description

This PR fixes a bug in `DicomImagePiiVerifyEngine._remove_duplicate_entities` where the return value of `sorted()` was being discarded instead of assigned back to the `results` list variable. 

Because `sorted()` operates non-destructively, the bounding box results retained their original input order rather than prioritizing highest-confidence matches. This caused lower-scoring overlapping PII blocks to mistakenly suppress higher-scoring targets during downstream deduplication passes.

### Modifications
1. **Engine Fix:** Assigned the result of the `sorted()` execution pattern directly to the `results` tracking variable on line 215 of `dicom_image_pii_verify_engine.py`.
2. **Test Suite Alignment:** Updated the strict list-equality assertions within `test_dicom_image_pii_verify_engine.py` to compare elements using string serialization keys, matching items accurately regardless of structural score sorting layout.

Fixes #2083