### PR TITLE
fix(analyzer): let AzureAILanguageRecognizer load from a registry config, and un-mute the test that guards it

### DIFF
--- a/presidio-analyzer/presidio_analyzer/predefined_recognizers/third_party/azure_ai_language.py
+++ b/presidio-analyzer/presidio_analyzer/predefined_recognizers/third_party/azure_ai_language.py
@@ -25,6 +25,8 @@ class AzureAILanguageRecognizer(RemoteRecognizer):
         ta_client: Optional["TextAnalyticsClient"] = None,
         azure_ai_key: Optional[str] = None,
         azure_ai_endpoint: Optional[str] = None,
+        name: Optional[str] = None,
+        context: Optional[List[str]] = None,
     ):
         """
         Wrap the PII detection in Azure AI Language.
@@ -36,15 +38,24 @@ class AzureAILanguageRecognizer(RemoteRecognizer):
         the client will be created using the key and endpoint.
         :param azure_ai_key: Azure AI for language key
         :param azure_ai_endpoint: Azure AI for language endpoint
+        :param name: Name of the recognizer. Defaults to "Azure AI Language PII".
+        :param context: List of context words to boost confidence score.
 
         For more info, see https://learn.microsoft.com/en-us/azure/ai-services/language-service/personally-identifiable-information/overview
         """
 
+        # `name` and `context` are appended last so existing positional callers
+        # are unaffected. They exist because RecognizerListLoader passes both
+        # when building a recognizer from a registry configuration, and
+        # RemoteRecognizer.__init__ accepts neither **kwargs nor unknown keys.
+        # Without them, any YAML entry naming this class raises TypeError before
+        # the registry finishes loading (#1457, and again after #1800).
         super().__init__(
             supported_entities=supported_entities,
             supported_language=supported_language,
-            name="Azure AI Language PII",
+            name=name if name else "Azure AI Language PII",
             version="5.2.0",
+            context=context,
         )
 
         is_available = bool(TextAnalyticsClient)

--- a/presidio-analyzer/tests/conf/test_azure_ai_language_reco.yaml
+++ b/presidio-analyzer/tests/conf/test_azure_ai_language_reco.yaml
@@ -1,9 +1,15 @@
 recognizer_registry:
   global_regex_flags: 26
   recognizers:
+    # Plain form: `name` doubles as the class selector and is also passed to the
+    # constructor. This is the entry shape from #1457.
     - name: MockAzureAiLanguageRecognizer
       type: predefined
-      ta_client: "test" # This is a placeholder for testing purposes
+    # Rename form: `class_name` selects the class, `name` becomes the instance
+    # name. This is the documented reason the loader passes `name` at all.
+    - name: Azure AI Language PII
+      class_name: MockAzureAiLanguageRecognizer
+      type: predefined
 
 
 supported_languages:

--- a/presidio-analyzer/tests/test_analyzer_engine_provider.py
+++ b/presidio-analyzer/tests/test_analyzer_engine_provider.py
@@ -1,5 +1,7 @@
 # ruff: noqa: D103,D205,E501,F541,F841,W293
 
+import importlib.util
+import os
 import re
 from pathlib import Path
 from typing import List
@@ -16,6 +18,27 @@ from presidio_analyzer.predefined_recognizers import (
     SpacyRecognizer,
     StanzaRecognizer,
 )
+
+def _has_module(name: str) -> bool:
+    # find_spec imports the parent packages of a dotted name, so a missing
+    # intermediate raises ModuleNotFoundError instead of returning None --
+    # "azure.health.deidentification" does exactly that without the ahds extra.
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+# Gate the optional-dependency tests below on the module each one actually
+# imports. `pytest.importorskip` cannot be used for this: evaluated inside a
+# decorator it runs at module import, so a missing extra takes the whole file
+# out of collection instead of skipping the two tests that need it.
+#
+# The bare `azure` name is also too coarse. `azure.*` are namespace packages and
+# the `ahds` extra populates them too, so `import azure` can succeed while
+# `azure.ai.textanalytics` is absent.
+_HAS_TEXT_ANALYTICS = _has_module("azure.ai.textanalytics")
+_HAS_HEALTH_DEID = _has_module("azure.health.deidentification")
 
 
 def get_full_paths(analyzer_yaml, nlp_engine_yaml=None, recognizer_registry_yaml=None):
@@ -241,9 +264,15 @@ def test_analyzer_engine_provider_with_files_per_provider():
 
 
 @pytest.mark.skipif(
-    pytest.importorskip("azure"), reason="Optional dependency not installed"
-)  # noqa: E501
-def test_analyzer_engine_provider_with_azure_ai_language():
+    not _HAS_TEXT_ANALYTICS, reason="azure-ai-language extra not installed"
+)
+def test_analyzer_engine_provider_with_azure_ai_language(monkeypatch):
+    # The constructor builds a client when none is injected, falling back to
+    # these variables. Nothing here reaches the network: the SDK client is
+    # constructed locally and `analyze` is overridden below.
+    monkeypatch.setenv("AZURE_AI_KEY", "test-key")
+    monkeypatch.setenv("AZURE_AI_ENDPOINT", "https://example.invalid/")
+
     analyzer_yaml, _, _ = get_full_paths(
         "conf/test_azure_ai_language_reco.yaml",
     )
