### PR TITLE
fix(anonymizer): include confidence score in OperatorResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - `BasicLangExtractRecognizer` now honours values under `langextract.model.provider.language_model_params` (including `timeout` and `num_ctx`). Previously these were silently dropped because `langextract.extract()` ignores its `language_model_params` argument when a pre-built `ModelConfig` is passed via `config=`, causing Ollama-backed recognizers to fall back to langextract's 120s default regardless of the configured timeout. The recognizer now merges `language_model_params` into `ModelConfig.provider_kwargs`, which is the path that reaches the provider constructor. Explicit entries under `provider.kwargs:` still take precedence. Also fixed a `TypeError` when `kwargs:` or `language_model_params:` is `null` in the YAML. (#1943, Thanks @lsternlicht)
 
 ### Anonymizer
+#### Changed
+- Added an optional `score` field to `OperatorResult`, threaded through from the originating `RecognizerResult` during `AnonymizerEngine.anonymize()` and preserved through `DeanonymizeEngine.deanonymize()`. The surviving entity after conflict resolution keeps its own score, not a dropped entity's. `score` defaults to `None`, is included in `to_dict()`/`to_json()` output, and round-trips via `OperatorResult.from_json()`, so existing callers are unaffected. Enables audit/traceability use cases where the confidence of an anonymized entity needs to be recoverable after anonymization (#2057)
+
 ### General
 #### Added
 - Added `BatchDeanonymizeEngine` to complement `BatchAnonymizerEngine` for batch deanonymization over lists and nested dictionaries.

--- a/presidio-anonymizer/presidio_anonymizer/core/engine_base.py
+++ b/presidio-anonymizer/presidio_anonymizer/core/engine_base.py
@@ -67,12 +67,17 @@ class EngineBase(ABC):
             # The following creates an intermediate list of result entities,
             # ordered from end to start, and the indexes will be normalized
             # from start to end once the loop ends and the text length is deterministic.
+            # `score` is carried over from the originating entity when available
+            # (e.g. a RecognizerResult during anonymize, or an already-scored
+            # OperatorResult during deanonymize). Entities without a score
+            # (e.g. plain PIIEntity) simply yield score=None.
             result_item = OperatorResult(
                 0,
                 index_from_end,
                 entity.entity_type,
                 changed_text,
                 operator_metadata.operator_name,
+                getattr(entity, "score", None),
             )
             engine_result.add_item(result_item)
 

--- a/presidio-anonymizer/presidio_anonymizer/entities/engine/result/operator_result.py
+++ b/presidio-anonymizer/presidio_anonymizer/entities/engine/result/operator_result.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 from presidio_anonymizer.entities import PIIEntity
 
@@ -13,10 +13,12 @@ class OperatorResult(PIIEntity):
         entity_type: str,
         text: str = None,
         operator: str = None,
+        score: Optional[float] = None,
     ):
         PIIEntity.__init__(self, start, end, entity_type)
         self.text = text
         self.operator = operator
+        self.score = score
 
     def __repr__(self):
         """Return a string representation of the object."""
@@ -43,6 +45,7 @@ class OperatorResult(PIIEntity):
             and self.entity_type == other.entity_type
             and self.operator == other.operator
             and self.text == other.text
+            and self.score == other.score
         )
 
     @classmethod
@@ -58,6 +61,7 @@ class OperatorResult(PIIEntity):
             "entity_type":"PERSON",
             "text":"resulted_text",
             "operator":"encrypt",
