### PR TITLE
Fix analyzer CI numpy resolver flake

### DIFF
--- a/presidio-analyzer/pyproject.toml
+++ b/presidio-analyzer/pyproject.toml
@@ -24,7 +24,7 @@ include = ["conf/*",]
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "spacy (>=3.4.4,!=3.7.0,<4.0.0)",
-    "numpy (>=1.19.0,<3.0.0)",
+    "numpy (>=1.19.0,<2.5.0)",
     "click (>=8.1.0,<9.0.0)",
     "regex (>=2023.0.0)",
     "tldextract (>=5.3.1,<6.0.0)",


### PR DESCRIPTION
Constrain numpy below 2.5.0 so Poetry does not resolve overlapping numpy entries for Python 3.12. The overlap installs numpy 2.4.x and 2.5.x into the same environment and causes flaky spaCy crashes during analyzer CI.
