### PR TITLE
Fix EsNieRecognizer.validate_result raising instead of returning False

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/spain/es_nie_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/spain/es_nie_recognizer.py
@@ -66,7 +66,7 @@ class EsNieRecognizer(PatternRecognizer):
         letter = pattern_text[-1]
 
         # check last is a letter, and first is in X,Y,Z
-        if not pattern_text[1:-1].isdigit or pattern_text[:1] not in "XYZ":
+        if not pattern_text[1:-1].isdigit() or pattern_text[:1] not in "XYZ":
             return False
         # check size is 8 or 9
         if len(pattern_text) < 8 or len(pattern_text) > 9:

--- a/presidio-analyzer/tests/test_es_nie_recognizer.py
+++ b/presidio-analyzer/tests/test_es_nie_recognizer.py
@@ -1,7 +1,8 @@
 import pytest
+from presidio_analyzer import Pattern
+from presidio_analyzer.predefined_recognizers import EsNieRecognizer
 
 from tests import assert_result
-from presidio_analyzer.predefined_recognizers import EsNieRecognizer
 
 
 @pytest.fixture(scope="module")
@@ -51,3 +52,11 @@ def test_when_all_es_nie_then_succeed(
     assert len(results) == expected_len
     for res, (st_pos, fn_pos) in zip(results, expected_positions):
         assert_result(res, entities[0], st_pos, fn_pos, max_score)
+
+
+def test_when_custom_pattern_allows_non_digit_middle_then_no_crash(entities):
+    """A non-digit middle segment should be rejected, not raise."""
+    loose_pattern = Pattern("NIE_LOOSE", r"\b[X-Z][0-9A-Za-z]{6}[A-Z]\b", 0.5)
+    recognizer = EsNieRecognizer(patterns=[loose_pattern])
+    results = recognizer.analyze("XABCDEFG", entities)
+    assert results == []


### PR DESCRIPTION
Fixes #2145.

`isdigit` was referenced without being called, so the digit guard in `validate_result` was always truthy and never actually checked anything. The recognizer's default pattern already limits the middle characters to digits, so this stayed hidden in normal use, but the constructor explicitly accepts a custom `patterns` argument, and a looser pattern lets non-digit text reach the checksum line further down and raise a `ValueError` instead of returning `False`.

The fix is one character, calling `isdigit()` instead of referencing it.

Added a regression test that builds the recognizer with a custom pattern loose enough to trigger the old crash, and asserts `analyze()` now returns an empty list instead of raising.
