### PR TITLE
revert: undo accidental direct-to-main docs pushes (fix duplicate copyright)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,10 +221,6 @@ plugins:
             filters:
               - "!^_"
 
-copyright: >
-  Maintained by
-  <a href="https://dataprivacystack.org" target="_blank" rel="noopener">Data Privacy Stack</a>
-
 extra:
   social:
     - icon: fontawesome/brands/github

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,10 +1,5 @@
 {% extends "base.html" %}
 
-{% block extrahead %}
-{{ super() }}
-<meta name="google-site-verification" content="XTJynzxw5KJpNFN8WemNurQh1lj33OTCbkDbQr8267k" />
-{% endblock %}
-
 {% block analytics %}
 <!-- Microsoft Clarity with Consent Mode -->
 <script type="text/javascript">


### PR DESCRIPTION
## What

Reverts two commits that were pushed **directly to `main` by mistake**:
- `b9e1f6dd` — Google Search Console verification meta tag
- `836cfa83` — Data Privacy Stack footer link

## Why

[#2102](https://github.com/microsoft/presidio/pull/2102) (Zensical migration) independently added its own `copyright` entry pointing to dataprivacystack.org. That left `main` with **two top-level `copyright:` keys** in `mkdocs.yml` — a duplicate-key bug (YAML keeps the last one, so footer behavior is ambiguous).

This revert:
- removes our **redundant** `copyright` block (keeps #2102's), fixing the duplicate-key bug, and
- removes the **orphaned** meta tag that should have gone through review.

## Follow-up

The Search Console meta tag is re-introduced properly in #PLACEHOLDER, stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)