### PR TITLE
Fix AU ACN checksum rejecting valid ACNs whose check digit is 0

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/australia/au_acn_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/australia/au_acn_recognizer.py
@@ -84,5 +84,8 @@ class AuAcnRecognizer(PatternRecognizer):
         for i in range(8):
             sum_product += acn_list[i] * weight[i]
         remainder = sum_product % 10
-        complement = 10 - remainder
+        # The complement must be reduced mod 10: when the weighted sum is a
+        # multiple of 10 the check digit is 0, not 10. Without the outer "% 10"
+        # every valid ACN whose check digit is 0 (e.g. 000000180) is rejected.
+        complement = (10 - remainder) % 10
         return complement == acn_list[-1]

--- a/presidio-analyzer/tests/test_au_acn_recognizer.py
+++ b/presidio-analyzer/tests/test_au_acn_recognizer.py
@@ -17,10 +17,12 @@ def entities():
 @pytest.mark.parametrize(
     "text, expected_len, expected_positions, expected_score_ranges",
     [
-        # Valid formatting and valid ACNs 
+        # Valid formatting and valid ACNs
         ("000 000 019", 1, ((0, 11),), ((1.0, 1.0),), ),
         ("005 499 981", 1, ((0, 11),), ((1.0, 1.0),), ),
         ("006249976", 1, ((0, 9),), ((1.0, 1.0),), ),
+        # Valid ACN whose check digit is 0 (weighted sum is a multiple of 10)
+        ("000000180", 1, ((0, 9),), ((1.0, 1.0),), ),
         # Valid formatting but invalid ACNs 
         ("824 753 557", 0, (), (),),
         ("824753557", 0, (), (),),


### PR DESCRIPTION
## Change Description

`AuAcnRecognizer.validate_result` rejects valid Australian Company Numbers
(ACNs) whose check digit is `0`, so those ACNs are never detected (a false
negative — for a PII recognizer, valid sensitive data is silently missed).

**Root cause** (`au_acn_recognizer.py`):

```python
remainder = sum_product % 10
complement = 10 - remainder        # missing the outer "% 10"
return complement == acn_list[-1]
```

Per the official [ASIC ACN algorithm](https://asic.gov.au/for-business/registering-a-company/steps-to-register-a-company/australian-company-numbers/australian-company-number-digit-check/),
the check digit is `(10 - (weighted_sum % 10)) % 10`. When the weighted sum is
a multiple of 10 the remainder is `0`, so the correct check digit is `0` — but
the code produces `complement = 10`, which can never equal a single digit, and
the ACN is rejected.

Example: `000000180` is a valid ACN (weights `[8,7,6,5,4,3,2,1]` over the first
8 digits give a weighted sum of 10 → check digit 0), yet
`validate_result("000000180")` returns `False`.

**Fix:** reduce the complement mod 10 so a zero remainder maps to check digit
`0`. This only changes the `remainder == 0` case; every other ACN (and all
existing tests) is unaffected.

```python
complement = (10 - remainder) % 10
```

## Issue reference

N/A — found while reviewing the recognizer; no pre-existing issue.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required) <!-- will sign when the CLA bot prompts -->
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required <!-- N/A: internal checksum fix, no doc change -->

<details>
<summary>Local verification</summary>

```text
$ pytest presidio-analyzer/tests/test_au_acn_recognizer.py -q
10 passed

$ ruff check .../australia/au_acn_recognizer.py && ruff format --check ...
All checks passed!  /  already formatted
```

Before the fix `validate_result("000000180")` → `False`; after → `True`. The
three existing valid test ACNs (`000000019`, `005499981`, `006249976`) have
non-zero check digits and pass under both versions. Added a regression case
for a valid ACN whose check digit is 0.
</details>
