### PR TITLE
Pin Pillow exactly to 12.3.0

### DIFF
--- a/presidio-image-redactor/pyproject.toml
+++ b/presidio-image-redactor/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.15"
 
 dependencies = [
-    "pillow>=12.3.0,<13.0.0",
+    "pillow==12.3.0",
     "pytesseract (>=0.3.13,<0.4)",
     "presidio-analyzer (>=2.2.0,<3.0.0)",
     "matplotlib (>=3.6.0,<4.0.0)",

--- a/presidio-image-redactor/uv.lock
+++ b/presidio-image-redactor/uv.lock
@@ -1791,7 +1791,7 @@ requires-dist = [
     { name = "gunicorn", marker = "extra == 'server'", specifier = ">=25.3.0,<26.0.0" },
     { name = "matplotlib", specifier = ">=3.6.0,<4.0.0" },
     { name = "opencv-python", specifier = ">=4.13.0.92,<5.0.0" },
-    { name = "pillow", specifier = ">=12.3.0,<13.0.0" },
+    { name = "pillow", specifier = "==12.3.0" },
     { name = "presidio-analyzer", specifier = ">=2.2.0,<3.0.0" },
     { name = "pydicom", specifier = ">=2.3.0,<4.0.0" },
     { name = "pypng", specifier = ">=0.20220715.0,<1.0.0" },


### PR DESCRIPTION
## Summary

- Pin the image redactor PEP 621 Pillow requirement exactly to `12.3.0`.
- Regenerate the committed uv lock metadata with uv `0.11.6`.

This is a deliberate exact-pin workaround intended to force GitHub's new Python Dependabot graph job to stop reporting stale transitive Pillow `12.2.0`. The committed uv lock already resolved only Pillow `12.3.0`; this change makes the root package metadata requirement exact as well. Dependabot alert closure must be verified after merge.

## Validation

- `uv 0.11.6`
- `uv lock --check`
- `uv build --wheel` (validates the `poetry-core` package manifest)