### PR TITLE
Raise Pillow minimum to 12.3.0

### DIFF
--- a/presidio-image-redactor/pyproject.toml
+++ b/presidio-image-redactor/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.15"
 
 dependencies = [
-    "pillow (>=9.0.0,<13.0.0)",
+    "pillow (>=12.3.0,<13.0.0)",
     "pytesseract (>=0.3.13,<0.4)",
     "presidio-analyzer (>=2.2.0,<3.0.0)",
     "matplotlib (>=3.6.0,<4.0.0)",

--- a/presidio-image-redactor/uv.lock
+++ b/presidio-image-redactor/uv.lock
@@ -1791,7 +1791,7 @@ requires-dist = [
     { name = "gunicorn", marker = "extra == 'server'", specifier = ">=25.3.0,<26.0.0" },
     { name = "matplotlib", specifier = ">=3.6.0,<4.0.0" },
     { name = "opencv-python", specifier = ">=4.13.0.92,<5.0.0" },
-    { name = "pillow", specifier = ">=9.0.0,<13.0.0" },
+    { name = "pillow", specifier = ">=12.3.0,<13.0.0" },
     { name = "presidio-analyzer", specifier = ">=2.2.0,<3.0.0" },
     { name = "pydicom", specifier = ">=2.3.0,<4.0.0" },
     { name = "pypng", specifier = ">=0.20220715.0,<1.0.0" },


### PR DESCRIPTION
## Summary
- require Pillow 12.3.0 or newer for `presidio-image-redactor`
- synchronize the published dependency constraint in `uv.lock`

## Security impact
Pillow is the most recurring dependency in the current Dependabot backlog, accounting for 13 of 27 open alerts (10 high and 3 medium). All 13 advisories are patched in Pillow 12.3.0.

## Validation
- `poetry -C presidio-image-redactor check --strict`
- locked dependency resolution for Python 3.10 and 3.14 with uv 0.11.6