@@ -261,17 +290,27 @@ def test_analyzer_engine_provider_with_azure_ai_language():
 
     analyzer_engine = provider.create_engine()
 
-    azure_ai_recognizers = [
-        rec
+    names = {
+        rec.name
         for rec in analyzer_engine.registry.recognizers
-        if rec.name == "Azure AI Language PII"
-    ]
+        if isinstance(rec, MockAzureAiLanguageRecognizer)
+    }
 
-    assert len(azure_ai_recognizers) == 1
+    # The plain entry takes its name from the YAML key; the `class_name` entry
+    # takes the name configured next to it. Both require the constructor to
+    # accept `name`, which is what regressed after #1800.
+    assert names == {"MockAzureAiLanguageRecognizer", "Azure AI Language PII"}
 
     assert len(analyzer_engine.analyze("This is a test", language="en")) > 0
 
-@pytest.mark.skipif(pytest.importorskip("azure"), reason="Optional dependency not installed") # noqa: E501
+
+# AzureHealthDeidRecognizer.__init__ builds a client when none is passed, and
+# that path reads AHDS_ENDPOINT and raises ValueError without it. The YAML entry
+# supplies no client, so the endpoint is as much a precondition as the package.
+@pytest.mark.skipif(
+    not _HAS_HEALTH_DEID or not os.getenv("AHDS_ENDPOINT"),
+    reason="ahds extra not installed or AHDS_ENDPOINT not set",
+)
 def test_analyzer_engine_provider_with_ahds():
     analyzer_yaml, _, _ = get_full_paths(
         "conf/test_ahds_reco.yaml",

--- a/presidio-analyzer/tests/test_azure_ai_language_recognizer.py
+++ b/presidio-analyzer/tests/test_azure_ai_language_recognizer.py
@@ -87,3 +87,39 @@ def test_mocked_entities_match_recognizer_results():
         assert expected.offset == actual.start
         assert expected.length == actual.end - actual.start
         assert expected.confidence_score == actual.score
+
+
+def _mock_ta_client():
+    try:
+        importlib.import_module("azure.ai.textanalytics")
+    except ImportError:
+        pytest.skip("Skipping test because 'azure.ai.textanalytics' is not installed")
+
+    from azure.ai.textanalytics import TextAnalyticsClient
+    from azure.core.credentials import AzureKeyCredential
+
+    return TextAnalyticsClient(endpoint="", credential=AzureKeyCredential(key=""))
+
+
+def test_name_defaults_to_the_display_name():
+    recognizer = AzureAILanguageRecognizer(ta_client=_mock_ta_client())
+    assert recognizer.name == "Azure AI Language PII"
+
+
+def test_name_can_be_overridden():
+    # RecognizerListLoader passes `name` for every entry it builds, so the
+    # constructor has to accept it; a `class_name` entry relies on it winning
+    # over the hardcoded display name.
+    recognizer = AzureAILanguageRecognizer(
+        ta_client=_mock_ta_client(), name="Custom Azure PII"
+    )
+    assert recognizer.name == "Custom Azure PII"
+
+
+def test_context_is_accepted():
+    # The kwarg #1457 originally failed on. RemoteRecognizer takes it, so the
+    # subclass has to forward it rather than reject it.
+    recognizer = AzureAILanguageRecognizer(
+        ta_client=_mock_ta_client(), context=["patient", "record"]
+    )
+    assert recognizer.context == ["patient", "record"]


### PR DESCRIPTION
## Change Description

`AzureAILanguageRecognizer` cannot be built from a registry configuration on `main`. `RecognizerListLoader` passes `name` for every entry it constructs, and passed `context` before that; the constructor accepts neither, so any YAML entry naming the class raises before the registry finishes loading:

```python
RecognizerListLoader.get(
    recognizers=[{"name": "AzureAILanguageRecognizer", "type": "predefined",
                  "supported_languages": ["en"]}],
    supported_languages=["en"], global_regex_flags=26,
)
# TypeError: AzureAILanguageRecognizer.__init__() got an unexpected keyword argument 'name'
```

This is #1457, reported in 2024 against the `context` kwarg and fixed in #1458 by adding `**kwargs`. #1800 removed the `**kwargs` — correctly, since `RemoteRecognizer.__init__` does not accept them either, so it never absorbed anything and only moved the same `TypeError` one frame deeper — but without adding the explicit parameters that were holding the loader path up. The other two recognizers that PR touched have since been repaired; `ahds_recognizer.py` and `lm_recognizer.py` both take `name: Optional[str] = None` today.

The regression test #1458 added was already unable to run by then, which is the second half of this PR.

## Why the regression test could not fire

```python
@pytest.mark.skipif(pytest.importorskip("azure"), reason="Optional dependency not installed")
```

`pytest.importorskip` skips when a module is missing and otherwise returns the module, which is truthy. Both branches lose:

| `azure` present? | Result |
| --- | --- |
| No | `Skipped` is raised while the decorator is evaluated, i.e. at module import — **the whole file drops out of collection** |
| Yes | truthy module → `skipif(True)` → **skipped**, reporting `Optional dependency not installed` while it is installed |

Measured on `main`:

```
$ python -m pytest tests --collect-only -q | tail -1
3248 tests collected      # without the azure-ai-language extra
3292 tests collected      # with it
```

So 44 tests — the entire module — are silently uncollected in any environment without the extra, and the two tests the marker was written for skip on every CI run, where `--all-extras` is used (`ci.yml:74`).

`azure` is also the wrong module to name. `azure.*` are namespace packages and the `ahds` extra populates them too, so `import azure` can succeed with `azure.ai.textanalytics` absent.

## Changes

- **`azure_ai_language.py`** — added `name` and `context`, appended last so existing positional callers are unaffected. `name` falls back to `"Azure AI Language PII"` when omitted, matching how `AzureHealthDeidRecognizer` resolves the same conflict between a configured name and a hardcoded display name.
- **`test_analyzer_engine_provider.py`** — both markers now gate on `importlib.util.find_spec` for the module each test actually imports. A local helper swallows the `ModuleNotFoundError` that `find_spec` raises when an intermediate parent package is missing, which is what `azure.health.deidentification` does without the `ahds` extra.
- The AHDS test additionally requires `AHDS_ENDPOINT`. `AzureHealthDeidRecognizer.__init__` builds a client when the config supplies none, and that path raises `ValueError` without the variable — so the endpoint is as much a precondition as the package. `tests/test_ahds_recognizer.py:26` already gates on it this way.
- **`tests/conf/test_azure_ai_language_reco.yaml`** — dropped `ta_client: "test"`, which no longer reaches the constructor (see follow-up 1 below), and added a second entry so the fixture covers both entry shapes: the plain form where `name` doubles as the class selector, and the `class_name` rename form. The test supplies credentials through `monkeypatch.setenv` instead; nothing reaches the network, as the SDK client is constructed locally and `analyze` is overridden.
- **`tests/test_azure_ai_language_recognizer.py`** — three direct-construction tests for the name default, the name override, and `context`.

## Verification

- Reverting only `azure_ai_language.py` fails exactly three tests — `test_name_can_be_overridden`, `test_context_is_accepted`, `test_analyzer_engine_provider_with_azure_ai_language` — and nothing else.
- Full `presidio-analyzer` suite, this branch against an `origin/main` baseline in the same environment: **identical failure sets**, 42 pre-existing failures/errors from optional dependencies absent locally (`transformers`, `langextract`, some spaCy models). Compared line by line, not by count.

  ```
  main:   26 failed, 3168 passed, 83 skipped, 16 errors
  branch: 26 failed, 3172 passed, 82 skipped, 16 errors
  ```

  The delta is exactly this PR: three new tests, plus the Azure AI Language test moving from skipped to passing.
- With the extra uninstalled and `site-packages/azure` removed, `pytest tests --collect-only` reports **3295** on this branch against **3248** on `main`. The module is collected, its 41 other tests run, and only the two optional-dependency tests skip, with accurate reasons.
- `ruff check` from the repo root as CI runs it, `ruff format --check` on the modified module, and `git diff --check` all pass.

Reproducing the "extra absent" rows takes more than `pip uninstall azure-ai-textanalytics azure-core`: `azure-common` also claims the `azure` namespace, and pip leaves an empty `site-packages/azure/ai/` behind. Either keeps `import azure` succeeding.

## Follow-ups, not in this PR

1. **`PredefinedRecognizerConfig` silently drops recognizer-specific kwargs.** It inherits pydantic's default `extra="ignore"`, so `ta_client` — and `azure_ai_key` / `azure_ai_endpoint`, which users would reasonably put in YAML — never reach the constructor. `HuggingFaceRecognizerConfig`, `GLiNERRecognizerConfig` and `LangExtractRecognizerConfig` each set `extra="allow"` to work around this one class at a time. Worth a decision on whether that should be the default for predefined entries.
2. **`AzureHealthDeidRecognizer` does not accept `context` either.** Same shape as the `name` gap fixed here, and the same YAML path reaches it. Left alone to keep this diff scoped.
3. `AzureAILanguageRecognizer` is still absent from `default_recognizers.yaml`, so #2170's contract tests do not reach it — the load test only walks shipped entries, and the signature test only covers `PatternRecognizer` subclasses. Adding a shipped entry is a separate question, since the recognizer needs credentials to construct.

Per the changelog policy in #2200, `CHANGELOG.md` is not modified.

## Issue reference

Closes #2223. Follows up on #1457 / #1458 (the original report and fix), #1521 (which introduced the marker), #1800 (which removed the `**kwargs`) and #1819 (which made the loader pass `name`).

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/data-privacy-stack/presidio/blob/main/CONTRIBUTING.md)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/data-privacy-stack/presidio/blob/main/CODE_OF_CONDUCT.md)
- [x] I confirm that I have the right to submit this contribution and that it does not knowingly contain proprietary or confidential code.
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