+            "score": 0.85,
         }
         """
         start = json.get("start")
@@ -65,10 +69,12 @@ class OperatorResult(PIIEntity):
         entity_type = json.get("entity_type")
         text = json.get("text")
         operator = json.get("operator")
+        score = json.get("score")
         return cls(
             start=start,
             end=end,
             entity_type=entity_type,
             text=text,
             operator=operator,
+            score=score,
         )

--- a/presidio-anonymizer/tests/integration/test_anonymize_engine.py
+++ b/presidio-anonymizer/tests/integration/test_anonymize_engine.py
@@ -27,7 +27,7 @@ def test_given_url_at_the_end_then_we_redact_is_successfully():
     ]
     expected_result = (
         '{"text": "The url is ", "items": [{"start": 11, "end": 11, "entity_type": '
-        '"URL", "text": "", "operator": "redact"}]}'
+        '"URL", "text": "", "operator": "redact", "score": 1.0}]}'
     )
     run_engine_and_validate(text, anonymizer_config, analyzer_results, expected_result)
 
@@ -63,9 +63,9 @@ def test_given_name_and_phone_number_then_we_anonymize_correctly():
     expected_result = (
         '{"text": "hello world, my name is ********. My number is: '
         '03-******4", "items": [{"start": 48, "end": 57, "entity_type": '
-        '"PHONE_NUMBER", "text": "03-******", "operator": "mask"}, '
+        '"PHONE_NUMBER", "text": "03-******", "operator": "mask", "score": 0.95}, '
         '{"start": 24, "end": 32, "entity_type": "NAME", '
-        '"text": "********", "operator": "mask"}]}'
+        '"text": "********", "operator": "mask", "score": 0.8}]}'
     )
     run_engine_and_validate(text, anonymizer_config, analyzer_results, expected_result)
 
@@ -85,9 +85,9 @@ def test_given_name_and_phone_number_without_anonymizers_then_we_use_default():
         '{"text": "hello world, my name is <NAME>. My number is: '
         '<PHONE_NUMBER>4", "items": [{"start": 46, "end": 60, '
         '"entity_type": "PHONE_NUMBER", "text": "<PHONE_NUMBER>", '
-        '"operator": "replace"}, {"start": 24, "end": 30, '
+        '"operator": "replace", "score": 0.95}, {"start": 24, "end": 30, '
         '"entity_type": "NAME", "text": "<NAME>", '
-        '"operator": "replace"}]}'
+        '"operator": "replace", "score": 0.8}]}'
     )
     run_engine_and_validate(text, anonymizer_config, analyzer_results, expected_result)
 
@@ -106,9 +106,9 @@ def test_given_redact_and_replace_then_we_anonymize_successfully():
         '{"text": "hello world, my name is . My number is: '
         '<PHONE_NUMBER>4", "items": [{"start": 40, "end": 54, '
         '"entity_type": "PHONE_NUMBER", "text": "<PHONE_NUMBER>", '
-        '"operator": "replace"}, {"start": 24, "end": 24, '
+        '"operator": "replace", "score": 0.95}, {"start": 24, "end": 24, '
         '"entity_type": "NAME", "text": "", "operator": '
-        '"redact"}]}'
+        '"redact", "score": 0.8}]}'
     )
     run_engine_and_validate(text, anonymizer_config, analyzer_results, expected_result)
 
@@ -128,13 +128,13 @@ def test_given_intersecting_entities_then_we_anonymize_correctly():
         '{"text": "hello world, my name is <FULL_NAME><LAST_NAME> My '
         'number is: <PHONE_NUMBER><SSN>4", "items": [{"start": 75, '
         '"end": 80, "entity_type": "SSN", "text": "<SSN>", '
-        '"operator": "replace"}, {"start": 61, "end": 75, '
+        '"operator": "replace", "score": 0.8}, {"start": 61, "end": 75, '
         '"entity_type": "PHONE_NUMBER", "text": "<PHONE_NUMBER>", '
-        '"operator": "replace"}, {"start": 35, "end": 46, '
+        '"operator": "replace", "score": 0.95}, {"start": 35, "end": 46, '
         '"entity_type": "LAST_NAME", "text": "<LAST_NAME>", '
-        '"operator": "replace"}, {"start": 24, "end": 35, '
+        '"operator": "replace", "score": 0.6}, {"start": 24, "end": 35, '
         '"entity_type": "FULL_NAME", "text": "<FULL_NAME>", '
-        '"operator": "replace"}]}'
+        '"operator": "replace", "score": 0.6}]}'
     )
     run_engine_and_validate(text, anonymizer_config, analyzer_results, expected_result)
 
@@ -149,7 +149,7 @@ def test_given_intersecting_the_same_entities_then_we_anonymize_correctly():
     expected_result = (
         '{"text": "hello world, my name is <FULL_NAME> My number is: 03-4453334", '
         '"items": [{"start": 24, "end": 35, "entity_type": "FULL_NAME",'
-        ' "text": "<FULL_NAME>", "operator": "replace"}]}'
+        ' "text": "<FULL_NAME>", "operator": "replace", "score": 0.6}]}'
     )
     run_engine_and_validate(text, anonymizer_config, analyzer_results, expected_result)
 

--- a/presidio-anonymizer/tests/integration/test_deanonymize_engine.py
+++ b/presidio-anonymizer/tests/integration/test_deanonymize_engine.py
@@ -90,6 +90,61 @@ def test_given_anonymize_with_encrypt_then_text_returned_with_encrypted_content(
     assert decryption.items[0].entity_type == "PERSON"
 
 
+def test_given_encrypted_entity_with_score_then_deanonymized_result_keeps_score():
+    text = "My name is S184CMt9Drj7QaKQ21JTrpYzghnboTF9pn/neN8JME0="
+    encryption_results = [
+        OperatorResult(start=11, end=55, entity_type="PERSON", score=0.88),
+    ]
+    engine = DeanonymizeEngine()
+    decryption = engine.deanonymize(
+        text,
+        encryption_results,
+        {"DEFAULT": OperatorConfig(Decrypt.NAME, {"key": b"WmZq4t7w!z%C&F)J"})},
+    )
+    assert decryption.items[0].score == 0.88
+
+
+def test_given_encrypted_entity_without_score_then_deanonymized_result_score_is_none():
+    text = "My name is S184CMt9Drj7QaKQ21JTrpYzghnboTF9pn/neN8JME0="
+    encryption_results = [
+        OperatorResult(start=11, end=55, entity_type="PERSON"),
+    ]
+    engine = DeanonymizeEngine()
+    decryption = engine.deanonymize(
+        text,
+        encryption_results,
+        {"DEFAULT": OperatorConfig(Decrypt.NAME, {"key": b"WmZq4t7w!z%C&F)J"})},
+    )
+    assert decryption.items[0].score is None
+
+
+def test_given_anonymize_then_deanonymize_score_survives_the_round_trip():
+    """The score set on the original RecognizerResult should survive through
+    anonymize (encrypt) and remain readable on the anonymized OperatorResult,
+    then be preserved through deanonymize (decrypt) as well."""
+    unencrypted_text = "My name is "
+    expected_encrypted_text = "Chloë"
+    text = unencrypted_text + expected_encrypted_text
+    start_index = 11
+    end_index = 16
+    key = "WmZq4t7w!z%C&F)J"
+    analyzer_results = [RecognizerResult("PERSON", start_index, end_index, 0.73)]
+    anonymizers_config = {"PERSON": OperatorConfig("encrypt", {"key": key})}
+
+    actual_anonymize_result = AnonymizerEngine().anonymize(
+        text, analyzer_results, anonymizers_config
+    )
+    assert actual_anonymize_result.items[0].score == 0.73
+
+    engine = DeanonymizeEngine()
+    decryption = engine.deanonymize(
+        actual_anonymize_result.text,
+        actual_anonymize_result.items,
+        {"PERSON": OperatorConfig(Decrypt.NAME, {"key": key})},
+    )
+    assert decryption.items[0].score == 0.73
+
+
 def test_given_request_deanonymizers_return_list():
     engine = DeanonymizeEngine()
     expected_list = ["deanonymize_keep", "decrypt"]

--- a/presidio-anonymizer/tests/test_anonymizer_engine.py
+++ b/presidio-anonymizer/tests/test_anonymizer_engine.py
@@ -173,7 +173,7 @@ def test_given_several_results_then_we_filter_them_and_get_correct_mocked_result
             EngineResult(
                 text="My name is BIP",
                 items=[
-                    OperatorResult(11, 14, "PERSON", "BIP", "replace"),
+                    OperatorResult(11, 14, "PERSON", "BIP", "replace", 0.8),
                 ]
             )
         ),
@@ -186,7 +186,7 @@ def test_given_several_results_then_we_filter_them_and_get_correct_mocked_result
             EngineResult(
                 text="My name is BIP",
                 items=[
-                    OperatorResult(11, 14, "PERSON", "BIP", "replace"),
+                    OperatorResult(11, 14, "PERSON", "BIP", "replace", 0.8),
                 ]
             )
         ),
@@ -199,8 +199,8 @@ def test_given_several_results_then_we_filter_them_and_get_correct_mocked_result
             EngineResult(
                 text="My name is BIP, BIP",
                 items=[
-                    OperatorResult(11, 14, "PERSON", "BIP", "replace"),
-                    OperatorResult(16, 19, "PERSON", "BIP", "replace"),
+                    OperatorResult(11, 14, "PERSON", "BIP", "replace", 0.8),
+                    OperatorResult(16, 19, "PERSON", "BIP", "replace", 0.8),
                 ]
             )
         ),
@@ -215,8 +215,8 @@ def test_given_several_results_then_we_filter_them_and_get_correct_mocked_result
             EngineResult(
                 text="The phone book said: BIP BEEP",
                 items=[
-                    OperatorResult(21, 24, "PERSON", "BIP", "replace"),
-                    OperatorResult(25, 29, "PHONE NUMBER", "BEEP", "replace"),
+                    OperatorResult(21, 24, "PERSON", "BIP", "replace", 0.8),
+                    OperatorResult(25, 29, "PHONE NUMBER", "BEEP", "replace", 0.8),
                 ]
             )
         ),
@@ -275,6 +275,66 @@ def test_given_unsorted_input_then_merged_correctly():
         original_analyzer_results
     )
     assert anonymizer_result.text == "<PERSON> is a person"
+
+
+# ---------------------------------------------------------------------------
+# Tests for score propagation from RecognizerResult to OperatorResult
+# (issue #2057)
+# ---------------------------------------------------------------------------
+
+
+def test_given_analyzer_result_with_score_then_operator_result_carries_score():
+    engine = AnonymizerEngine()
+    text = "please REPLACE ME."
+    analyzer_result = RecognizerResult("SSN", 7, 17, 0.8)
+    result = engine.anonymize(text, [analyzer_result], {})
+    assert len(result.items) == 1
+    assert result.items[0].score == 0.8
+
+
+def test_given_multiple_analyzer_results_then_each_operator_result_keeps_own_score():
+    engine = AnonymizerEngine()
+    text = "The phone book said: Jones 212-555-5555"
+    analyzer_results = [
+        RecognizerResult(start=21, end=26, score=0.7, entity_type="PERSON"),
+        RecognizerResult(start=27, end=39, score=0.95, entity_type="PHONE_NUMBER"),
+    ]
+    result = engine.anonymize(
+        text,
+        analyzer_results,
+        operators={
+            "PERSON": OperatorConfig("replace", {"new_value": "BIP"}),
+            "PHONE_NUMBER": OperatorConfig("replace", {"new_value": "BEEP"}),
+        },
+    )
+    scores_by_type = {item.entity_type: item.score for item in result.items}
+    assert scores_by_type["PERSON"] == 0.7
+    assert scores_by_type["PHONE_NUMBER"] == 0.95
+
+
+def test_given_conflicting_results_of_same_type_then_surviving_entity_keeps_max_score():
+    """The surviving entity should keep its own (max) score, not a dropped one's."""
+    engine = AnonymizerEngine()
+    text = "My name is David Jones"
+    analyzer_results = [
+        RecognizerResult(start=11, end=16, score=0.3, entity_type="PERSON"),
+        RecognizerResult(start=11, end=22, score=0.9, entity_type="PERSON"),
+    ]
+    result = engine.anonymize(
+        text,
+        analyzer_results,
+        operators={"PERSON": OperatorConfig("replace", {"new_value": "BIP"})},
+    )
+    assert len(result.items) == 1
+    assert result.items[0].score == 0.9
+
+
+def test_given_no_score_needed_operator_result_still_backward_compatible():
+    """OperatorResult without an explicit score keeps existing behavior/equality."""
+    result = OperatorResult(11, 14, "PERSON", "BIP", "replace")
+    assert result.score is None
+    # Equality with an identical, explicitly-scored-None instance still holds.
+    assert result == OperatorResult(11, 14, "PERSON", "BIP", "replace", None)
 
 
 def _operate(

--- a/presidio-anonymizer/tests/test_conflict_resolution_strategy.py
+++ b/presidio-anonymizer/tests/test_conflict_resolution_strategy.py
@@ -70,8 +70,8 @@ def test_when_merge_similar_or_contained_selected_then_default_conflict_handled(
                 ),
                 items=[
                     OperatorResult(17, 36, 'CREDIT_CARD',
-                                   '4151 3217 6243 3448', 'keep'),
-                    OperatorResult(36, 40, 'URL', '.com', 'keep')
+                                   '4151 3217 6243 3448', 'keep', 1),
+                    OperatorResult(36, 40, 'URL', '.com', 'keep', 0.5)
                 ]
             )
         ),
