### PR TITLE
Fix CI and release container publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
           for image_archive in image-artifacts/*.tar.gz; do
             gzip -dc "${image_archive}" | docker load
           done
-          docker image ls "${{ env.REGISTRY_NAME }}/*:${{ env.TAG }}"
+          docker image ls
 
       - name: Start Presidio cluster
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,198 +183,11 @@ jobs:
           pip install --require-hashes -r ${{ github.workspace }}/.github/pipelines/requirements-build.txt
           python -m build --wheel
 
-  build-platform-images:
-    name: Build ${{ matrix.image }} (${{ matrix.platform }})
-    runs-on: ${{ matrix.runner }}
-    needs: [lint]
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-    strategy:
-      matrix:
-        include:
-          - image: presidio-anonymizer
-            platform: linux/amd64
-            runner: ubuntu-latest
-          - image: presidio-analyzer
-            platform: linux/amd64
-            runner: ubuntu-latest
-          - image: presidio-image-redactor
-            platform: linux/amd64
-            runner: ubuntu-latest
-          - image: presidio-anonymizer
-            platform: linux/arm64
-            runner: ubuntu-24.04-arm
-          - image: presidio-analyzer
-            platform: linux/arm64
-            runner: ubuntu-24.04-arm
-          - image: presidio-image-redactor
-            platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
-        with:
-          persist-credentials: false
-
-      - name: Log in to GitHub Container Registry
-        env:
-          GHCR_TOKEN: ${{ github.repository_owner == 'data-privacy-stack' && github.token || secrets.GHCR_TOKEN }}
-          GHCR_USERNAME: ${{ github.repository_owner == 'data-privacy-stack' && github.actor || vars.GHCR_USERNAME || github.actor }}
-        run: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Build and Push ${{ matrix.image }} for ${{ matrix.platform }}
-        run: |
-          # Create platform-specific tag
-          PLATFORM_TAG=$(echo "${{ matrix.platform }}" | sed 's/\//-/g')
-          docker buildx build \
-            --platform ${{ matrix.platform }} \
-            --push \
-            --tag ${{ env.REGISTRY_NAME }}/${{ matrix.image }}:${{ env.TAG }}-${PLATFORM_TAG} \
-            --cache-from type=registry,ref=${{ env.REGISTRY_NAME }}/${{ matrix.image }}:latest \
-            --cache-to type=inline \
-            --attest type=sbom \
-            --attest type=provenance,mode=max \
-            ./${{ matrix.image }}
-        env:
-          REGISTRY_NAME: ${{ env.REGISTRY_NAME }}
-          TAG: ${{ env.TAG }}
-
-  create-manifests:
-    name: Create Multi-Platform Manifests
-    runs-on: ubuntu-latest
-    needs: build-platform-images
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Log in to GitHub Container Registry
-        env:
-          GHCR_TOKEN: ${{ github.repository_owner == 'data-privacy-stack' && github.token || secrets.GHCR_TOKEN }}
-          GHCR_USERNAME: ${{ github.repository_owner == 'data-privacy-stack' && github.actor || vars.GHCR_USERNAME || github.actor }}
-        run: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Create all multi-platform manifests
-        run: |
-          IMAGES=("presidio-anonymizer" "presidio-analyzer" "presidio-image-redactor")
-          
-          for image in "${IMAGES[@]}"; do
-            echo "Creating manifest for $image"
-            docker buildx imagetools create \
-              --tag ${{ env.REGISTRY_NAME }}/${image}:${{ env.TAG }} \
-              ${{ env.REGISTRY_NAME }}/${image}:${{ env.TAG }}-linux-amd64 \
-              ${{ env.REGISTRY_NAME }}/${image}:${{ env.TAG }}-linux-arm64
-          done
-        env:
-          REGISTRY_NAME: ${{ env.REGISTRY_NAME }}
-          TAG: ${{ env.TAG }}
-
-  e2e-tests:
-    name: E2E Tests (${{ matrix.platform }})
-    runs-on: ${{ matrix.runner }}
-    needs: create-manifests
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      contents: read
-      packages: read
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
-        with:
-          persist-credentials: false
-
-      - name: Log in to GitHub Container Registry
-        env:
-          GHCR_TOKEN: ${{ github.repository_owner == 'data-privacy-stack' && github.token || secrets.GHCR_TOKEN }}
-          GHCR_USERNAME: ${{ github.repository_owner == 'data-privacy-stack' && github.actor || vars.GHCR_USERNAME || github.actor }}
-        run: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
-
-      - name: Pull Presidio images from GHCR
-        run: |
-          export DOCKER_DEFAULT_PLATFORM=${{ matrix.platform }}
-          docker compose -f docker-compose.yml pull
-        env:
-          REGISTRY_NAME: ${{ env.REGISTRY_NAME }}
-          TAG: ':${{ env.TAG }}'
-
-      - name: Start Presidio cluster
-        run: |
-          export DOCKER_DEFAULT_PLATFORM=${{ matrix.platform }}
-          docker compose -f docker-compose.yml up -d
-        env:
-          REGISTRY_NAME: ${{ env.REGISTRY_NAME }}
-          TAG: ':${{ env.TAG }}'
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.10'
-
-      - name: Cache E2E dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.0
-        with:
-          path: |
-            ~/.cache/pip
-            e2e-tests/env
-          key: ${{ runner.os }}-${{ matrix.platform }}-e2e-${{ hashFiles('e2e-tests/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.platform }}-e2e-
-
-      - name: Install E2E test dependencies
-        working-directory: e2e-tests
-        run: |
-          python -m venv env
-          source env/bin/activate
-          pip install -r requirements.txt
-          python -m spacy download en_core_web_lg
-
-      - name: Wait for services to be ready
-        run: sleep 60
-
-      - name: Download Ollama model for Ollama LangExtract recognizer tests
-        run: |
-          docker exec $(docker ps -qf "name=ollama") ollama pull qwen2.5:1.5b
-          docker exec $(docker ps -qf "name=ollama") ollama run qwen2.5:1.5b
-
-      - name: Run E2E tests
-        working-directory: e2e-tests
-        run: |
-          source env/bin/activate
-          pytest -vv --tb=short
-
-      - name: Capture Docker logs on failure (${{ matrix.platform }})
-        if: failure()
-        run: |
-          echo "Capturing Docker logs for platform: ${{ matrix.platform }}"
-          docker compose -f docker-compose.yml logs
-
-      - name: Stop Docker containers
-        if: always()
-        run: |
-          docker compose -f docker-compose.yml down
-
-  # Local build and test jobs for external contributors (no secrets required) 
+  # Build and test Docker images locally so CI does not publish ephemeral tags.
   local-build-and-test:
-    name: Local Build and E2E Tests (${{ matrix.platform }})
+    name: Build and E2E Tests (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     needs: [lint]
-    if: github.ref != 'refs/heads/main'
     strategy:
       matrix:
         include:
@@ -396,17 +209,17 @@ jobs:
           # Build all images locally without pushing
           docker compose -f docker-compose.yml build
         env:
-          REGISTRY_NAME: 'ghcr.io/data-privacy-stack'
+          REGISTRY_NAME: ${{ env.REGISTRY_NAME }}
           IMAGE_PREFIX: ''
-          TAG: ':gha${{ github.run_number }}'
+          TAG: ':${{ env.TAG }}'
 
       - name: Start Presidio cluster locally
         run: |
           docker compose -f docker-compose.yml up -d
         env:
-          REGISTRY_NAME: 'ghcr.io/data-privacy-stack'
+          REGISTRY_NAME: ${{ env.REGISTRY_NAME }}
           IMAGE_PREFIX: ''
-          TAG: ':gha${{ github.run_number }}'
+          TAG: ':${{ env.TAG }}'
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,11 +183,164 @@ jobs:
           pip install --require-hashes -r ${{ github.workspace }}/.github/pipelines/requirements-build.txt
           python -m build --wheel
 
-  # Build and test Docker images locally so CI does not publish ephemeral tags.
-  local-build-and-test:
-    name: Build and E2E Tests (${{ matrix.platform }})
+  build-platform-images:
+    name: Build ${{ matrix.image }} (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     needs: [lint]
+    if: github.ref == 'refs/heads/main'
+    strategy:
+      matrix:
+        include:
+          - image: presidio-anonymizer
+            platform: linux/amd64
+            platform_tag: linux-amd64
+            runner: ubuntu-latest
+          - image: presidio-analyzer
+            platform: linux/amd64
+            platform_tag: linux-amd64
+            runner: ubuntu-latest
+          - image: presidio-image-redactor
+            platform: linux/amd64
+            platform_tag: linux-amd64
+            runner: ubuntu-latest
+          - image: presidio-anonymizer
+            platform: linux/arm64
+            platform_tag: linux-arm64
+            runner: ubuntu-24.04-arm
+          - image: presidio-analyzer
+            platform: linux/arm64
+            platform_tag: linux-arm64
+            runner: ubuntu-24.04-arm
+          - image: presidio-image-redactor
+            platform: linux/arm64
+            platform_tag: linux-arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build ${{ matrix.image }} image artifact
+        run: |
+          mkdir -p image-artifacts
+          image_ref="${{ env.REGISTRY_NAME }}/${{ matrix.image }}:${{ env.TAG }}"
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            --cache-from type=registry,ref=${{ env.REGISTRY_NAME }}/${{ matrix.image }}:latest \
+            --tag "${image_ref}" \
+            --output type=docker,dest="image-artifacts/${{ matrix.image }}.tar" \
+            ./${{ matrix.image }}
+          gzip "image-artifacts/${{ matrix.image }}.tar"
+
+      - name: Upload ${{ matrix.image }} image artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ matrix.image }}-${{ matrix.platform_tag }}
+          path: image-artifacts/${{ matrix.image }}.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+  e2e-tests:
+    name: E2E Tests (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    needs: build-platform-images
+    if: github.ref == 'refs/heads/main'
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            platform_tag: linux-amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            platform_tag: linux-arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download image artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: presidio-*-${{ matrix.platform_tag }}
+          path: image-artifacts
+          merge-multiple: true
+
+      - name: Load Presidio images
+        run: |
+          for image_archive in image-artifacts/*.tar.gz; do
+            gzip -dc "${image_archive}" | docker load
+          done
+          docker image ls "${{ env.REGISTRY_NAME }}/*:${{ env.TAG }}"
+
+      - name: Start Presidio cluster
+        run: |
+          export DOCKER_DEFAULT_PLATFORM=${{ matrix.platform }}
+          docker compose -f docker-compose.yml up -d --no-build
+        env:
+          REGISTRY_NAME: ${{ env.REGISTRY_NAME }}
+          IMAGE_PREFIX: ''
+          TAG: ':${{ env.TAG }}'
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.10'
+
+      - name: Cache E2E dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.0
+        with:
+          path: |
+            ~/.cache/pip
+            e2e-tests/env
+          key: ${{ runner.os }}-${{ matrix.platform }}-e2e-${{ hashFiles('e2e-tests/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.platform }}-e2e-
+
+      - name: Install E2E test dependencies
+        working-directory: e2e-tests
+        run: |
+          python -m venv env
+          source env/bin/activate
+          pip install -r requirements.txt
+          python -m spacy download en_core_web_lg
+
+      - name: Wait for services to be ready
+        run: sleep 60
+
+      - name: Download Ollama model for Ollama LangExtract recognizer tests
+        run: |
+          docker exec $(docker ps -qf "name=ollama") ollama pull qwen2.5:1.5b
+          docker exec $(docker ps -qf "name=ollama") ollama run qwen2.5:1.5b
+
+      - name: Run E2E tests
+        working-directory: e2e-tests
+        run: |
+          source env/bin/activate
+          pytest -vv --tb=short
+
+      - name: Capture Docker logs on failure (${{ matrix.platform }})
+        if: failure()
+        run: |
+          echo "Capturing Docker logs for platform: ${{ matrix.platform }}"
+          docker compose -f docker-compose.yml logs
+
+      - name: Stop Docker containers
+        if: always()
+        run: |
+          docker compose -f docker-compose.yml down
+
+  # Build and test Docker images locally for non-main branches without publishing.
+  local-build-and-test:
+    name: Local Build and E2E Tests (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    needs: [lint]
+    if: github.ref != 'refs/heads/main'
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: [lint]
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: read
     strategy:
       matrix:
         include:
@@ -220,6 +223,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           persist-credentials: false
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ permissions: read-all
 env:
   IMAGE_REGISTRY: ghcr.io
   IMAGE_NAMESPACE: data-privacy-stack
+  CONTAINER_PLATFORMS_JSON: '["linux/amd64","linux/arm64"]'
 
 jobs:
   get-version:
@@ -119,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         image: [presidio-anonymizer, presidio-analyzer, presidio-image-redactor]
-        platform: [linux/amd64, linux/arm64]
+        platform: ${{ fromJson(env.CONTAINER_PLATFORMS_JSON) }}
 
     steps:
       - name: Checkout code
@@ -183,12 +184,13 @@ jobs:
             fi
 
             for tag in latest "${version_tag}"; do
+              platform_refs=$(repo="${repo}" tag="${tag}" python -c 'import json, os; print(" ".join(f"{os.environ[\"repo\"]}:{os.environ[\"tag\"]}-{platform.replace(\"/\", \"-\")}" for platform in json.loads(os.environ["CONTAINER_PLATFORMS_JSON"])))')
               docker buildx imagetools create \
                 --tag ${repo}:${tag} \
-                ${repo}:${tag}-linux-amd64 \
-                ${repo}:${tag}-linux-arm64
+                ${platform_refs}
             done
           done
         env:
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           IMAGE_NAMESPACE: ${{ env.IMAGE_NAMESPACE }}
+          CONTAINER_PLATFORMS_JSON: ${{ env.CONTAINER_PLATFORMS_JSON }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [presidio-anonymizer, presidio-analyzer, presidio-image-redactor]
+        image: [presidio-anonymizer, presidio-image-redactor]
 
     steps:
       - name: Checkout code
@@ -148,6 +148,89 @@ jobs:
             --attest type=provenance,mode=max \
             --push \
             ./${{ matrix.image }}
+        env:
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+          IMAGE_NAMESPACE: ${{ env.IMAGE_NAMESPACE }}
+
+  build-and-push-analyzer-platform-images:
+    name: Build and Push Analyzer (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    needs: get-version
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        with:
+          persist-credentials: false
+
+      - name: Log in to GitHub Container Registry
+        env:
+          GHCR_TOKEN: ${{ github.repository_owner == 'data-privacy-stack' && github.token || secrets.GHCR_TOKEN }}
+          GHCR_USERNAME: ${{ github.repository_owner == 'data-privacy-stack' && github.actor || vars.GHCR_USERNAME || github.actor }}
+        run: echo "${GHCR_TOKEN}" | docker login ${{ env.IMAGE_REGISTRY }} -u "${GHCR_USERNAME}" --password-stdin
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build and Push presidio-analyzer for ${{ matrix.platform }}
+        run: |
+          repo="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/presidio-analyzer"
+          version_tag="${{ needs.get-version.outputs.version }}"
+          platform_tag=$(echo "${{ matrix.platform }}" | sed 's/\//-/g')
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            --cache-from type=registry,ref=${repo}:latest \
+            --cache-to type=inline \
+            --tag ${repo}:latest-${platform_tag} \
+            --tag ${repo}:${version_tag}-${platform_tag} \
+            --attest type=sbom \
+            --attest type=provenance,mode=max \
+            --push \
+            ./presidio-analyzer
+        env:
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+          IMAGE_NAMESPACE: ${{ env.IMAGE_NAMESPACE }}
+
+  create-analyzer-manifests:
+    name: Create Analyzer Multi-Platform Manifests
+    runs-on: ubuntu-latest
+    needs: [get-version, build-and-push-analyzer-platform-images]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Log in to GitHub Container Registry
+        env:
+          GHCR_TOKEN: ${{ github.repository_owner == 'data-privacy-stack' && github.token || secrets.GHCR_TOKEN }}
+          GHCR_USERNAME: ${{ github.repository_owner == 'data-privacy-stack' && github.actor || vars.GHCR_USERNAME || github.actor }}
+        run: echo "${GHCR_TOKEN}" | docker login ${{ env.IMAGE_REGISTRY }} -u "${GHCR_USERNAME}" --password-stdin
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Create analyzer manifests
+        run: |
+          repo="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/presidio-analyzer"
+          version_tag="${{ needs.get-version.outputs.version }}"
+
+          for tag in latest "${version_tag}"; do
+            docker buildx imagetools create \
+              --tag ${repo}:${tag} \
+              ${repo}:${tag}-linux-amd64 \
+              ${repo}:${tag}-linux-arm64
+          done
         env:
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           IMAGE_NAMESPACE: ${{ env.IMAGE_NAMESPACE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
     outputs:
       version: ${{ steps.set-version.outputs.version }}
       image-version: ${{ steps.set-image-version.outputs.image-version }}
-      container-images: ${{ steps.set-container-images.outputs.container-images }}
-      container-platforms: ${{ steps.set-container-platforms.outputs.container-platforms }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
@@ -39,14 +37,6 @@ jobs:
           imageVer=$(grep -m 1 version presidio-image-redactor/pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)
           echo "image-version=$imageVer" >> $GITHUB_OUTPUT
           echo "Image-redactor version: $imageVer"
-
-      - name: Set container platforms
-        id: set-container-platforms
-        run: echo 'container-platforms=["linux/amd64","linux/arm64"]' >> $GITHUB_OUTPUT
-
-      - name: Set container images
-        id: set-container-images
-        run: echo 'container-images=["presidio-anonymizer","presidio-analyzer","presidio-image-redactor"]' >> $GITHUB_OUTPUT
 
   github-release:
     name: Create GitHub Release
@@ -128,8 +118,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ${{ fromJson(needs.get-version.outputs.container-images) }}
-        platform: ${{ fromJson(needs.get-version.outputs.container-platforms) }}
+        image: [presidio-anonymizer, presidio-analyzer, presidio-image-redactor]
+        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            platform_tag: linux-amd64
+          - platform: linux/arm64
+            platform_tag: linux-arm64
 
     steps:
       - name: Checkout code
@@ -148,22 +143,25 @@ jobs:
 
       - name: Build and Push ${{ matrix.image }} for ${{ matrix.platform }}
         run: |
-          repo="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}"
-          version_tag="${{ matrix.image == 'presidio-image-redactor' && needs.get-version.outputs.image-version || needs.get-version.outputs.version }}"
-          platform_tag=$(echo "${{ matrix.platform }}" | sed 's/\//-/g')
+          repo="${IMAGE_REGISTRY}/${IMAGE_NAMESPACE}/${{ matrix.image }}"
+          version_tag="${VERSION}"
+          if [ "${{ matrix.image }}" = "presidio-image-redactor" ]; then
+            version_tag="${IMAGE_VERSION}"
+          fi
+
           docker buildx build \
             --platform ${{ matrix.platform }} \
             --cache-from type=registry,ref=${repo}:latest \
             --cache-to type=inline \
-            --tag ${repo}:latest-${platform_tag} \
-            --tag ${repo}:${version_tag}-${platform_tag} \
+            --tag "${repo}:latest-${{ matrix.platform_tag }}" \
+            --tag "${repo}:${version_tag}-${{ matrix.platform_tag }}" \
             --attest type=sbom \
             --attest type=provenance,mode=max \
             --push \
             ./${{ matrix.image }}
         env:
-          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
-          IMAGE_NAMESPACE: ${{ env.IMAGE_NAMESPACE }}
+          VERSION: ${{ needs.get-version.outputs.version }}
+          IMAGE_VERSION: ${{ needs.get-version.outputs.image-version }}
 
   create-container-manifests:
     name: Create Multi-Platform Container Manifests
@@ -184,27 +182,27 @@ jobs:
 
       - name: Create multi-platform manifests
         run: |
-          for image in $(python -c 'import json, os; print("\n".join(json.loads(os.environ["CONTAINER_IMAGES_JSON"])))'); do
-            repo="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${image}"
+          images=(presidio-anonymizer presidio-analyzer presidio-image-redactor)
+          platform_tags=(linux-amd64 linux-arm64)
+
+          for image in "${images[@]}"; do
+            repo="${IMAGE_REGISTRY}/${IMAGE_NAMESPACE}/${image}"
+            version_tag="${VERSION}"
             if [ "${image}" = "presidio-image-redactor" ]; then
-              version_tag="${{ needs.get-version.outputs.image-version }}"
-            else
-              version_tag="${{ needs.get-version.outputs.version }}"
+              version_tag="${IMAGE_VERSION}"
             fi
 
             for tag in latest "${version_tag}"; do
-              platform_refs=""
-              for platform_tag in $(python -c 'import json, os; print("\n".join(platform.replace("/", "-") for platform in json.loads(os.environ["CONTAINER_PLATFORMS_JSON"])))'); do
-                platform_refs="${platform_refs} ${repo}:${tag}-${platform_tag}"
+              platform_refs=()
+              for platform_tag in "${platform_tags[@]}"; do
+                platform_refs+=("${repo}:${tag}-${platform_tag}")
               done
-              platform_refs="${platform_refs# }"
+
               docker buildx imagetools create \
-                --tag ${repo}:${tag} \
-                ${platform_refs}
+                --tag "${repo}:${tag}" \
+                "${platform_refs[@]}"
             done
           done
         env:
-          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
-          IMAGE_NAMESPACE: ${{ env.IMAGE_NAMESPACE }}
-          CONTAINER_IMAGES_JSON: ${{ needs.get-version.outputs.container-images }}
-          CONTAINER_PLATFORMS_JSON: ${{ needs.get-version.outputs.container-platforms }}
+          VERSION: ${{ needs.get-version.outputs.version }}
+          IMAGE_VERSION: ${{ needs.get-version.outputs.image-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ permissions: read-all
 env:
   IMAGE_REGISTRY: ghcr.io
   IMAGE_NAMESPACE: data-privacy-stack
-  CONTAINER_PLATFORMS_JSON: '["linux/amd64","linux/arm64"]'
 
 jobs:
   get-version:
@@ -17,6 +16,7 @@ jobs:
     outputs:
       version: ${{ steps.set-version.outputs.version }}
       image-version: ${{ steps.set-image-version.outputs.image-version }}
+      container-platforms: ${{ steps.set-container-platforms.outputs.container-platforms }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
@@ -38,6 +38,10 @@ jobs:
           imageVer=$(grep -m 1 version presidio-image-redactor/pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | cut -d' ' -f3)
           echo "image-version=$imageVer" >> $GITHUB_OUTPUT
           echo "Image-redactor version: $imageVer"
+
+      - name: Set container platforms
+        id: set-container-platforms
+        run: echo 'container-platforms=["linux/amd64","linux/arm64"]' >> $GITHUB_OUTPUT
 
   github-release:
     name: Create GitHub Release
@@ -120,7 +124,7 @@ jobs:
       fail-fast: false
       matrix:
         image: [presidio-anonymizer, presidio-analyzer, presidio-image-redactor]
-        platform: ${{ fromJson(env.CONTAINER_PLATFORMS_JSON) }}
+        platform: ${{ fromJson(needs.get-version.outputs.container-platforms) }}
 
     steps:
       - name: Checkout code
@@ -184,7 +188,11 @@ jobs:
             fi
 
             for tag in latest "${version_tag}"; do
-              platform_refs=$(repo="${repo}" tag="${tag}" python -c 'import json, os; print(" ".join(f"{os.environ[\"repo\"]}:{os.environ[\"tag\"]}-{platform.replace(\"/\", \"-\")}" for platform in json.loads(os.environ["CONTAINER_PLATFORMS_JSON"])))')
+              platform_refs=""
+              for platform_tag in $(python -c 'import json, os; print("\n".join(platform.replace("/", "-") for platform in json.loads(os.environ["CONTAINER_PLATFORMS_JSON"])))'); do
+                platform_refs="${platform_refs} ${repo}:${tag}-${platform_tag}"
+              done
+              platform_refs="${platform_refs# }"
               docker buildx imagetools create \
                 --tag ${repo}:${tag} \
                 ${platform_refs}
@@ -193,4 +201,4 @@ jobs:
         env:
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           IMAGE_NAMESPACE: ${{ env.IMAGE_NAMESPACE }}
-          CONTAINER_PLATFORMS_JSON: ${{ env.CONTAINER_PLATFORMS_JSON }}
+          CONTAINER_PLATFORMS_JSON: ${{ needs.get-version.outputs.container-platforms }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,53 +108,8 @@ jobs:
           skip-existing: true
 
   build-and-push-containers:
-    name: Build and Push Containers
-    runs-on: ubuntu-latest
-    needs: get-version
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [presidio-anonymizer, presidio-image-redactor]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
-        with:
-          persist-credentials: false
-
-      - name: Log in to GitHub Container Registry
-        env:
-          GHCR_TOKEN: ${{ github.repository_owner == 'data-privacy-stack' && github.token || secrets.GHCR_TOKEN }}
-          GHCR_USERNAME: ${{ github.repository_owner == 'data-privacy-stack' && github.actor || vars.GHCR_USERNAME || github.actor }}
-        run: echo "${GHCR_TOKEN}" | docker login ${{ env.IMAGE_REGISTRY }} -u "${GHCR_USERNAME}" --password-stdin
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Build and Push ${{ matrix.image }}
-        run: |
-          repo="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}"
-          version_tag="${{ matrix.image == 'presidio-image-redactor' && needs.get-version.outputs.image-version || needs.get-version.outputs.version }}"
-          docker buildx build \
-            --platform linux/amd64,linux/arm64 \
-            --cache-from type=registry,ref=${repo}:latest \
-            --cache-to type=inline \
-            --tag ${repo}:latest \
-            --tag ${repo}:${version_tag} \
-            --attest type=sbom \
-            --attest type=provenance,mode=max \
-            --push \
-            ./${{ matrix.image }}
-        env:
-          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
-          IMAGE_NAMESPACE: ${{ env.IMAGE_NAMESPACE }}
-
-  build-and-push-analyzer-platform-images:
-    name: Build and Push Analyzer (${{ matrix.platform }})
-    runs-on: ${{ matrix.runner }}
+    name: Build and Push ${{ matrix.image }} (${{ matrix.platform }})
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     needs: get-version
     permissions:
       contents: read
@@ -163,11 +118,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
+        image: [presidio-anonymizer, presidio-analyzer, presidio-image-redactor]
+        platform: [linux/amd64, linux/arm64]
 
     steps:
       - name: Checkout code
@@ -184,10 +136,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Build and Push presidio-analyzer for ${{ matrix.platform }}
+      - name: Build and Push ${{ matrix.image }} for ${{ matrix.platform }}
         run: |
-          repo="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/presidio-analyzer"
-          version_tag="${{ needs.get-version.outputs.version }}"
+          repo="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}"
+          version_tag="${{ matrix.image == 'presidio-image-redactor' && needs.get-version.outputs.image-version || needs.get-version.outputs.version }}"
           platform_tag=$(echo "${{ matrix.platform }}" | sed 's/\//-/g')
           docker buildx build \
             --platform ${{ matrix.platform }} \
@@ -198,15 +150,15 @@ jobs:
             --attest type=sbom \
             --attest type=provenance,mode=max \
             --push \
-            ./presidio-analyzer
+            ./${{ matrix.image }}
         env:
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           IMAGE_NAMESPACE: ${{ env.IMAGE_NAMESPACE }}
 
-  create-analyzer-manifests:
-    name: Create Analyzer Multi-Platform Manifests
+  create-container-manifests:
+    name: Create Multi-Platform Container Manifests
     runs-on: ubuntu-latest
-    needs: [get-version, build-and-push-analyzer-platform-images]
+    needs: [get-version, build-and-push-containers]
     permissions:
       contents: read
       packages: write
@@ -220,16 +172,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Create analyzer manifests
+      - name: Create multi-platform manifests
         run: |
-          repo="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/presidio-analyzer"
-          version_tag="${{ needs.get-version.outputs.version }}"
+          for image in presidio-anonymizer presidio-analyzer presidio-image-redactor; do
+            repo="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${image}"
+            if [ "${image}" = "presidio-image-redactor" ]; then
+              version_tag="${{ needs.get-version.outputs.image-version }}"
+            else
+              version_tag="${{ needs.get-version.outputs.version }}"
+            fi
 
-          for tag in latest "${version_tag}"; do
-            docker buildx imagetools create \
-              --tag ${repo}:${tag} \
-              ${repo}:${tag}-linux-amd64 \
-              ${repo}:${tag}-linux-arm64
+            for tag in latest "${version_tag}"; do
+              docker buildx imagetools create \
+                --tag ${repo}:${tag} \
+                ${repo}:${tag}-linux-amd64 \
+                ${repo}:${tag}-linux-arm64
+            done
           done
         env:
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       version: ${{ steps.set-version.outputs.version }}
       image-version: ${{ steps.set-image-version.outputs.image-version }}
+      container-images: ${{ steps.set-container-images.outputs.container-images }}
       container-platforms: ${{ steps.set-container-platforms.outputs.container-platforms }}
     steps:
       - name: Checkout code
@@ -42,6 +43,10 @@ jobs:
       - name: Set container platforms
         id: set-container-platforms
         run: echo 'container-platforms=["linux/amd64","linux/arm64"]' >> $GITHUB_OUTPUT
+
+      - name: Set container images
+        id: set-container-images
+        run: echo 'container-images=["presidio-anonymizer","presidio-analyzer","presidio-image-redactor"]' >> $GITHUB_OUTPUT
 
   github-release:
     name: Create GitHub Release
@@ -123,7 +128,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [presidio-anonymizer, presidio-analyzer, presidio-image-redactor]
+        image: ${{ fromJson(needs.get-version.outputs.container-images) }}
         platform: ${{ fromJson(needs.get-version.outputs.container-platforms) }}
 
     steps:
@@ -179,7 +184,7 @@ jobs:
 
       - name: Create multi-platform manifests
         run: |
-          for image in presidio-anonymizer presidio-analyzer presidio-image-redactor; do
+          for image in $(python -c 'import json, os; print("\n".join(json.loads(os.environ["CONTAINER_IMAGES_JSON"])))'); do
             repo="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${image}"
             if [ "${image}" = "presidio-image-redactor" ]; then
               version_tag="${{ needs.get-version.outputs.image-version }}"
@@ -201,4 +206,5 @@ jobs:
         env:
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           IMAGE_NAMESPACE: ${{ env.IMAGE_NAMESPACE }}
+          CONTAINER_IMAGES_JSON: ${{ needs.get-version.outputs.container-images }}
           CONTAINER_PLATFORMS_JSON: ${{ needs.get-version.outputs.container-platforms }}


### PR DESCRIPTION
## Summary
- run release container builds through a shared image/platform matrix for all three images, using native amd64 and arm64 runners
- create release multi-platform manifests for all images after platform-specific pushes complete
- keep main-branch CI E2E tests on ephemeral images by saving build outputs as short-lived workflow artifacts and loading them in the E2E jobs instead of publishing `gha*` tags to GHCR
- keep non-main CI using local Docker Compose build+E2E without publishing

## Validation
- parsed updated workflow YAML
- checked workflow diffs for whitespace issues
- validated Docker Compose config with CI image environment