### PR TITLE
Fix SG UEN detection missing Format C UENs with the 'R' prefix

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/singapore/sg_uen_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/singapore/sg_uen_recognizer.py
@@ -23,7 +23,7 @@ class SgUenRecognizer(PatternRecognizer):
     PATTERNS = [
         Pattern(
             "UEN (low)",
-            r"\b\d{8}[A-Z]\b|\b\d{9}[A-Z]\b|\b(T|S)\d{2}[A-Z]{2}\d{4}[A-Z]\b",
+            r"\b\d{8}[A-Z]\b|\b\d{9}[A-Z]\b|\b[TSR]\d{2}[A-Z]{2}\d{4}[A-Z]\b",
             0.3,
         )
     ]

--- a/presidio-analyzer/tests/test_sg_uen_recognizer.py
+++ b/presidio-analyzer/tests/test_sg_uen_recognizer.py
@@ -27,6 +27,8 @@ def entities():
         ("T16RF0037C", 1, [(0, 10)],),
         # # Test with valid UEN Format C starting with S
         ("S57TU0392K", 1, [(0, 10)],),
+        # # Test with valid UEN Format C starting with R
+        ("R16RF0037F", 1, [(0, 10)],),
         # Test with multiple valid UENs
         ("53125226D 201434292D S57TU0392K", 3, [(0, 9), (10, 20), (21, 31)],),
         # Test with valid UEN in a sentence


### PR DESCRIPTION
## Change Description

The `SG_UEN` recognizer never detects valid **Format C UENs that start with
`R`**, even though the recognizer itself considers `R` a valid prefix — a false
negative (valid PII silently missed).

**Root cause** (`sg_uen_recognizer.py`): the detection regex restricts the
Format C prefix to `(T|S)`:

```python
r"\b\d{8}[A-Z]\b|\b\d{9}[A-Z]\b|\b(T|S)\d{2}[A-Z]{2}\d{4}[A-Z]\b"
```

…but the recognizer's own constant and validator accept `R` too:

```python
UEN_FORMAT_C_PREFIX = {"T", "S", "R"}
```

So a valid R-prefixed Format C UEN such as `R16RF0037F` passes
`validate_result(...)` (`True`) yet `analyze(...)` returns **0 results**,
because the regex never matches the `R` prefix and an R-prefixed 10-char string
cannot fall through to the Format B branch either.

**Fix:** widen the Format C alternative from `(T|S)` to `[TSR]` so the regex
prefix set matches `UEN_FORMAT_C_PREFIX`. This is a strict widening; existing
T/S and Format A/B detections are unaffected, and the checksum in
`validate_result` still gates out false positives (e.g. `R16RF0037A` with a bad
check digit is still rejected).

## Issue reference

N/A — found while reviewing the recognizer; no pre-existing issue.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required) <!-- will sign when the CLA bot prompts -->
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required <!-- N/A: regex fix, no doc change -->

<details>
<summary>Local verification</summary>

```text
$ pytest presidio-analyzer/tests/test_sg_uen_recognizer.py -q
9 passed

# before fix: analyze("R16RF0037F") -> 0 results ; after: -> 1 result
# validate_result("R16RF0037F") == True (already), R16RF0037A (bad checksum) still 0 results
$ ruff check .../singapore/sg_uen_recognizer.py
All checks passed!
```

Added a regression case for a valid R-prefixed Format C UEN (mirrors the
existing T/S Format C cases).
</details>
