### PR TITLE
fix(analyzer): register three predefined recognizers missing from default_recognizers.yaml

### DIFF
--- a/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
+++ b/presidio-analyzer/presidio_analyzer/conf/default_recognizers.yaml
@@ -84,6 +84,13 @@ recognizers:
     enabled: false
     country_code: us
 
+  - name: AbaRoutingRecognizer
+    supported_languages:
+    - en
+    type: predefined
+    enabled: false
+    country_code: us
+
   - name: NhsRecognizer
     supported_languages: 
     - en
@@ -134,6 +141,13 @@ recognizers:
 
   - name: SgFinRecognizer
     supported_languages: 
+    - en
+    type: predefined
+    enabled: false
+    country_code: sg
+
+  - name: SgUenRecognizer
+    supported_languages:
     - en
     type: predefined
     enabled: false
@@ -278,6 +292,13 @@ recognizers:
     - pl
     type: predefined
     country_code: pl
+
+  - name: FiPersonalIdentityCodeRecognizer
+    supported_languages:
+    - fi
+    type: predefined
+    enabled: false
+    country_code: fi
 
   - name: KrBrnRecognizer
     supported_languages: 

--- a/presidio-analyzer/tests/test_recognizer_registry.py
+++ b/presidio-analyzer/tests/test_recognizer_registry.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+import yaml
 import regex as re
 from presidio_analyzer import (
     AnalyzerEngine,
@@ -11,6 +12,7 @@ from presidio_analyzer import (
     PatternRecognizer,
     RecognizerRegistry,
 )
+from presidio_analyzer.recognizer_registry import RecognizerRegistryProvider
 from presidio_analyzer.predefined_recognizers import SpacyRecognizer, UsSsnRecognizer
 
 
@@ -696,3 +698,38 @@ def test_load_predefined_recognizers_validates_countries_input():
 # ---------------------------------------------------------------------------
 # YAML ``country_code`` cross-validation
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Newly registered pattern recognizers are enable-safe
+# ---------------------------------------------------------------------------
+
+
+def test_when_newly_registered_yaml_recognizers_enabled_then_they_load(tmp_path):
+    """AbaRouting, FiPersonalIdentityCode and SgUen were exported in code but
+    missing from ``default_recognizers.yaml``; their entries ship
+    ``enabled: false``, so this flips them on and asserts they instantiate."""
+    conf_path = (
+        Path(__file__).parent.parent
+        / "presidio_analyzer"
+        / "conf"
+        / "default_recognizers.yaml"
+    )
+    conf = yaml.safe_load(conf_path.read_text())
+    targets = {
+        "AbaRoutingRecognizer",
+        "FiPersonalIdentityCodeRecognizer",
+        "SgUenRecognizer",
+    }
+    conf["supported_languages"] = ["en", "fi"]
+    for recognizer_conf in conf["recognizers"]:
+        if recognizer_conf["name"] in targets:
+            recognizer_conf["enabled"] = True
+    enabled_conf = tmp_path / "enabled.yaml"
+    enabled_conf.write_text(yaml.safe_dump(conf))
+
+    registry = RecognizerRegistryProvider(
+        conf_file=str(enabled_conf)
+    ).create_recognizer_registry()
+
+    assert targets <= _recognizer_class_names(registry)


### PR DESCRIPTION
## Change Description

Register the three pattern-based predefined recognizers that are exported in code but missing from `default_recognizers.yaml`: `AbaRoutingRecognizer`, `FiPersonalIdentityCodeRecognizer` and `SgUenRecognizer`. Each entry ships `enabled: false` with the matching `country_code`, so default behavior is unchanged while no-code YAML users can discover and enable them. A test flips the three entries on and asserts they instantiate (all three constructors already accept the loader's `name` kwarg, so these entries are enable-safe on their own).

Scope note: this PR originally also fixed the `name`-kwarg TypeError on four other recognizers and registered `KrPassportRecognizer`. That overlaps #2176 / #2170, which predate this PR and which I missed when filing (sorry about that). I rescoped this PR to only the parts #2170 doesn't cover, so the two PRs are complementary and can land in either order.

## Issue reference

Fixes #2217

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/data-privacy-stack/presidio/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/data-privacy-stack/presidio/blob/main/CODE_OF_CONDUCT.md)
- [x] I confirm that I have the right to submit this contribution and that it does not knowingly contain proprietary or confidential code.
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required
