### PR TITLE
Fix UK_NINO regex matching a leading space

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/uk/uk_nino_recognizer.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/country_specific/uk/uk_nino_recognizer.py
@@ -18,7 +18,7 @@ class UkNinoRecognizer(PatternRecognizer):
     PATTERNS = [
         Pattern(
             "NINO (medium)",
-            r"\b(?!bg|gb|nk|kn|nt|tn|zz|BG|GB|NK|KN|NT|TN|ZZ) ?([a-ceghj-pr-tw-zA-CEGHJ-PR-TW-Z]{1}[a-ceghj-npr-tw-zA-CEGHJ-NPR-TW-Z]{1}) ?([0-9]{2}) ?([0-9]{2}) ?([0-9]{2}) ?([a-dA-D]{1})\b",  # noqa: E501
+            r"\b(?!bg|gb|nk|kn|nt|tn|zz|BG|GB|NK|KN|NT|TN|ZZ)([a-ceghj-pr-tw-zA-CEGHJ-PR-TW-Z]{1}[a-ceghj-npr-tw-zA-CEGHJ-NPR-TW-Z]{1}) ?([0-9]{2}) ?([0-9]{2}) ?([0-9]{2}) ?([a-dA-D]{1})\b",  # noqa: E501
             0.5,
         ),
     ]

--- a/presidio-analyzer/tests/test_uk_nino_recognizer.py
+++ b/presidio-analyzer/tests/test_uk_nino_recognizer.py
@@ -23,7 +23,10 @@ def entities():
         ("hh 01 02 03 d", 1, ((0, 13),), ((0.5, 0.5),), ),
         ("tw987654a", 1, ((0, 9),), ((0.5, 0.5),), ),
         ("nino: PR 123612C", 1, ((6, 16),), ((0.5, 0.5),), ),
-        ("Here is my National Insurance Number YZ 61 48 68 B", 1, ((36, 50),), ((0.5, 0.5),), ),
+        ("Here is my National Insurance Number YZ 61 48 68 B", 1, ((37, 50),), ((0.5, 0.5),), ),
+        # The span starts at the NINO, never at a preceding space.
+        ("my AB123456C", 1, ((3, 12),), ((0.5, 0.5),), ),
+        ("contact AB 12 34 56 C now", 1, ((8, 21),), ((0.5, 0.5),), ),
         # Invalid National Insurance Numbers
         ("AA 12 34 56 H", 0, (), (), ),
         # The suffix must be a letter A-D; a numeric suffix is never valid.
@@ -31,6 +34,9 @@ def entities():
         ("ab1234561", 0, (), (), ),
         ("FQ 00 00 00 C", 0, (), (), ),
         ("BG123612A", 0, (), (), ),
+        # Excluded prefixes must stay excluded when the NINO follows a word.
+        ("my BG123612A", 0, (), (), ),
+        ("nino BG 12 36 12 A", 0, (), (), ),
         ("nino: nt 99 88 77 a", 0, (), (), ),
         ("This isn't a valid national insurance number UV 98 76 54 B", 0, (), (), ),
         # fmt: on


### PR DESCRIPTION
## Change Description

The `UK_NINO` pattern places an optional space between `\b` and the prefix capture group:

```
\b(?!bg|gb|nk|kn|nt|tn|zz|BG|GB|NK|KN|NT|TN|ZZ) ?([a-ceghj-pr-tw-z...]{1}...)
                                               ^^^
```

When a NINO follows a word, `\b` matches after that word and the ` ?` consumes the separating space, so the match begins one character early. This has two consequences.

**1. The reported span includes the leading space, corrupting anonymized output.**

```
>>> AnonymizerEngine().anonymize(text="my AB123456C", analyzer_results=results).text
'my<UK_NINO>'      # expected: 'my <UK_NINO>'
```

**2. The excluded prefixes stop being excluded**, because the negative lookahead is evaluated at the space rather than at the prefix letters.

```
>>> recognizer.analyze("BG123456A", ["UK_NINO"])        # correctly rejected
[]
>>> recognizer.analyze("my BG123456A", ["UK_NINO"])     # matched
[type: UK_NINO, start: 2, end: 12, score: 0.5]
```

`BG`, `GB`, `NK`, `KN`, `NT`, `TN` and `ZZ` are never issued as NINO prefixes
([HMRC NIM39110](https://www.gov.uk/hmrc-internal-manuals/national-insurance-manual/nim39110)),
which is the reason the lookahead exists.

## Fix

A NINO never begins with a space, and the five remaining ` ?` already handle the optional
spaces *within* the number. Remove the leading one:

```diff
-r"\b(?!bg|gb|nk|kn|nt|tn|zz|BG|GB|NK|KN|NT|TN|ZZ) ?([a-ceghj-pr-tw-z...
+r"\b(?!bg|gb|nk|kn|nt|tn|zz|BG|GB|NK|KN|NT|TN|ZZ)([a-ceghj-pr-tw-z...
```

## Tests

Adds parametrized cases covering both symptoms: spans when the NINO follows a word, and
excluded prefixes in that same position.

One existing expectation is **corrected** rather than added. The case
`"Here is my National Insurance Number YZ 61 48 68 B"` asserted `(36, 50)`, but index 36 is
the space and index 37 is the `Y` — it encoded the buggy span. Every other case in the file
places the NINO at position 0 or after punctuation, where the bug cannot fire, which is why
it went unnoticed.


## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/data-privacy-stack/presidio/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/data-privacy-stack/presidio/blob/main/CODE_OF_CONDUCT.md)
- [x] I confirm that I have the right to submit this contribution and that it does not knowingly contain proprietary or confidential code.
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required

