### PR TITLE
Support Azure credentials for DocumentIntelligenceOCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ All notable changes to this project will be documented in this file.
 - Turkish PII recognizer for `TR_LICENSE_PLATE` (plaka) to identify Turkish vehicle license plates using pattern match, context, and province code validation (01-81). Disabled by default.
 - Added PH_MOBILE_NUMBER recognizer for Philippine mobile phone numbers using PhoneRecognizer with supported_regions=['PH'] (disabled by default).
 
+### Image Redactor
+#### Added
+- Added Azure SDK credential support to `DocumentIntelligenceOCR` so callers can use Azure Identity credentials instead of API keys. Fixes #1882.
+
 ## [2.2.362] - 2026-03-15
 ### General
 #### Added

--- a/docs/image-redactor/index.md
+++ b/docs/image-redactor/index.md
@@ -161,9 +161,9 @@ The most basic usage of the engine can be setup like the following in python
 diOCR = DocumentIntelligenceOCR(endpoint="<your_endpoint>", key="<your_key>")
 ```
 
-If your environment uses Azure Identity instead of API keys, pass any Azure SDK
-credential object. For example, install `azure-identity` and use
-`DefaultAzureCredential`:
+If your environment uses Azure Identity instead of API keys, pass an Azure SDK
+credential that implements `TokenCredential`, such as `DefaultAzureCredential`.
+For example, install `azure-identity` and use `DefaultAzureCredential`:
 
 ```
 from azure.identity import DefaultAzureCredential

--- a/docs/image-redactor/index.md
+++ b/docs/image-redactor/index.md
@@ -161,6 +161,19 @@ The most basic usage of the engine can be setup like the following in python
 diOCR = DocumentIntelligenceOCR(endpoint="<your_endpoint>", key="<your_key>")
 ```
 
+If your environment uses Azure Identity instead of API keys, pass any Azure SDK
+credential object. For example, install `azure-identity` and use
+`DefaultAzureCredential`:
+
+```
+from azure.identity import DefaultAzureCredential
+
+diOCR = DocumentIntelligenceOCR(
+    endpoint="<your_endpoint>",
+    credential=DefaultAzureCredential(),
+)
+```
+
 The DocumentIntelligenceOCR can also attempt to pull your endpoint and key values from environment variables.  
 
 ```

--- a/presidio-image-redactor/presidio_image_redactor/document_intelligence_ocr.py
+++ b/presidio-image-redactor/presidio_image_redactor/document_intelligence_ocr.py
@@ -1,6 +1,6 @@
 import os
 from io import BytesIO