@@ -92,8 +92,8 @@ def test_when_merge_similar_or_contained_selected_then_default_conflict_handled(
                     "that overlaps with nonexisting URL."
                 ),
                 items=[
-                    OperatorResult(17, 32, 'CREDIT_CARD', '4151 3217 6243 ', 'keep'),
-                    OperatorResult(32, 40, 'URL', '3448.com', 'keep')
+                    OperatorResult(17, 32, 'CREDIT_CARD', '4151 3217 6243 ', 'keep', 0.8),
+                    OperatorResult(32, 40, 'URL', '3448.com', 'keep', 1)
                 ]
             )
         ),
@@ -115,8 +115,8 @@ def test_when_merge_similar_or_contained_selected_then_default_conflict_handled(
                 ),
                 items=[
                     OperatorResult(17, 36, 'CREDIT_CARD',
-                                   '4151 3217 6243 3448', 'keep'),
-                    OperatorResult(36, 40, 'URL', '.com', 'keep')
+                                   '4151 3217 6243 3448', 'keep', 0.8),
+                    OperatorResult(36, 40, 'URL', '.com', 'keep', 0.8)
                 ]
             )
         ),
@@ -139,8 +139,8 @@ def test_when_merge_similar_or_contained_selected_then_default_conflict_handled(
                     "that overlaps with nonexisting URL."
                 ),
                 items=[
-                    OperatorResult(31, 42, 'Ent1', ' 3448.com t', 'keep'),
-                    OperatorResult(17, 31, 'CREDIT_CARD', '4151 3217 6243',  'keep')
+                    OperatorResult(31, 42, 'Ent1', ' 3448.com t', 'keep', 0.9),
+                    OperatorResult(17, 31, 'CREDIT_CARD', '4151 3217 6243',  'keep', 0.8)
                 ]
             )
         )

