### PR TITLE
Fix MedicalNERRecognizer loading with YAML context

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/ner/medical_ner_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/ner/medical_ner_recognizer.py
@@ -36,6 +36,7 @@ class MedicalNERRecognizer(HuggingFaceNerRecognizer):
         supported_entities: Optional[List[str]] = None,
         name: str = "MedicalNERRecognizer",
         supported_language: str = "en",
+        context: Optional[List[str]] = None,
         aggregation_strategy: str = "simple",
         threshold: float = 0.3,
         device: Optional[Union[str, int]] = None,
@@ -50,6 +51,7 @@ class MedicalNERRecognizer(HuggingFaceNerRecognizer):
         :param supported_entities: Entity types to return (None = all mapped).
         :param name: Recognizer name
         :param supported_language: Language code
+        :param context: Context words used for context-aware score enhancement
         :param aggregation_strategy: Pipeline aggregation strategy
         :param threshold: Minimum confidence score (0.0 - 1.0)
         :param device: Device string/int (None = auto-detect)
@@ -61,6 +63,7 @@ class MedicalNERRecognizer(HuggingFaceNerRecognizer):
             supported_entities=supported_entities,
             name=name,
             supported_language=supported_language,
+            context=context,
             aggregation_strategy=aggregation_strategy,
             threshold=threshold,
             device=device,

--- a/presidio-analyzer/tests/test_medical_ner_recognizer.py
+++ b/presidio-analyzer/tests/test_medical_ner_recognizer.py
@@ -8,6 +8,9 @@ from presidio_analyzer.predefined_recognizers.ner.medical_ner_recognizer import 
 from presidio_analyzer.predefined_recognizers.ner.huggingface_ner_recognizer import (
     HuggingFaceNerRecognizer,
 )
+from presidio_analyzer.recognizer_registry.recognizers_loader_utils import (
+    RecognizerListLoader,
+)
 
 
 def _make_pipeline_prediction(entity_group, score, word, start, end):
@@ -84,6 +87,35 @@ def test_default_model_name(recognizer):
 def test_default_aggregation_strategy(recognizer):
     """Default aggregation_strategy should be 'simple'."""
     assert recognizer.aggregation_strategy == "simple"
+
+
+def test_loader_with_language_context():
+    """YAML loader should be able to pass language context."""
+    recognizer_conf = {
+        "name": "MedicalNERRecognizer",
+        "type": "predefined",
+        "supported_languages": [
+            {"language": "en", "context": ["diagnosis", "medication"]}
+        ],
+    }
+
+    with (
+        patch(_PATCH_HF, new=MagicMock()),
+        patch(_PATCH_TORCH, new=MagicMock()),
+        patch(_PATCH_DEVICE) as mock_dd,
+    ):
+        mock_dd.get_device.return_value = "cpu"
+        recognizers = list(
+            RecognizerListLoader.get(
+                recognizers=[recognizer_conf],
+                supported_languages=["en"],
+                global_regex_flags=26,
+            )
+        )
+
+    assert len(recognizers) == 1
+    assert isinstance(recognizers[0], MedicalNERRecognizer)
+    assert recognizers[0].context == ["diagnosis", "medication"]
 
 
 def test_custom_supported_entities():


### PR DESCRIPTION
## Change Description

`MedicalNERRecognizer` could not be loaded from a YAML recognizer config when it was configured with language-specific `context` in `supported_languages`.

This change adds the missing optional `context` parameter to `MedicalNERRecognizer` and forwards it to the parent class.

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/data-privacy-stack/presidio/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/data-privacy-stack/presidio/blob/main/CODE_OF_CONDUCT.md)
- [x] I confirm that I have the right to submit this contribution and that it does not knowingly contain proprietary or confidential code.
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
