### PR TITLE
Add CLI threshold override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+### CLI
+#### Added
+- Added a `--threshold` flag to `presidio-cli` so one-shot invocations can override the configured analyzer confidence threshold without writing inline YAML or a temporary config file. Fixes [#2101](https://github.com/data-privacy-stack/presidio/issues/2101).
+
 ## [2.2.363] - 2026-06-28
 ### General
 #### Added

--- a/presidio-cli/README.md
+++ b/presidio-cli/README.md
@@ -70,6 +70,8 @@ Configuration file supports the following parameters in a yaml file:
 
 - allow - list of tokens that should not be marked as PII.
 
+- threshold - minimum confidence score for detected entities.
+
 Note: a file requires at least one parameter to be set.
 
 An example of yaml configuration file content:
@@ -113,6 +115,9 @@ presidio -c presidio_cli/conf/limited.yaml tests/
 
 # run with configuration limited.yaml in single file only tests/test_analyzer.py
 presidio -c presidio_cli/conf/limited.yaml tests/test_analyzer.py
+
+# override the configured threshold for one invocation
+presidio -c presidio_cli/conf/limited.yaml --threshold 0.7 tests/
 ```
 
 ### Configuration as a parameter

--- a/presidio-cli/presidio_cli/cli.py
+++ b/presidio-cli/presidio_cli/cli.py
@@ -81,6 +81,19 @@ class Format(object):
         return line
 
 
+def threshold_value(value: str) -> float:
+    """Parse and validate a CLI threshold value."""
+    try:
+        threshold = float(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError("threshold must be a number") from e
+
+    if not 0 <= threshold <= 1:
+        raise argparse.ArgumentTypeError("threshold must be between 0 and 1")
+
+    return threshold
+
+
 def supports_color() -> bool:
     """Check whether the platform supports colored output."""
     supported_platform = not (
@@ -215,6 +228,11 @@ def run() -> None:
         action="store_true",
         help="output only error level problems",
     )
+    parser.add_argument(
+        "--threshold",
+        type=threshold_value,
+        help="minimum confidence score for detected entities (overrides configuration)",
+    )
 
     args = parser.parse_args()
 
@@ -232,6 +250,9 @@ def run() -> None:
     except PresidioCLIConfigError as e:
         print(e, file=sys.stderr)
         sys.exit(1)
+
+    if args.threshold is not None:
+        conf.threshold = args.threshold
 
     if conf.locale is not None:
         locale.setlocale(locale.LC_ALL, conf.locale)

--- a/presidio-cli/tests/test_cli.py
+++ b/presidio-cli/tests/test_cli.py
@@ -1,6 +1,8 @@
+import argparse
 import os
-import pytest
 from io import StringIO
+
+import pytest
 from presidio_cli import cli
 
 
@@ -90,9 +92,74 @@ def test_run_with_config(temp_workspace, mocker):
 
 
 def test_run_with_stdin(mocker):
-    mocked_args = mocker.Mock(stdin=True, config_data=None, config_file=None, files="")
+    mocked_args = mocker.Mock(
+        stdin=True,
+        config_data=None,
+        config_file=None,
+        files=(),
+        threshold=None,
+        format="standard",
+        no_warnings=False,
+    )
     ec = mocker.patch("sys.exit")
-    with mocker.patch("argparse.ArgumentParser.parse_args", return_value=mocked_args):
-        with mocker.patch("sys.stdin", StringIO("Example input")):
-            cli.run()
+    mocker.patch("argparse.ArgumentParser.parse_args", return_value=mocked_args)
+    mocker.patch("sys.stdin", StringIO("Example input"))
+    cli.run()
     ec.assert_called_once_with(0)
+
+
+def test_run_with_threshold_overrides_config_data(mocker):
+    mocked_args = mocker.Mock(
+        stdin=True,
+        config_data="threshold: 0.2",
+        config_file=None,
+        files="",
+        threshold=0.8,
+        format="standard",
+        no_warnings=False,
+    )
+    analyze = mocker.patch("presidio_cli.cli.analyze", return_value=())
+    ec = mocker.patch("sys.exit")
+    mocker.patch("argparse.ArgumentParser.parse_args", return_value=mocked_args)
+    mocker.patch("sys.stdin", StringIO("Example input"))
+
+    cli.run()
+
+    assert analyze.call_args.args[1].threshold == 0.8
+    ec.assert_called_once_with(0)
+
+
+def test_run_with_threshold_overrides_config_file(tmp_path, mocker):
+    config_file = tmp_path / ".presidiocli"
+    config_file.write_text("threshold: 0.2")
+    mocked_args = mocker.Mock(
+        stdin=True,
+        config_data=None,
+        config_file=str(config_file),
+        files="",
+        threshold=0.8,
+        format="standard",
+        no_warnings=False,
+    )
+    analyze = mocker.patch("presidio_cli.cli.analyze", return_value=())
+    ec = mocker.patch("sys.exit")
+    mocker.patch("argparse.ArgumentParser.parse_args", return_value=mocked_args)
+    mocker.patch("sys.stdin", StringIO("Example input"))
+
+    cli.run()
+
+    assert analyze.call_args.args[1].threshold == 0.8
+    ec.assert_called_once_with(0)
+
+
+def test_threshold_value_rejects_invalid_values():
+    assert cli.threshold_value("0.7") == 0.7
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli.threshold_value("-0.1")
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli.threshold_value("1.1")
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        cli.threshold_value("not-a-number")


### PR DESCRIPTION
## Change Description

Adds a `--threshold` option to `presidio-cli`, validates it as a 0..1 confidence score, and applies it after loading the selected configuration so one-off runs can override the configured threshold without inline YAML or a temporary config file.

Also documents the flag and records the change in the unreleased changelog.

## Issue reference

Fixes #2101

## Tests

- `uv run --project presidio-cli --python python3.13 --with pytest --with pytest-mock pytest presidio-cli/tests -q`
- `uv run --project presidio-cli --python python3.13 --with 'ruff==0.9.2' ruff check`\n- `printf 'hello\\n' | uv run --project presidio-cli --python python3.13 presidio --threshold 0.7 -`\n\n## Checklist\n\n- [x] I have reviewed the [contribution guidelines](https://github.com/microsoft/presidio/blob/main/CONTRIBUTING.md)\n- [ ] I have signed the CLA (if required)\n- [x] My code includes unit tests\n- [x] All unit tests and lint checks pass locally\n- [x] My PR contains documentation updates / additions if required\n