-from typing import Optional, Sequence, Union
+from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 import numpy as np
 from azure.ai.formrecognizer import (
@@ -14,6 +14,9 @@ from PIL import Image
 
 from presidio_image_redactor import OCR
 
+if TYPE_CHECKING:
+    from azure.core.credentials import TokenCredential
+
 
 class DocumentIntelligenceOCR(OCR):
     """OCR class that uses Azure AI Document Intelligence OCR engine.
@@ -21,6 +24,8 @@ class DocumentIntelligenceOCR(OCR):
     :param key: The API key
     :param endpoint: The API endpoint
     :param model_id: Which model to use
+    :param credential: An Azure credential object, such as
+        DefaultAzureCredential or AzureKeyCredential
 
     For details, see
     https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/
@@ -43,24 +48,30 @@ class DocumentIntelligenceOCR(OCR):
         endpoint: Optional[str] = None,
         key: Optional[str] = None,
         model_id: Optional[str] = "prebuilt-document",
+        credential: Optional[Union[AzureKeyCredential, "TokenCredential"]] = None,
     ):
         if model_id not in DocumentIntelligenceOCR.SUPPORTED_MODELS:
             raise ValueError("Unsupported model id: %s" % model_id)
 
+        if credential is not None and key is not None:
+            raise ValueError("Only one of key or credential may be specified")
+
         # If endpoint and/or key are not passed, attempt to get from environment
-        # variables
+        # variables.
         if not endpoint:
             endpoint = os.getenv("DOCUMENT_INTELLIGENCE_ENDPOINT")
 
-        if not key:
-            key = os.getenv("DOCUMENT_INTELLIGENCE_KEY")
+        if credential is None:
+            if not key:
+                key = os.getenv("DOCUMENT_INTELLIGENCE_KEY")
+            if not key or not endpoint:
+                raise ValueError("Endpoint and key must be specified")
+            credential = AzureKeyCredential(key)
 
-        if not key or not endpoint:
-            raise ValueError("Endpoint and key must be specified")
+        if not endpoint:
+            raise ValueError("Endpoint must be specified")
 
-        self.client = DocumentAnalysisClient(
-            endpoint=endpoint, credential=AzureKeyCredential(key)
-        )
+        self.client = DocumentAnalysisClient(endpoint=endpoint, credential=credential)
         self.model_id = model_id
 
     @staticmethod

--- a/presidio-image-redactor/tests/test_document_intelligence_ocr.py
+++ b/presidio-image-redactor/tests/test_document_intelligence_ocr.py
@@ -129,6 +129,18 @@ def test_credential_auth_uses_passed_credential(document_analysis_client):
     )
 
 
+@mock.patch("presidio_image_redactor.document_intelligence_ocr.DocumentAnalysisClient")
+def test_credential_auth_accepts_azure_key_credential(document_analysis_client):
+    """Confirm credential auth can receive AzureKeyCredential directly."""
+    credential = AzureKeyCredential("fake_key")
+
+    DocumentIntelligenceOCR(endpoint="fake_endpoint", credential=credential)
+
+    document_analysis_client.assert_called_once_with(
+        endpoint="fake_endpoint", credential=credential
+    )
+
+
 def test_key_and_credential_then_raises_exception():
     """Confirm key and credential auth cannot be mixed."""
     with pytest.raises(ValueError, match="Only one of key or credential"):

--- a/presidio-image-redactor/tests/test_document_intelligence_ocr.py
+++ b/presidio-image-redactor/tests/test_document_intelligence_ocr.py
@@ -1,7 +1,9 @@
-import pytest
 from unittest import mock
-from presidio_image_redactor.document_intelligence_ocr import DocumentIntelligenceOCR
+
+import pytest
 from azure.ai.formrecognizer import AnalyzeResult
+from azure.core.credentials import AzureKeyCredential
+from presidio_image_redactor.document_intelligence_ocr import DocumentIntelligenceOCR
 
 
 @pytest.fixture(scope="module")
@@ -101,6 +103,75 @@ def test_model_id_wrong_then_raises_exception():
 def test_model_id_correct_then_raises_no_exception():
     """Confirm that there's no exception if the model_id is correct"""
     DocumentIntelligenceOCR(key="fake_key", endpoint="fake_endpoint", model_id="prebuilt-document")
+
+
+@mock.patch("presidio_image_redactor.document_intelligence_ocr.DocumentAnalysisClient")
+def test_key_auth_uses_azure_key_credential(document_analysis_client):
+    """Confirm key auth wraps the key in an AzureKeyCredential."""
+    DocumentIntelligenceOCR(key="fake_key", endpoint="fake_endpoint")
+
+    document_analysis_client.assert_called_once()
+    assert document_analysis_client.call_args.kwargs["endpoint"] == "fake_endpoint"
+    credential = document_analysis_client.call_args.kwargs["credential"]
+    assert isinstance(credential, AzureKeyCredential)
+    assert credential.key == "fake_key"
+
+
+@mock.patch("presidio_image_redactor.document_intelligence_ocr.DocumentAnalysisClient")
+def test_credential_auth_uses_passed_credential(document_analysis_client):
+    """Confirm credential auth forwards the caller-provided credential."""
+    credential = mock.Mock()
+
+    DocumentIntelligenceOCR(endpoint="fake_endpoint", credential=credential)
+
+    document_analysis_client.assert_called_once_with(
+        endpoint="fake_endpoint", credential=credential
+    )
+
+
+def test_key_and_credential_then_raises_exception():
+    """Confirm key and credential auth cannot be mixed."""
+    with pytest.raises(ValueError, match="Only one of key or credential"):
+        DocumentIntelligenceOCR(
+            endpoint="fake_endpoint", key="fake_key", credential=mock.Mock()
+        )
+
+
+@mock.patch("presidio_image_redactor.document_intelligence_ocr.DocumentAnalysisClient")
+def test_credential_auth_uses_environment_endpoint(document_analysis_client, monkeypatch):
+    """Confirm credential auth can use the endpoint environment variable."""
+    credential = mock.Mock()
+    monkeypatch.setenv("DOCUMENT_INTELLIGENCE_ENDPOINT", "fake_endpoint")
+    monkeypatch.delenv("DOCUMENT_INTELLIGENCE_KEY", raising=False)
+
+    DocumentIntelligenceOCR(credential=credential)
+
+    document_analysis_client.assert_called_once_with(
+        endpoint="fake_endpoint", credential=credential
+    )
+
+
+@mock.patch("presidio_image_redactor.document_intelligence_ocr.DocumentAnalysisClient")
+def test_credential_auth_ignores_key_environment_variable(
+    document_analysis_client, monkeypatch
+):
+    """Confirm credential auth does not fall back to key environment auth."""
+    credential = mock.Mock()
+    monkeypatch.setenv("DOCUMENT_INTELLIGENCE_KEY", "fake_key")
+
+    DocumentIntelligenceOCR(endpoint="fake_endpoint", credential=credential)
+
+    document_analysis_client.assert_called_once_with(
+        endpoint="fake_endpoint", credential=credential
+    )
+
+
+def test_credential_without_endpoint_then_raises_exception(monkeypatch):
+    """Confirm credential auth still requires an endpoint."""
+    monkeypatch.delenv("DOCUMENT_INTELLIGENCE_ENDPOINT", raising=False)
+
+    with pytest.raises(ValueError, match="Endpoint must be specified"):
+        DocumentIntelligenceOCR(credential=mock.Mock())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Description

Adds an optional `credential` parameter to `DocumentIntelligenceOCR` so callers can pass Azure SDK credentials such as `DefaultAzureCredential` while keeping the existing endpoint/key flow intact.

This also rejects mixed `key` and `credential` inputs, preserves the existing environment variable fallback behavior, and documents Azure Identity usage without adding `azure-identity` as a required dependency.

## Issue reference

Fixes #1882

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required

## Tests

- `presidio-image-redactor/.venv/bin/ruff check`
- `.venv/bin/python -m pytest tests/test_document_intelligence_ocr.py -q`
