### PR TITLE
Fix DE_FUEHRERSCHEIN docstring example that contradicts the pattern

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/de_fuehrerschein_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/germany/de_fuehrerschein_recognizer.py
@@ -13,9 +13,13 @@ class DeFuehrerscheinRecognizer(PatternRecognizer):
     via FeV reform), the number follows a fixed 11-character structure:
 
         Pos 1–2:   Behördenkürzel – 2 uppercase letters identifying the issuing
-                   Fahrerlaubnisbehörde (derived from the Kfz-Zulassungskürzel of
-                   the issuing Kreis/Stadt, e.g. "B0" Berlin, "MU" München,
-                   "HH" Hamburg, "KO" Koblenz)
+                   Fahrerlaubnisbehörde (derived from the Kfz-Zulassungskürzel
+                   of the issuing Kreis/Stadt, e.g. "MU" München, "HH" Hamburg,
+                   "KO" Koblenz, "BO" Bochum).  Single-letter Kfz codes such
+                   as "B" (Berlin) or "K" (Köln) are used in combination as
+                   2-letter authority codes here (e.g. "BO", "KN"); pure
+                   single-letter + digit forms like "B0" are out of scope for
+                   this strict pattern (see tests/test_de_fuehrerschein_recognizer.py).
         Pos 3–5:   Behördennummer – 3-digit authority code within the Bundesland
                    (assigned by the Kraftfahrt-Bundesamt, KBA)
         Pos 6–10:  Laufende Nummer – 5-digit sequential issue number
@@ -27,7 +31,7 @@ class DeFuehrerscheinRecognizer(PatternRecognizer):
     EU standard: Annex I to Directive 2006/126/EC (Field 5).
     Data protection: DSGVO Art. 4 Nr. 1 (personenbezogene Daten), BDSG.
 
-    Examples (fictitious): B012345678A, MU12345678B, HH98765432C
+    Examples (fictitious): BO12345678A, MU12345678B, HH98765432C
 
     Scope note: Pre-2013 German driving licenses (pink folded card, laminated
     card) used locally defined, non-standardized number formats and remain


### PR DESCRIPTION
## Summary

Documentation-only fix. The class docstring of `DeFuehrerscheinRecognizer` contradicts the recognizer's own regex and tests:

- The `Pos 1–2` description gives `"B0" Berlin` as an example Behördenkürzel.
- The `Examples (fictitious)` line lists `B012345678A`.

…but the pattern `[A-Z]{2}\d{8}[A-Z0-9]` requires **both** leading characters to be uppercase letters, so `B012345678A` never matches:

```python
>>> DeFuehrerscheinRecognizer().analyze("B012345678A", ["DE_FUEHRERSCHEIN"])
[]   # rejected
>>> DeFuehrerscheinRecognizer().analyze("MU12345678B", ["DE_FUEHRERSCHEIN"])
[<RecognizerResult ...>]
```

The test file's docstring is the authoritative one and explicitly notes:

> single-letter Kfz abbreviations (B Berlin, K Köln, M München as single chars) are always used in combination as 2-char authority codes in the Führerschein system (e.g. `BO`, `MU`, `KN`).  Pure single-letter + digit combos like `B0` are NOT part of the 2-letter authority code and are out of scope for this strict pattern.

…and `test_when_all_de_fuehrerschein_numbers_then_succeed` explicitly asserts `B12345678A` is rejected.

## Change

Docstring only:

- Replace the `"B0" Berlin` example with `"BO" Bochum` and add a short clarification mirroring the test file's note about single-letter Kfz codes.
- Change the misleading `B012345678A` in the `Examples` line to `BO12345678A`.

No functional / regex / test changes.

## Verification

Full `tests/test_de_fuehrerschein_recognizer.py` still passes (14 passed), `ruff check .` is clean.