### PR TITLE
docs(image-redactor): fix undefined di_ocr variable in Document Intelligence example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ All notable changes to this project will be documented in this file.
 #### Added
 - Added Azure SDK credential support to `DocumentIntelligenceOCR` so callers can use Azure Identity credentials instead of API keys. Fixes #1882.
 
+#### Fixed
+- Fixed an undefined variable in the Document Intelligence OCR setup example in the image-redactor documentation. The "Creating an image redactor engine in Python" snippet defined `diOCR` but referenced `di_ocr`, raising `NameError` when copied verbatim; the snippet now consistently uses `diOCR`.
+
 ## [2.2.362] - 2026-03-15
 ### General
 #### Added

--- a/docs/image-redactor/index.md
+++ b/docs/image-redactor/index.md
@@ -191,7 +191,7 @@ Additional metadata can be sent to the Document Intelligence API call, such as p
 
 ```
 diOCR = DocumentIntelligenceOCR()
-ia_engine = ImageAnalyzerEngine(ocr=di_ocr)
+ia_engine = ImageAnalyzerEngine(ocr=diOCR)
 my_engine = ImageRedactorEngine(image_analyzer_engine=ia_engine)
 ```
 


### PR DESCRIPTION
## Change Description

The "Creating an image redactor engine in Python" example in the Document Intelligence OCR section defines the OCR engine as `diOCR` but then passes `ocr=di_ocr` to `ImageAnalyzerEngine`. Copying the snippet verbatim raises `NameError: name 'di_ocr' is not defined`. This changes the reference to match the definition (`diOCR`) so the example runs as written.

```python
diOCR = DocumentIntelligenceOCR()
ia_engine = ImageAnalyzerEngine(ocr=diOCR)   # was: ocr=di_ocr
my_engine = ImageRedactorEngine(image_analyzer_engine=ia_engine)
```

## Issue reference

No tracking issue; trivial documentation fix in `docs/image-redactor/index.md`.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [ ] I have signed the CLA (if required)
- [ ] My code includes unit tests _(N/A — documentation-only change)_
- [x] All unit tests and lint checks pass locally _(no code changed)_
- [x] My PR contains documentation updates / additions if required
