### PR TITLE
Canonicalize Pillow dependency constraint

### DIFF
--- a/presidio-image-redactor/pyproject.toml
+++ b/presidio-image-redactor/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.15"
 
 dependencies = [
-    "pillow (>=12.3.0,<13.0.0)",
+    "pillow>=12.3.0,<13.0.0",
     "pytesseract (>=0.3.13,<0.4)",
     "presidio-analyzer (>=2.2.0,<3.0.0)",
     "matplotlib (>=3.6.0,<4.0.0)",


### PR DESCRIPTION
## Summary

- express the image redactor Pillow requirement in canonical PEP 508 form
- preserve the existing `>=12.3.0,<13.0.0` version range exactly
- force GitHub dependency graph/SBOM to reparse the requirement after #2188

This is a dependency-graph reparsing workaround; it does not change the resolved Pillow version or any unrelated dependency. `uv.lock` was regenerated with uv 0.11.6 and remained unchanged.

## Validation

- `poetry check`
- `/tmp/presidio-uv-0116/bin/uv lock`
- `/tmp/presidio-uv-0116/bin/uv lock --check`
- `git diff --check`