### PR TITLE
ci: restrict release workflow to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
       version: ${{ steps.set-version.outputs.version }}
       image-version: ${{ steps.set-image-version.outputs.image-version }}
     steps:
+      - name: Validate release branch
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: |
+          echo "::error::Releases must be triggered from the main branch. Selected ref: ${{ github.ref }}"
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:


### PR DESCRIPTION
## Summary

Restricts the manually triggered release workflow to the `main` branch.

`workflow_dispatch` allows users to select the ref from which the workflow runs. Previously, selecting another branch or tag could publish Python packages and container images built from code that had not been merged into `main`.

This change adds an early validation step to the `get-version` job. The workflow fails before checkout and version extraction when the selected ref is not `refs/heads/main`.

Since all publishing jobs depend directly or indirectly on `get-version`, the validation prevents:

- Creating a GitHub release from a non-`main` ref
- Publishing packages to PyPI from a non-`main` ref
- Publishing container images to GHCR from a non-`main` ref

## Testing

- A workflow dispatched from `main` proceeds normally.
- A workflow dispatched from another branch or tag fails during the `Validate release branch` step before any artifacts are published.