### PR TITLE
feat(analyzer): add Canadian postal code (CA_POSTAL_CODE) recognizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [unreleased]
 
 ### Analyzer
+#### Added
+- Canadian postal code (`CA_POSTAL_CODE`) recognizer with English/French context; disabled by default
+
 #### Fixed
 - Language model recognizers (`BasicLangExtractRecognizer`, `AzureOpenAILangExtractRecognizer`) configured in a recognizer registry YAML now honour `config_path` (and other recognizer-specific kwargs). Previously these entries were validated by the strict `PredefinedRecognizerConfig` schema, which has no `config_path` field and does not allow extra keys, so `config_path` was silently dropped and the recognizer fell back to its bundled default model configuration. Added a `LangExtractRecognizerConfig` model (`extra="allow"`) and registered both recognizer class names in `CONFIG_MODEL_MAP`.
 - `BasicLangExtractRecognizer` now honours values under `langextract.model.provider.language_model_params` (including `timeout` and `num_ctx`). Previously these were silently dropped because `langextract.extract()` ignores its `language_model_params` argument when a pre-built `ModelConfig` is passed via `config=`, causing Ollama-backed recognizers to fall back to langextract's 120s default regardless of the configured timeout. The recognizer now merges `language_model_params` into `ModelConfig.provider_kwargs`, which is the path that reaches the provider constructor. Explicit entries under `provider.kwargs:` still take precedence. Also fixed a `TypeError` when `kwargs:` or `language_model_params:` is `null` in the YAML. (#1943, Thanks @lsternlicht)

