### PR TITLE
Pin Pillow exactly at 12.3.0

### DIFF
--- a/presidio-image-redactor/pyproject.toml
+++ b/presidio-image-redactor/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.15"
 
 dependencies = [
-    "pillow>=12.3.0,<13.0.0",
+    "pillow==12.3.0",
     "pytesseract (>=0.3.13,<0.4)",
     "presidio-analyzer (>=2.2.0,<3.0.0)",
     "matplotlib (>=3.6.0,<4.0.0)",

--- a/presidio-image-redactor/uv.lock
+++ b/presidio-image-redactor/uv.lock
@@ -91,8 +91,8 @@ name = "blis"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/d0/d8cc8c9a4488a787e7fa430f6055e5bd1ddb22c340a751d9e901b82e2efe/blis-1.3.3.tar.gz", hash = "sha256:034d4560ff3cc43e8aa37e188451b0440e3261d989bb8a42ceee865607715ecd", size = 2644873, upload-time = "2025-11-17T12:28:30.511Z" }
 wheels = [
@@ -307,7 +307,7 @@ name = "cloudpathlib"
 version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/19/58bc6b5d7d0f81c7209b05445af477e147c486552f96665a5912211839b9/cloudpathlib-0.24.0.tar.gz", hash = "sha256:c521a984e77b47e656fe78e20a7e3e260e0ab45fc69e33ac01094227c979e34a", size = 53600, upload-time = "2026-04-30T00:54:43.265Z" }
 wheels = [
@@ -343,7 +343,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -415,7 +415,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -697,7 +697,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1791,7 +1791,7 @@ requires-dist = [
     { name = "gunicorn", marker = "extra == 'server'", specifier = ">=25.3.0,<26.0.0" },
     { name = "matplotlib", specifier = ">=3.6.0,<4.0.0" },
     { name = "opencv-python", specifier = ">=4.13.0.92,<5.0.0" },
-    { name = "pillow", specifier = ">=12.3.0,<13.0.0" },
+    { name = "pillow", specifier = "==12.3.0" },
     { name = "presidio-analyzer", specifier = ">=2.2.0,<3.0.0" },
     { name = "pydicom", specifier = ">=2.3.0,<4.0.0" },
     { name = "pypng", specifier = ">=0.20220715.0,<1.0.0" },


### PR DESCRIPTION
## Summary

- exact-pin Pillow 12.3.0 in `presidio-image-redactor/pyproject.toml`
- regenerate `presidio-image-redactor/uv.lock` with uv 0.11.6
- preserve the single resolved Pillow 12.3.0 package and its SHA-256 artifact hashes

## Context

GitHub's Python Dependabot graph job continues to report a stale transitive Pillow 12.2.0 through matplotlib and pytesseract, even though both dependencies allow Pillow 12.3.0, the project requires Pillow 12.3.0 or newer, and the committed uv lock resolves only Pillow 12.3.0.

This deliberately narrows the requirement to `pillow==12.3.0` to force GitHub to re-resolve the `pyproject.toml` manifest without selecting 12.2.0. The uv regeneration only updates the root requirement metadata and normalizes existing environment markers; no package versions change.

The 13 Pillow alert closures must be verified after this PR merges and GitHub rebuilds the dependency graph.