### PR TITLE
Canonicalize Pillow requirement syntax

### DIFF
--- a/presidio-image-redactor/pyproject.toml
+++ b/presidio-image-redactor/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.15"
 
 dependencies = [
-    "pillow (>=12.3.0,<13.0.0)",
+    "pillow>=12.3.0,<13.0.0",
     "pytesseract (>=0.3.13,<0.4)",
     "presidio-analyzer (>=2.2.0,<3.0.0)",
     "matplotlib (>=3.6.0,<4.0.0)",


### PR DESCRIPTION
## Change Description

Canonicalize the image redactor Pillow requirement to `pillow>=12.3.0,<13.0.0` without changing its version range. This is a GitHub dependency-graph/SBOM reparsing workaround after #2188: removing the optional PEP 508 parentheses prompts GitHub to reparse the source requirement and discard the stale duplicate Pillow 12.2.0 entry.

`uv.lock` was regenerated with uv 0.11.6 and remained unchanged. This replaces #2193 solely to use the required branch name.

## Issue reference

Follow-up to #2188.

## Checklist

- [x] I have reviewed the contribution guidelines
- [x] I agree to follow the project Code of Conduct
- [x] I confirm that I have the right to submit this contribution and that it does not knowingly contain proprietary or confidential code.
- [x] Unit tests are not applicable to this metadata-only syntax change
- [x] Metadata and lock checks pass locally
- [x] Documentation updates are not required

Validation:
- `poetry check`
- `uv tool run --from uv==0.11.6 uv lock --check`
- `git diff --check`