--- a/presidio-anonymizer/tests/test_operator_result.py
+++ b/presidio-anonymizer/tests/test_operator_result.py
@@ -33,3 +33,69 @@ def test_given_idenctical_decrypt_results_item_they_are_equal():
 def test_given_changed_decrypt_results_item_they_are_equal(result_item):
     result_1 = OperatorResult(0, 3, "NAME", "bla", "decrypt")
     assert result_1 != result_item
+
+
+def test_given_no_score_provided_then_score_defaults_to_none():
+    result = OperatorResult(0, 3, "NAME", "bla", "decrypt")
+    assert result.score is None
+
+
+def test_given_score_provided_then_score_is_set():
+    result = OperatorResult(0, 3, "NAME", "bla", "decrypt", 0.85)
+    assert result.score == 0.85
+
+
+def test_given_score_provided_as_kwarg_then_score_is_set():
+    result = OperatorResult(
+        start=0, end=3, entity_type="NAME", text="bla", operator="decrypt", score=0.6
+    )
+    assert result.score == 0.6
+
+
+def test_given_two_results_with_different_scores_then_they_are_not_equal():
+    result_1 = OperatorResult(0, 3, "NAME", "bla", "decrypt", 0.9)
+    result_2 = OperatorResult(0, 3, "NAME", "bla", "decrypt", 0.1)
+    assert result_1 != result_2
+
+
+def test_given_two_results_with_same_score_then_they_are_equal():
+    result_1 = OperatorResult(0, 3, "NAME", "bla", "decrypt", 0.9)
+    result_2 = OperatorResult(0, 3, "NAME", "bla", "decrypt", 0.9)
+    assert result_1 == result_2
+
+
+def test_given_one_result_has_score_and_other_does_not_then_they_are_not_equal():
+    result_1 = OperatorResult(0, 3, "NAME", "bla", "decrypt", 0.9)
+    result_2 = OperatorResult(0, 3, "NAME", "bla", "decrypt")
+    assert result_1 != result_2
+
+
+def test_given_result_with_score_then_to_dict_includes_score():
+    result = OperatorResult(0, 3, "NAME", "bla", "decrypt", 0.75)
+    result_dict = result.to_dict()
+    assert result_dict["score"] == 0.75
+
+
+def test_given_json_with_score_then_from_json_sets_score():
+    json_data = {
+        "start": 0,
+        "end": 10,
+        "entity_type": "PERSON",
+        "text": "resulted_text",
+        "operator": "encrypt",
+        "score": 0.85,
+    }
+    result = OperatorResult.from_json(json_data)
+    assert result.score == 0.85
+
+
+def test_given_json_without_score_then_from_json_defaults_score_to_none():
+    json_data = {
+        "start": 0,
+        "end": 10,
+        "entity_type": "PERSON",
+        "text": "resulted_text",
+        "operator": "encrypt",
+    }
+    result = OperatorResult.from_json(json_data)
+    assert result.score is None


### PR DESCRIPTION
## Summary
Adds an optional `score` field to `OperatorResult`, threaded through from the originating `RecognizerResult` during `AnonymizerEngine.anonymize()` and preserved through `DeanonymizeEngine.deanonymize()`.

- `score` defaults to `None` so existing callers are unaffected
- The surviving entity after conflict resolution keeps its own (max) score, not a dropped entity's — this relies on existing conflict-resolution behavior in `anonymizer_engine.py`, unmodified here
- Included in `to_dict()`/`to_json()` output and round-trips via `from_json()`

Enables audit/traceability use cases where the confidence of an anonymized entity needs to be recoverable after anonymization.

Closes #2057

## Test plan
- [x] Unit tests for `OperatorResult` score default, equality, `to_dict`/`from_json`
- [x] Unit tests for score propagation through `AnonymizerEngine` (single, multiple, conflicting entities)
- [x] Integration tests updated for new `score` field in output
- [x] Round-trip test: encrypt → decrypt preserves score