--- a/docs/supported_entities.md
+++ b/docs/supported_entities.md
@@ -130,6 +130,7 @@ For more information, refer to the [adding new recognizers documentation](analyz
 |FieldType|Description|Detection Method|
 |--- |--- |--- |
 |CA_SIN|A Canadian Social Insurance Number (SIN) is a 9-digit number issued by Employment and Social Development Canada (ESDC) to administer government programs. The last digit is a Luhn check digit. SINs starting with 0 or 8 are reserved and not issued.|Pattern match, context, and checksum|
+|CA_POSTAL_CODE|A Canadian postal code in the format `A1A 1A1`, made up of a Forward Sortation Area (first three characters) and a Local Delivery Unit (last three). Canada Post never uses the letters D, F, I, O, Q, U, and does not use W or Z as the first letter.|Pattern match and context|
 
 ### Sweden
 | FieldType  | Description                                                                                             | Detection Method                         |

--- a/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
+++ b/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
@@ -502,3 +502,11 @@ recognizers:
     type: predefined
     enabled: false
     country_code: ca
+
+  - name: CaPostalCodeRecognizer
+    supported_languages:
+    - en
+    - fr
+    type: predefined
+    enabled: false
+    country_code: ca

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/__init__.py
@@ -11,6 +11,7 @@ from .country_specific.australia.au_medicare_recognizer import AuMedicareRecogni
 from .country_specific.australia.au_tfn_recognizer import AuTfnRecognizer
 
 # Canada recognizers
+from .country_specific.canada.ca_postal_code_recognizer import CaPostalCodeRecognizer
 from .country_specific.canada.ca_sin_recognizer import CaSinRecognizer
 
 # Finland recognizers
@@ -185,6 +186,7 @@ NLP_RECOGNIZERS = {
 
 __all__ = [
     "AbaRoutingRecognizer",
+    "CaPostalCodeRecognizer",
     "CaSinRecognizer",
     "CreditCardRecognizer",
     "CryptoRecognizer",

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/canada/__init__.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/canada/__init__.py
@@ -1,7 +1,9 @@
 """Canada-specific recognizers package."""
 
+from .ca_postal_code_recognizer import CaPostalCodeRecognizer
 from .ca_sin_recognizer import CaSinRecognizer
 
 __all__ = [
+    "CaPostalCodeRecognizer",
     "CaSinRecognizer",
 ]

--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/canada/ca_postal_code_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/canada/ca_postal_code_recognizer.py
@@ -1,0 +1,78 @@
+from typing import List, Optional
+
+from presidio_analyzer import Pattern, PatternRecognizer
+
+
+class CaPostalCodeRecognizer(PatternRecognizer):
+    """Recognizes Canadian postal codes using Regex.
+
+    Canadian postal codes follow the format `A1A 1A1` (letter-digit-letter,
+    optional space, digit-letter-digit). Specific letters are excluded by
+    Canada Post: D, F, I, O, Q, U are never used, and W and Z are not used
+    as the first letter.
+
+    Reference: https://en.wikipedia.org/wiki/Postal_codes_in_Canada
+
+    :param patterns: List of patterns to be used by this recognizer
+    :param context: List of context words to increase confidence in detection
+    :param supported_language: Language this recognizer supports
+    :param supported_entity: The entity this recognizer can detect
+    """
+
+    COUNTRY_CODE = "ca"
+
+    # First letter excludes D, F, I, O, Q, U (never used) and W, Z (not used
+    # as the first letter); other letters exclude only D, F, I, O, Q, U.
+    PATTERNS = [
+        # Canonical Canada Post form with a single separating space.
+        Pattern(
+            "Postal code (medium)",
+            r"\b"
+            r"[ABCEGHJ-NPR-TVXY][0-9][ABCEGHJ-NPR-TV-Z]\s[0-9][ABCEGHJ-NPR-TV-Z][0-9]"
+            r"\b",
+            0.4,
+        ),
+        # Space omitted (common in stored data); more false-positive prone.
+        Pattern(
+            "Postal code (weak)",
+            r"\b"
+            r"[ABCEGHJ-NPR-TVXY][0-9][ABCEGHJ-NPR-TV-Z][0-9][ABCEGHJ-NPR-TV-Z][0-9]"
+            r"\b",
+            0.1,
+        ),
+    ]
+
+    CONTEXT = [
+        "postal code",
+        "postal",
+        "postcode",
+        "post code",
+        "zip",
+        "address",
+        "mailing",
+        "shipping",
+        # French equivalents (Canada is officially bilingual)
+        "code postal",
+        "adresse",
+        "courrier",
+        "livraison",
+        "expédition",
+    ]
+
+    def __init__(
+        self,
+        patterns: Optional[List[Pattern]] = None,
+        context: Optional[List[str]] = None,
+        supported_language: str = "en",
+        supported_entity: str = "CA_POSTAL_CODE",
+        name: Optional[str] = None,
+    ):
+        patterns = patterns if patterns else self.PATTERNS
+        context = context if context else self.CONTEXT
+        super().__init__(
+            supported_entity=supported_entity,
+            patterns=patterns,
+            context=context,
+            supported_language=supported_language,
+            name=name,
+        )

--- a/presidio-analyzer/tests/test_ca_postal_code_recognizer.py
+++ b/presidio-analyzer/tests/test_ca_postal_code_recognizer.py
@@ -1,0 +1,79 @@
+import pytest
+
+from tests import assert_result_within_score_range
+from presidio_analyzer.predefined_recognizers import CaPostalCodeRecognizer
+
+
+@pytest.fixture(scope="module")
+def recognizer():
+    return CaPostalCodeRecognizer()
+
+
+@pytest.fixture(scope="module")
+def entities():
+    return ["CA_POSTAL_CODE"]
+
+
+@pytest.mark.parametrize(
+    "text, expected_len, expected_positions, expected_score_ranges",
+    [
+        # fmt: off
+        # --- Valid, canonical spaced form (medium) ---
+        ("K1A 0B1", 1, ((0, 7),), ((0.4, 0.81),),),
+        ("M5V 2T6", 1, ((0, 7),), ((0.4, 0.81),),),
+        ("H0H 0H0", 1, ((0, 7),), ((0.4, 0.81),),),
+        # W and Z are permitted in non-leading letter positions
+        ("N1W 2Z9", 1, ((0, 7),), ((0.4, 0.81),),),
+        # Case-insensitive (re.IGNORECASE)
+        ("k1a 0b1", 1, ((0, 7),), ((0.4, 0.81),),),
+
+        # --- Valid, space omitted (weak) ---
+        ("K1A0B1", 1, ((0, 6),), ((0.0, 0.3),),),
+        ("M5V2T6", 1, ((0, 6),), ((0.0, 0.3),),),
+
+        # --- Valid within surrounding context (English / French) ---
+        ("My postal code is K1A 0B1", 1, ((18, 25),), ((0.4, 0.81),),),
+        ("Mon code postal est H2X 1Y4", 1, ((20, 27),), ((0.4, 0.81),),),
+
+        # --- Invalid: letters excluded as the first letter (D, W, Z) ---
+        ("D1A 0B1", 0, (), (),),
+        ("W1A 0B1", 0, (), (),),
+        ("Z1A 0B1", 0, (), (),),
+
+        # --- Invalid: letters never used anywhere (D, F, I, O, Q, U) ---
+        ("K1D 0B1", 0, (), (),),
+        ("K1A 0O1", 0, (), (),),
+
+        # --- Invalid: wrong length ---
+        ("K1A 0B", 0, (), (),),
+        ("K1A 0B12", 0, (), (),),
+
+        # --- Invalid: digit where a letter is required ---
+        ("11A 0B1", 0, (), (),),
+
+        # --- Invalid: unsupported separators ---
+        ("K1A-0B1", 0, (), (),),
+        ("K1A  0B1", 0, (), (),),
+        # fmt: on
+    ],
+)
+def test_when_postal_code_in_text_then_all_ca_postal_codes_are_found(
+    text,
+    expected_len,
+    expected_positions,
+    expected_score_ranges,
+    recognizer,
+    entities,
+    max_score,
+):
+    results = recognizer.analyze(text, entities)
+    results = sorted(results, key=lambda x: x.start)
+    assert len(results) == expected_len
+    for res, (st_pos, fn_pos), (st_score, fn_score) in zip(
+        results, expected_positions, expected_score_ranges
+    ):
+        if fn_score == "max":
+            fn_score = max_score
+        assert_result_within_score_range(
+            res, entities[0], st_pos, fn_pos, st_score, fn_score
+        )


### PR DESCRIPTION
## Change Description

Adds `CaPostalCodeRecognizer` for Canadian postal codes (entity `CA_POSTAL_CODE`)
in the `A1A 1A1` (letter, digit, letter, optional space, digit, letter, digit) format

- **Two patterns:** a higher-confidence match (0.4) for the canonical
  space-separated form, and a lower-confidence match (0.1) for the space-omitted
  form commonly seen in stored data.
- **Encodes Canada Post letter rules:** excludes D, F, I, O, Q, U everywhere, and
  W, Z as the first letter.
- **Context:** English and French context words (Canada is officially bilingual).
- **Disabled by default**, consistent with other country-specific recognizers.
- Registered in the predefined recognizers package (`__init__.py`) and
  `default_recognizers.yaml` (with `country_code: ca`), plus unit tests and
  documentation (`supported_entities.md`, `CHANGELOG.md`).

## Issue reference

Fixes #2163

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/data-privacy-stack/presidio/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/data-privacy-stack/presidio/blob/main/CODE_OF_CONDUCT.md)
- [x] I confirm that I have the right to submit this contribution and that it does not knowingly contain proprietary or confidential code.
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required