### PR TITLE
feat(image-redactor): redact all frames of multi-frame DICOM images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ All notable changes to this project will be documented in this file.
 ### Image Redactor
 #### Added
 - Added Azure SDK credential support to `DocumentIntelligenceOCR` so callers can use Azure Identity credentials instead of API keys (#2085) (Thanks @mturac)
+- Multi-frame DICOM redaction support in `DicomImageRedactorEngine`. PII is now detected and redacted on every frame of a multi-frame instance (`NumberOfFrames > 1`), rather than only the first frame. This also resolves the `ValueError: Too many dimensions: 3 > 2` raised when redacting multi-frame (e.g., XA) grayscale instances (#2094). Fixes #1737, #1731.
 
 #### Changed
 - Updated image-redactor dependencies for `opencv-python`, `gunicorn`, `pytesseract`, and `azure-ai-formrecognizer` (#1978, #1977, #1980, #1986) (Thanks @dependabot)

--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_pii_verify_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_pii_verify_engine.py
@@ -82,6 +82,12 @@ class DicomImagePiiVerifyEngine(ImagePiiVerifyEngine, DicomImageRedactorEngine):
 
         is_greyscale = self._check_if_greyscale(instance_copy)
         image = self._rescale_dcm_pixel_array(instance, is_greyscale)
+        num_frames = self._get_number_of_frames(instance)
+        if num_frames > 1 and image.shape[0] == num_frames:
+            # Verification visualizes a single representative frame; redaction
+            # (DicomImageRedactorEngine) handles every frame of a multi-frame
+            # instance.
+            image = image[0]
         if is_greyscale:
             # model L for grayscale, and has 8 bit-pixel to store the pixel value
             image_pil = Image.fromarray(image, mode="L")

--- a/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
+++ b/presidio-image-redactor/presidio_image_redactor/dicom_image_redactor_engine.py
@@ -70,31 +70,52 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
 
         is_greyscale = self._check_if_greyscale(instance)
         image_np = self._rescale_dcm_pixel_array(instance, is_greyscale)
-        if is_greyscale:
-            # model L for grayscale, and has 8 bit-pixel to store the pixel value
-            image_pil = Image.fromarray(image_np, mode="L")
-        else:
-            # model RGB, has 3x8 bit pixel available to store the value
-            image_pil = Image.fromarray(image_np, mode="RGB")
-        padded_image_pil = self._add_padding(image_pil, is_greyscale, padding_width)
+        num_frames = self._get_number_of_frames(instance)
+        is_multiframe = num_frames > 1 and image_np.shape[0] == num_frames
 
+        # Detect PII on each frame independently. Multi-frame DICOMs can carry
+        # burned-in PHI on any frame, and not necessarily in the same location.
+        frames = image_np if is_multiframe else [image_np]
+        bboxes_per_frame = []
+        for frame_np in frames:
+            image_pil = self._image_from_array(frame_np, is_greyscale)
+            padded_image_pil = self._add_padding(
+                image_pil, is_greyscale, padding_width
+            )
 
-        # Detect PII
-        analyzer_results = self._get_analyzer_results(
-            padded_image_pil,
-            instance,
-            use_metadata,
-            ocr_kwargs,
-            ad_hoc_recognizers,
-            **text_analyzer_kwargs,
+            # Detect PII
+            analyzer_results = self._get_analyzer_results(
+                padded_image_pil,
+                instance,
+                use_metadata,
+                ocr_kwargs,
+                ad_hoc_recognizers,
+                **text_analyzer_kwargs,
+            )
+
+            analyzer_bboxes = self.bbox_processor.get_bboxes_from_analyzer_results(
+                analyzer_results
+            )
+            frame_bboxes = self.bbox_processor.remove_bbox_padding(
+                analyzer_bboxes, padding_width
+            )
+            bboxes_per_frame.append(frame_bboxes)
+
+        # Redact all bounding boxes from DICOM file (every frame for multi-frame)
+        boxes_for_redaction = (
+            bboxes_per_frame if is_multiframe else bboxes_per_frame[0]
+        )
+        redacted_image = self._add_redact_box(
+            instance, boxes_for_redaction, crop_ratio, fill
         )
 
-        # Redact all bounding boxes from DICOM file
-        analyzer_bboxes = self.bbox_processor.get_bboxes_from_analyzer_results(
-            analyzer_results
-        )
-        bboxes = self.bbox_processor.remove_bbox_padding(analyzer_bboxes, padding_width)
-        redacted_image = self._add_redact_box(instance, bboxes, crop_ratio, fill)
+        # Aggregate bboxes across frames for the return value
+        bboxes = [
+            bbox
+            for frame_bboxes in bboxes_per_frame
+            if frame_bboxes
+            for bbox in frame_bboxes
+        ]
 
         return redacted_image, bboxes
 
@@ -313,6 +334,38 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         return is_greyscale
 
     @staticmethod
+    def _get_number_of_frames(instance: pydicom.dataset.FileDataset) -> int:
+        """Return the number of frames in a DICOM instance.
+
+        Reads the Number of Frames element (0028,0008). Defaults to 1 when the
+        element is absent or cannot be parsed (i.e., a single-frame instance).
+
+        :param instance: A single DICOM instance.
+
+        :return: Number of frames (>= 1).
+        """
+        try:
+            number_of_frames = instance[0x0028, 0x0008].value
+            if number_of_frames is None:
+                return 1
+            return int(number_of_frames)
+        except (KeyError, ValueError, TypeError):
+            return 1
+
+    @staticmethod
+    def _image_from_array(image_np: np.ndarray, is_greyscale: bool) -> Image.Image:
+        """Convert a single-frame pixel array into a PIL image.
+
+        :param image_np: Pixel data for a single frame (rescaled to uint8).
+        :param is_greyscale: FALSE if the Photometric Interpretation is RGB.
+
+        :return: PIL image (mode "L" for greyscale, "RGB" otherwise).
+        """
+        # mode "L" for grayscale (8 bit-pixel), "RGB" for 3x8 bit pixel values
+        mode = "L" if is_greyscale else "RGB"
+        return Image.fromarray(image_np, mode=mode)
+
+    @staticmethod
     def _rescale_dcm_pixel_array(
         instance: pydicom.dataset.FileDataset, is_greyscale: bool
     ) -> np.ndarray:
@@ -321,17 +374,37 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         :param instance: A singe DICOM instance.
         :param is_greyscale: FALSE if the Photometric Interpretation is RGB.
 
-        :return: Rescaled DICOM pixel_array.
+        :return: Rescaled DICOM pixel_array (2D for single-frame; stacked with a
+        leading frame dimension for multi-frame instances).
         """
-        # Normalize contrast
-        if "WindowWidth" in instance:
-            if is_greyscale:
-                image_2d = apply_voi_lut(instance.pixel_array, instance)
-            else:
-                image_2d = instance.pixel_array
+        # Normalize contrast. apply_voi_lut is applied element-wise and is safe
+        # for multi-frame stacks.
+        if "WindowWidth" in instance and is_greyscale:
+            pixel_array = apply_voi_lut(instance.pixel_array, instance)
         else:
-            image_2d = instance.pixel_array
+            pixel_array = instance.pixel_array
 
+        # Rescale each frame independently so that per-frame contrast is
+        # preserved for multi-frame instances.
+        num_frames = DicomImageRedactorEngine._get_number_of_frames(instance)
+        if num_frames > 1 and pixel_array.shape[0] == num_frames:
+            scaled_frames = [
+                DicomImageRedactorEngine._rescale_array(pixel_array[i], is_greyscale)
+                for i in range(num_frames)
+            ]
+            return np.stack(scaled_frames, axis=0)
+
+        return DicomImageRedactorEngine._rescale_array(pixel_array, is_greyscale)
+
+    @staticmethod
+    def _rescale_array(image_2d: np.ndarray, is_greyscale: bool) -> np.ndarray:
+        """Rescale a single-frame pixel array to uint8.
+
+        :param image_2d: Pixel data for a single frame.
+        :param is_greyscale: FALSE if the Photometric Interpretation is RGB.
+
+        :return: Rescaled uint8 array.
+        """
         # Convert to float to avoid overflow or underflow losses.
         image_2d_float = image_2d.astype(float)
 
@@ -339,10 +412,14 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
             image_2d_scaled = image_2d_float
         else:
             # Rescaling grey scale between 0-255
-            image_2d_scaled = (
-                (image_2d_float.max() - image_2d_float)
-                / (image_2d_float.max() - image_2d_float.min())
-            ) * 255.0
+            pixel_range = image_2d_float.max() - image_2d_float.min()
+            if pixel_range == 0:
+                # Flat frame; avoid division by zero.
+                image_2d_scaled = np.zeros_like(image_2d_float)
+            else:
+                image_2d_scaled = (
+                    (image_2d_float.max() - image_2d_float) / pixel_range
+                ) * 255.0
 
         # Convert to uint
         image_2d_scaled = np.uint8(image_2d_scaled)
@@ -430,6 +507,7 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         instance: pydicom.dataset.FileDataset,
         crop_ratio: float,
         fill: str = "contrast",
+        pixel_array: Optional[np.ndarray] = None,
     ) -> Union[int, Tuple[int, int, int]]:
         """Find the most common pixel value.
 
@@ -439,11 +517,14 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         :param fill: Determines how box color is selected.
         'contrast' - Masks stand out relative to background.
         'background' - Masks are same color as background.
+        :param pixel_array: Optional single-frame pixel array to use instead of
+        ``instance.pixel_array`` (used for multi-frame instances).
 
         :return: Most or least common pixel value (depending on fill).
         """
         # Crop down to just only look at image corners
-        cropped_array = cls._get_array_corners(instance.pixel_array, crop_ratio)
+        source_array = instance.pixel_array if pixel_array is None else pixel_array
+        cropped_array = cls._get_array_corners(source_array, crop_ratio)
 
         # Get flattened pixel array
         flat_pixel_array = np.array(cropped_array).flatten()
@@ -741,7 +822,10 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
 
     @classmethod
     def _set_bbox_color(
-        cls, instance: pydicom.dataset.FileDataset, fill: str
+        cls,
+        instance: pydicom.dataset.FileDataset,
+        fill: str,
+        pixel_array: Optional[np.ndarray] = None,
     ) -> Union[int, Tuple[int, int, int]]:
         """Set the bounding box color.
 
@@ -749,6 +833,8 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         :param fill: Determines how box color is selected.
         'contrast' - Masks stand out relative to background.
         'background' - Masks are same color as background.
+        :param pixel_array: Optional single-frame pixel array to use instead of
+        ``instance.pixel_array`` (used for multi-frame instances).
 
         :return: int or tuple of int values determining masking box color.
         """
@@ -761,12 +847,13 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
             raise ValueError("fill must be 'contrast' or 'background'")
 
         is_greyscale = cls._check_if_greyscale(instance)
+        source_array = instance.pixel_array if pixel_array is None else pixel_array
         if is_greyscale:
             # model L for grayscale, and has 8 bit-pixel to store the pixel value
-            image_pil = Image.fromarray(instance.pixel_array, mode="L")
+            image_pil = Image.fromarray(source_array, mode="L")
         else:
             # model RGB, has 3x8 bit pixel available to store the value
-            image_pil = Image.fromarray(instance.pixel_array, mode="RGB")
+            image_pil = Image.fromarray(source_array, mode="RGB")
         box_color = cls._get_bg_color(image_pil, is_greyscale, invert_flag)
 
         return box_color
@@ -839,6 +926,44 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
 
         return has_image_icon_sequence
 
+    @staticmethod
+    def _normalize_bboxes_per_frame(
+        bounding_boxes_coordinates: list, num_frames: int, is_multiframe: bool
+    ) -> List[list]:
+        """Normalize bbox input into one list of bboxes per frame.
+
+        Accepts either a flat list of bbox dicts (single-frame, or the same
+        boxes to apply to every frame of a multi-frame instance) or a list of
+        per-frame bbox lists.
+
+        :param bounding_boxes_coordinates: Flat bbox list or per-frame bbox lists.
+        :param num_frames: Number of frames in the instance.
+        :param is_multiframe: Whether the instance has more than one frame.
+
+        :return: List with one bbox list per frame.
+        """
+        if not is_multiframe:
+            # Accept the per-frame format ([[...]]) for a single-frame instance
+            # by collapsing it to that one frame's bbox list.
+            if bounding_boxes_coordinates and isinstance(
+                bounding_boxes_coordinates[0], list
+            ):
+                return [bounding_boxes_coordinates[0]]
+            return [bounding_boxes_coordinates or []]
+
+        if bounding_boxes_coordinates and isinstance(
+            bounding_boxes_coordinates[0], dict
+        ):
+            # A flat list was provided for a multi-frame instance: apply the
+            # same boxes to every frame.
+            return [list(bounding_boxes_coordinates) for _ in range(num_frames)]
+
+        # Already per-frame; pad/truncate to exactly num_frames entries.
+        per_frame = [list(frame or []) for frame in bounding_boxes_coordinates]
+        if len(per_frame) < num_frames:
+            per_frame += [[] for _ in range(num_frames - len(per_frame))]
+        return per_frame[:num_frames]
+
     @classmethod
     def _add_redact_box(
         cls,
@@ -848,6 +973,11 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         fill: str = "contrast",
     ) -> pydicom.dataset.FileDataset:
         """Add redaction bounding boxes on a DICOM instance.
+
+        For multi-frame instances the redaction is applied to every frame.
+        ``bounding_boxes_coordinates`` may be a flat list of bbox dicts (applied
+        to the single frame, or to all frames of a multi-frame instance) or a
+        list of per-frame bbox lists.
 
         :param instance: A single DICOM instance.
         :param bounding_boxes_coordinates: Bounding box coordinates.
@@ -865,26 +995,47 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
         has_image_icon_sequence = cls._check_if_has_image_icon_sequence(
             redacted_instance
         )
-
-        # Select masking box color
         is_greyscale = cls._check_if_greyscale(instance)
-        if is_greyscale:
-            box_color = cls._get_most_common_pixel_value(instance, crop_ratio, fill)
-        else:
-            box_color = cls._set_bbox_color(redacted_instance, fill)
 
-        # Apply mask
-        for i in range(0, len(bounding_boxes_coordinates)):
-            bbox = bounding_boxes_coordinates[i]
-            top = bbox["top"]
-            left = bbox["left"]
-            width = bbox["width"]
-            height = bbox["height"]
-            redacted_instance.pixel_array[top : top + height, left : left + width] = (
-                box_color
-            )
+        # Decode the pixel data once and mutate it in place; writing it back as a
+        # single block keeps multi-frame data consistent (each access to
+        # ``pixel_array`` otherwise re-decodes from ``PixelData``).
+        pixel_array = redacted_instance.pixel_array
+        num_frames = cls._get_number_of_frames(instance)
+        is_multiframe = num_frames > 1 and pixel_array.shape[0] == num_frames
 
-        redacted_instance.PixelData = redacted_instance.pixel_array.tobytes()
+        bboxes_per_frame = cls._normalize_bboxes_per_frame(
+            bounding_boxes_coordinates, num_frames, is_multiframe
+        )
+
+        for frame_idx, frame_bboxes in enumerate(bboxes_per_frame):
+            if not frame_bboxes:
+                # No PHI detected on this frame; nothing to mask.
+                continue
+
+            frame_view = pixel_array[frame_idx] if is_multiframe else pixel_array
+
+            # Select masking box color per frame so contrast is preserved. Reuse
+            # the already-decoded frame_view to avoid decoding the pixel data
+            # again.
+            if is_greyscale:
+                box_color = cls._get_most_common_pixel_value(
+                    redacted_instance, crop_ratio, fill, pixel_array=frame_view
+                )
+            else:
+                box_color = cls._set_bbox_color(
+                    redacted_instance, fill, pixel_array=frame_view
+                )
+
+            # Apply mask
+            for bbox in frame_bboxes:
+                top = bbox["top"]
+                left = bbox["left"]
+                width = bbox["width"]
+                height = bbox["height"]
+                frame_view[top : top + height, left : left + width] = box_color
+
+        redacted_instance.PixelData = pixel_array.tobytes()
 
         # If original pixel data is compressed, recompress after redaction
         if is_compressed or has_image_icon_sequence:
@@ -1021,33 +1172,53 @@ class DicomImageRedactorEngine(ImageRedactorEngine):
             raise AttributeError("Provided DICOM file lacks pixel data.")
 
         is_greyscale = self._check_if_greyscale(instance)
-        image = self._rescale_dcm_pixel_array(instance, is_greyscale)
-        if is_greyscale:
-            # model L for grayscale, and has 8 bit-pixel to store the pixel value
-            loaded_image = Image.fromarray(image, mode="L")
-        else:
-            loaded_image = Image.fromarray(image, mode="RGB")
-        image = self._add_padding(loaded_image, is_greyscale, padding_width)
+        image_np = self._rescale_dcm_pixel_array(instance, is_greyscale)
+        num_frames = self._get_number_of_frames(instance)
+        is_multiframe = num_frames > 1 and image_np.shape[0] == num_frames
 
-        # Detect PII
-        analyzer_results = self._get_analyzer_results(
-            image,
-            instance,
-            use_metadata,
-            ocr_kwargs,
-            ad_hoc_recognizers,
-            **text_analyzer_kwargs,
-        )
+        # Detect PII on each frame independently
+        frames = image_np if is_multiframe else [image_np]
+        bboxes_per_frame = []
+        for frame_np in frames:
+            loaded_image = self._image_from_array(frame_np, is_greyscale)
+            padded_image = self._add_padding(
+                loaded_image, is_greyscale, padding_width
+            )
 
-        # Redact all bounding boxes from DICOM file
-        analyzer_bboxes = self.bbox_processor.get_bboxes_from_analyzer_results(
-            analyzer_results
+            # Detect PII
+            analyzer_results = self._get_analyzer_results(
+                padded_image,
+                instance,
+                use_metadata,
+                ocr_kwargs,
+                ad_hoc_recognizers,
+                **text_analyzer_kwargs,
+            )
+
+            analyzer_bboxes = self.bbox_processor.get_bboxes_from_analyzer_results(
+                analyzer_results
+            )
+            frame_bboxes = self.bbox_processor.remove_bbox_padding(
+                analyzer_bboxes, padding_width
+            )
+            bboxes_per_frame.append(frame_bboxes)
+
+        # Redact all bounding boxes from DICOM file (every frame for multi-frame)
+        boxes_for_redaction = (
+            bboxes_per_frame if is_multiframe else bboxes_per_frame[0]
         )
-        bboxes = self.bbox_processor.remove_bbox_padding(analyzer_bboxes, padding_width)
         redacted_dicom_instance = self._add_redact_box(
-            instance, bboxes, crop_ratio, fill
+            instance, boxes_for_redaction, crop_ratio, fill
         )
         redacted_dicom_instance.save_as(dst_path)
+
+        # Aggregate bboxes across frames for saving
+        bboxes = [
+            bbox
+            for frame_bboxes in bboxes_per_frame
+            if frame_bboxes
+            for bbox in frame_bboxes
+        ]
 
         # Save redacted bboxes
         if save_bboxes:

--- a/presidio-image-redactor/tests/test_dicom_multiframe_redaction.py
+++ b/presidio-image-redactor/tests/test_dicom_multiframe_redaction.py
@@ -1,0 +1,296 @@
+"""Tests for multi-frame DICOM redaction support.
+
+Covers issue #1737 (every frame of a multi-frame instance must be scanned and
+redacted) and the related #1731 crash ("Too many dimensions: 3 > 2" on
+multi-frame XA grayscale instances).
+"""
+
+import numpy as np
+import pydicom
+import pytest
+from presidio_image_redactor.dicom_image_redactor_engine import (
+    DicomImageRedactorEngine,
+)
+from presidio_image_redactor.entities import ImageRecognizerResult
+from pydicom.dataset import FileDataset, FileMetaDataset
+from pydicom.uid import ExplicitVRLittleEndian, generate_uid
+
+
+def _build_dicom(
+    *,
+    frames: int,
+    rows: int = 16,
+    cols: int = 16,
+    samples_per_pixel: int = 1,
+    photometric: str = "MONOCHROME2",
+    bits_allocated: int = 16,
+) -> FileDataset:
+    """Build a minimal synthetic (optionally multi-frame) DICOM instance.
+
+    Pixel values are distinct and non-flat so that per-frame rescaling and
+    redaction can be observed.
+    """
+    file_meta = FileMetaDataset()
+    file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    file_meta.MediaStorageSOPClassUID = pydicom.uid.SecondaryCaptureImageStorage
+    file_meta.MediaStorageSOPInstanceUID = generate_uid()
+
+    instance = FileDataset(
+        "synthetic.dcm", {}, file_meta=file_meta, preamble=b"\x00" * 128
+    )
+    instance.Rows = rows
+    instance.Columns = cols
+    instance.NumberOfFrames = frames
+    instance.SamplesPerPixel = samples_per_pixel
+    instance.PhotometricInterpretation = photometric
+    instance.BitsAllocated = bits_allocated
+    instance.BitsStored = bits_allocated
+    instance.HighBit = bits_allocated - 1
+    instance.PixelRepresentation = 0
+    if samples_per_pixel == 3:
+        instance.PlanarConfiguration = 0
+
+    dtype = np.uint16 if bits_allocated == 16 else np.uint8
+    if samples_per_pixel == 1:
+        shape = (frames, rows, cols)
+    else:
+        shape = (frames, rows, cols, samples_per_pixel)
+    pixels = (np.arange(int(np.prod(shape))) % 200).astype(dtype).reshape(shape)
+    instance.PixelData = pixels.tobytes()
+    return instance
+
+
+class _StubAnalyzer:
+    """Minimal stand-in for ImageAnalyzerEngine (avoids OCR/NLP dependencies)."""
+
+    def __init__(self, results=None):
+        self._results = results or []
+
+    def analyze(self, image, **kwargs):  # noqa: ANN001, ANN003
+        return list(self._results)
+
+
+# ------------------------------------------------------
+# DicomImageRedactorEngine._get_number_of_frames()
+# ------------------------------------------------------
+@pytest.mark.parametrize("frames, expected", [(1, 1), (3, 3), (12, 12)])
+def test_get_number_of_frames_happy_path(frames: int, expected: int):
+    """Number of Frames (0028,0008) is read for multi- and single-frame data."""
+    instance = _build_dicom(frames=frames)
+    assert DicomImageRedactorEngine._get_number_of_frames(instance) == expected
+
+
+def test_get_number_of_frames_defaults_to_one_when_absent():
+    """A missing Number of Frames element defaults to a single frame."""
+    instance = _build_dicom(frames=1)
+    del instance.NumberOfFrames
+    assert DicomImageRedactorEngine._get_number_of_frames(instance) == 1
+
+
+# ------------------------------------------------------
+# DicomImageRedactorEngine._rescale_dcm_pixel_array() (multi-frame)
+# ------------------------------------------------------
+def test_rescale_dcm_pixel_array_multiframe_returns_stacked_uint8():
+    """Multi-frame rescaling returns a uint8 stack with the frame dimension."""
+    instance = _build_dicom(frames=4, rows=8, cols=8)
+    rescaled = DicomImageRedactorEngine._rescale_dcm_pixel_array(
+        instance, is_greyscale=True
+    )
+    assert rescaled.shape == (4, 8, 8)
+    assert rescaled.dtype == np.uint8
+
+
+def test_rescale_dcm_pixel_array_single_frame_returns_2d():
+    """Single-frame rescaling still returns a 2D uint8 array."""
+    instance = _build_dicom(frames=1, rows=8, cols=8)
+    rescaled = DicomImageRedactorEngine._rescale_dcm_pixel_array(
+        instance, is_greyscale=True
+    )
+    assert rescaled.shape == (8, 8)
+    assert rescaled.dtype == np.uint8
+
+
+def test_rescale_array_flat_frame_returns_zeros():
+    """A flat (single-intensity) greyscale frame rescales to zeros, no error."""
+    flat = np.full((6, 6), 7, dtype=np.uint16)
+    rescaled = DicomImageRedactorEngine._rescale_array(flat, is_greyscale=True)
+    assert rescaled.shape == (6, 6)
+    assert np.all(rescaled == 0)
+
+
+# ------------------------------------------------------
+# DicomImageRedactorEngine._add_redact_box() (multi-frame) -- core fix
+# ------------------------------------------------------
+def test_add_redact_box_multiframe_greyscale_redacts_every_frame(mocker):
+    """Per-frame bboxes redact the same region on every greyscale frame."""
+    frames = 3
+    instance = _build_dicom(frames=frames, rows=20, cols=20)
+    box_color = 0
+    mocker.patch.object(
+        DicomImageRedactorEngine,
+        "_get_most_common_pixel_value",
+        return_value=box_color,
+    )
+    bbox = {"top": 5, "left": 5, "width": 6, "height": 6}
+    per_frame_bboxes = [[bbox] for _ in range(frames)]
+
+    redacted = DicomImageRedactorEngine._add_redact_box(
+        instance, per_frame_bboxes, crop_ratio=0.75, fill="contrast"
+    )
+
+    redacted_pa = redacted.pixel_array
+    assert redacted_pa.shape == (frames, 20, 20)
+    assert int(redacted.NumberOfFrames) == frames
+    for i in range(frames):
+        region = redacted_pa[i, 5:11, 5:11]
+        assert np.all(region == box_color), f"frame {i} region not redacted"
+        # A pixel outside the box is unchanged from the original.
+        assert redacted_pa[i, 0, 0] == instance.pixel_array[i, 0, 0]
+
+
+def test_add_redact_box_multiframe_color_redacts_every_frame(mocker):
+    """Per-frame bboxes redact the same region on every color frame."""
+    frames = 2
+    instance = _build_dicom(
+        frames=frames,
+        rows=12,
+        cols=12,
+        samples_per_pixel=3,
+        photometric="RGB",
+        bits_allocated=8,
+    )
+    mocker.patch.object(
+        DicomImageRedactorEngine, "_set_bbox_color", return_value=(0, 0, 0)
+    )
+    bbox = {"top": 2, "left": 2, "width": 5, "height": 5}
+    per_frame_bboxes = [[bbox] for _ in range(frames)]
+
+    redacted = DicomImageRedactorEngine._add_redact_box(
+        instance, per_frame_bboxes, crop_ratio=0.75, fill="contrast"
+    )
+
+    redacted_pa = redacted.pixel_array
+    assert redacted_pa.shape == (frames, 12, 12, 3)
+    for i in range(frames):
+        assert np.all(redacted_pa[i, 2:7, 2:7, :] == 0), f"frame {i} not redacted"
+
+
+def test_add_redact_box_flat_list_applies_to_all_frames(mocker):
+    """A flat bbox list passed for a multi-frame instance redacts all frames."""
+    frames = 3
+    instance = _build_dicom(frames=frames, rows=16, cols=16)
+    mocker.patch.object(
+        DicomImageRedactorEngine, "_get_most_common_pixel_value", return_value=0
+    )
+    flat_bboxes = [{"top": 4, "left": 4, "width": 4, "height": 4}]
+
+    redacted = DicomImageRedactorEngine._add_redact_box(
+        instance, flat_bboxes, crop_ratio=0.75, fill="contrast"
+    )
+
+    redacted_pa = redacted.pixel_array
+    for i in range(frames):
+        assert np.all(redacted_pa[i, 4:8, 4:8] == 0), f"frame {i} not redacted"
+
+
+def test_add_redact_box_per_frame_shorter_than_frames(mocker):
+    """Fewer per-frame bbox lists than frames leaves trailing frames untouched."""
+    frames = 3
+    instance = _build_dicom(frames=frames, rows=16, cols=16)
+    mocker.patch.object(
+        DicomImageRedactorEngine, "_get_most_common_pixel_value", return_value=0
+    )
+    # Only the first frame has a bbox list provided.
+    per_frame_bboxes = [[{"top": 2, "left": 2, "width": 4, "height": 4}]]
+
+    redacted = DicomImageRedactorEngine._add_redact_box(
+        instance, per_frame_bboxes, crop_ratio=0.75, fill="contrast"
+    )
+
+    redacted_pa = redacted.pixel_array
+    assert np.all(redacted_pa[0, 2:6, 2:6] == 0)
+    # Frames 1 and 2 received no bbox list and are unchanged.
+    for i in range(1, frames):
+        assert np.array_equal(redacted_pa[i], instance.pixel_array[i])
+
+
+def test_add_redact_box_single_frame_unchanged_behavior(mocker):
+    """Single-frame redaction still operates on the lone 2D frame."""
+    instance = _build_dicom(frames=1, rows=16, cols=16)
+    mocker.patch.object(
+        DicomImageRedactorEngine, "_get_most_common_pixel_value", return_value=0
+    )
+    bboxes = [{"top": 3, "left": 3, "width": 5, "height": 5}]
+
+    redacted = DicomImageRedactorEngine._add_redact_box(
+        instance, bboxes, crop_ratio=0.75, fill="contrast"
+    )
+
+    redacted_pa = redacted.pixel_array
+    assert redacted_pa.shape == (16, 16)
+    assert np.all(redacted_pa[3:8, 3:8] == 0)
+
+
+def test_add_redact_box_single_frame_accepts_per_frame_format(mocker):
+    """A single-frame instance accepts the per-frame ([[...]]) bbox format."""
+    instance = _build_dicom(frames=1, rows=16, cols=16)
+    mocker.patch.object(
+        DicomImageRedactorEngine, "_get_most_common_pixel_value", return_value=0
+    )
+    per_frame_bboxes = [[{"top": 3, "left": 3, "width": 5, "height": 5}]]
+
+    redacted = DicomImageRedactorEngine._add_redact_box(
+        instance, per_frame_bboxes, crop_ratio=0.75, fill="contrast"
+    )
+
+    assert redacted.pixel_array.shape == (16, 16)
+    assert np.all(redacted.pixel_array[3:8, 3:8] == 0)
+
+
+# ------------------------------------------------------
+# DicomImageRedactorEngine.redact() end-to-end (multi-frame)
+# ------------------------------------------------------
+def test_redact_multiframe_does_not_raise_and_preserves_shape():
+    """XA-style multi-frame greyscale no longer raises 'Too many dimensions'.
+
+    Regression test for #1731.
+    """
+    instance = _build_dicom(frames=3, rows=24, cols=24)
+    engine = DicomImageRedactorEngine(image_analyzer_engine=_StubAnalyzer([]))
+
+    redacted = engine.redact(instance, use_metadata=False)
+
+    assert isinstance(
+        redacted, (pydicom.dataset.FileDataset, pydicom.dataset.Dataset)
+    )
+    assert int(redacted.NumberOfFrames) == 3
+    assert redacted.pixel_array.shape == (3, 24, 24)
+
+
+def test_redact_multiframe_redacts_all_frames_end_to_end(mocker):
+    """The full redact pipeline applies redaction to every frame (#1737)."""
+    frames = 3
+    instance = _build_dicom(frames=frames, rows=40, cols=40)
+    # Detection coordinates chosen so they remain inside the frame after the
+    # OCR padding is removed (padding_width defaults to 25).
+    detection = ImageRecognizerResult("PERSON", 0, 6, 0.99, 30, 30, 8, 8)
+    engine = DicomImageRedactorEngine(
+        image_analyzer_engine=_StubAnalyzer([detection])
+    )
+    mocker.patch.object(
+        DicomImageRedactorEngine, "_get_most_common_pixel_value", return_value=0
+    )
+
+    redacted, _ = engine.redact_and_return_bbox(instance, use_metadata=False)
+
+    redacted_pa = redacted.pixel_array
+    original_pa = instance.pixel_array
+    assert int(redacted.NumberOfFrames) == frames
+    # Every frame must differ from the original (PHI redacted on each frame).
+    for i in range(frames):
+        assert not np.array_equal(
+            redacted_pa[i], original_pa[i]
+        ), f"frame {i} was not redacted"
+    # Identical detection per frame => identical redaction across frames.
+    for i in range(1, frames):
+        assert np.array_equal(redacted_pa[0], redacted_pa[i])


### PR DESCRIPTION
## Change Description

`DicomImageRedactorEngine` previously detected and redacted PII on only the first frame of a multi-frame DICOM instance, and raised `ValueError: Too many dimensions: 3 > 2` when redacting multi-frame (e.g. XA) grayscale instances, because the pixel array was passed to `Image.fromarray` with the frame axis still present.

This makes redaction frame-aware:

- Frame count is read from `NumberOfFrames` (0028,0008); single-frame behavior is unchanged.
- PII detection runs **per frame**. Multi-frame instances can carry burned-in PHI on any frame, and not necessarily in the same location (as raised in #1737), so each frame is scanned and redacted independently.
- `_add_redact_box` decodes the pixel data once, applies each frame's boxes to that frame, and writes it back as a single block (this also removes a fragile re-decode that relied on `pixel_array` caching in the previous in-place mutation).
- Per-frame rescaling preserves per-frame contrast.
- The DICOM verify engine visualizes a representative frame for multi-frame inputs instead of raising.

This also resolves the `Too many dimensions: 3 > 2` crash (#1731).

### Prior art

#1735 was an earlier attempt at the #1731 crash and was closed without merging. That approach stopped the exception by processing only the first frame; it was confirmed in-thread that the other frames were still not redacted. This PR instead scans and redacts every frame, which is the behavior requested in #1737.

### Tests

Added `tests/test_dicom_multiframe_redaction.py`:
- `_get_number_of_frames` (multi-frame, single-frame, missing element)
- per-frame rescaling returns a stacked uint8 array
- `_add_redact_box` redacts every frame for greyscale and color multi-frame instances, and leaves single-frame behavior unchanged
- end-to-end `redact()` applies redaction to every frame
- regression test for the #1731 crash

The image-redactor unit suite (200 tests) and `ruff` pass locally. Integration tests that require a Tesseract binary were not run locally and are left to CI.

## Issue reference

Fixes #1737
Fixes #1731

### Open questions
- Detection runs OCR per frame, which is faithful to #1737 but is N x OCR for large cine loops. Would you prefer an optional frame-deduplication step (skip re-OCR on identical frames) or an opt-out for very large series?
- For multi-frame inputs the verify engine currently visualizes the first frame rather than returning per-frame results. Is that acceptable, or would per-frame verification output be preferable?

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)
- [x] I have signed the CLA (if required)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
